### PR TITLE
fix(async): prevent CountdownLatch underflow on extra decrements

### DIFF
--- a/crates/mister-smith-async/src/sync.rs
+++ b/crates/mister-smith-async/src/sync.rs
@@ -114,10 +114,27 @@ impl CountdownLatch {
     /// Decrement the count by one. If this brings the count to zero, all
     /// waiters are notified.
     pub fn count_down(&self) {
-        let prev = self.count.fetch_sub(1, Ordering::SeqCst);
-        if prev == 1 {
-            // Count just reached zero — notify all waiters.
-            self.notify.notify_waiters();
+        let mut current = self.count.load(Ordering::SeqCst);
+        loop {
+            if current == 0 {
+                return;
+            }
+
+            match self.count.compare_exchange(
+                current,
+                current - 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => {
+                    if current == 1 {
+                        // Count just reached zero — notify all waiters.
+                        self.notify.notify_waiters();
+                    }
+                    return;
+                }
+                Err(observed) => current = observed,
+            }
         }
     }
 
@@ -230,6 +247,30 @@ mod tests {
     async fn latch_zero_count_returns_immediately() {
         let latch = CountdownLatch::new(0);
         // Should not hang.
+        latch.wait().await;
+        assert_eq!(latch.remaining(), 0);
+    }
+
+    #[tokio::test]
+    async fn latch_extra_count_down_does_not_underflow() {
+        let latch = CountdownLatch::new(1);
+
+        latch.count_down();
+        assert_eq!(latch.remaining(), 0);
+
+        latch.count_down();
+        latch.count_down();
+        assert_eq!(latch.remaining(), 0);
+    }
+
+    #[tokio::test]
+    async fn latch_wait_immediate_after_extra_decrements_at_zero() {
+        let latch = CountdownLatch::new(1);
+
+        latch.count_down();
+        latch.count_down();
+
+        // Should still return immediately even after extra decrements.
         latch.wait().await;
         assert_eq!(latch.remaining(), 0);
     }


### PR DESCRIPTION
### Motivation
- Prevent the countdown latch from underflowing when `count_down()` is called after the counter reached zero. 
- Ensure waiter notification is only emitted on the precise `1 -> 0` transition to avoid spurious wakeups. 
- Add tests to validate behavior when extra decrements occur and to ensure `wait()` still returns immediately at zero.

### Description
- Replace the unconditional `fetch_sub(1, SeqCst)` in `CountdownLatch::count_down()` with a compare-exchange retry loop that first returns early if the current count is `0` and retries on contention.  
- Preserve waiter notification only when the observed `current == 1` (i.e., the transition to zero).  
- Add two tests to the existing `#[cfg(test)]` module: `latch_extra_count_down_does_not_underflow` and `latch_wait_immediate_after_extra_decrements_at_zero`.  
- Touched file: `crates/mister-smith-async/src/sync.rs`.

### Testing
- Ran `cargo test -p mister-smith-async latch_extra_count_down_does_not_underflow` and the test passed.  
- Ran `cargo test -p mister-smith-async latch_wait_immediate_after_extra_decrements_at_zero` and the test passed.  
- Ran `cargo test -p mister-smith-async sync::tests::` which executed the sync tests and reported all tests passing (`9 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f9bd853c83339f95eadccb1dc7ab)