### PR TITLE
fix(resources): prevent concurrent acquire oversubscription in pool

### DIFF
--- a/crates/mister-smith-resources/src/pool.rs
+++ b/crates/mister-smith-resources/src/pool.rs
@@ -155,6 +155,8 @@ pub struct ConnectionPool<R: Send + Sync + 'static> {
     factory: ResourceFactory<R>,
     /// Number of resources currently checked out.
     active_count: Arc<AtomicUsize>,
+    /// Number of capacity slots reserved for in-flight resource creation.
+    reserved_count: AtomicUsize,
     /// Total number of resources ever created by this pool.
     total_created: AtomicUsize,
     /// Whether the pool has been shut down.
@@ -183,6 +185,7 @@ impl<R: Send + Sync + 'static> ConnectionPool<R> {
             config,
             factory,
             active_count: Arc::new(AtomicUsize::new(0)),
+            reserved_count: AtomicUsize::new(0),
             total_created: AtomicUsize::new(0),
             shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
@@ -208,8 +211,7 @@ impl<R: Send + Sync + 'static> ConnectionPool<R> {
             }
 
             // Try to create a new one if under capacity.
-            let current_total = self.idle_count() + self.active_count.load(Ordering::Acquire);
-            if current_total < self.config.max_size {
+            if self.try_reserve_slot() {
                 match self.create_resource().await {
                     Ok(resource) => {
                         trace!("created new resource for pool");
@@ -343,10 +345,36 @@ impl<R: Send + Sync + 'static> ConnectionPool<R> {
         })
     }
 
+    fn try_reserve_slot(&self) -> bool {
+        loop {
+            let idle = self.idle_count();
+            let active = self.active_count.load(Ordering::Acquire);
+            let reserved = self.reserved_count.load(Ordering::Acquire);
+            if idle + active + reserved >= self.config.max_size {
+                return false;
+            }
+
+            if self
+                .reserved_count
+                .compare_exchange_weak(reserved, reserved + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
     async fn create_resource(&self) -> Result<PooledResource<R>, PoolError> {
-        let resource = (self.factory)().await?;
+        let resource = match (self.factory)().await {
+            Ok(resource) => resource,
+            Err(error) => {
+                self.reserved_count.fetch_sub(1, Ordering::Release);
+                return Err(error);
+            }
+        };
         self.total_created.fetch_add(1, Ordering::Release);
         self.active_count.fetch_add(1, Ordering::Release);
+        self.reserved_count.fetch_sub(1, Ordering::Release);
         Ok(PooledResource {
             pool: Arc::clone(&self.pool),
             active_count: Arc::clone(&self.active_count),
@@ -654,6 +682,45 @@ mod tests {
             result,
             Err(PoolError::ResourceCreationFailed(ref msg)) if msg == "boom"
         ));
+    }
+
+    #[tokio::test]
+    async fn concurrent_acquires_do_not_overshoot_max_size() {
+        let max_size = 3;
+        let config = PoolConfig {
+            max_size,
+            acquire_timeout: Duration::from_millis(300),
+            ..Default::default()
+        };
+        let pool = Arc::new(ConnectionPool::new(config, {
+            let counter = Arc::new(AtomicUsize::new(0));
+            move || {
+                let counter = Arc::clone(&counter);
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    Ok(MockResource::new(counter.fetch_add(1, Ordering::SeqCst)))
+                })
+            }
+        }));
+
+        let mut tasks = Vec::new();
+        for _ in 0..20 {
+            let pool = Arc::clone(&pool);
+            tasks.push(tokio::spawn(async move {
+                let resource = pool.acquire().await;
+                if let Ok(resource) = resource {
+                    tokio::time::sleep(Duration::from_millis(30)).await;
+                    drop(resource);
+                }
+            }));
+        }
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        assert!(pool.total_created() <= max_size);
+        assert!(pool.active() + pool.size() <= max_size);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent a race where multiple concurrent `acquire()` callers can overshoot `PoolConfig::max_size` by all simultaneously deciding to create new resources.
- Track in-flight creation reservations separately so `idle + active + reserved` never exceeds `max_size` under contention.

### Description
- Added `reserved_count: AtomicUsize` to `ConnectionPool` and initialized it in `new` to track capacity slots reserved for in-flight factory calls. (file: `crates/mister-smith-resources/src/pool.rs`)
- Added `try_reserve_slot()` which CAS-reserves a slot only if `idle + active + reserved < max_size`, and updated `acquire()` to call it before awaiting `create_resource()` so reservations are made atomically. (file: `crates/mister-smith-resources/src/pool.rs`)
- Updated `create_resource()` to release the reservation in all paths by decrementing `reserved_count` on factory failure and after successful creation, and kept existing `active_count` and `total_created` bookkeeping. (file: `crates/mister-smith-resources/src/pool.rs`)
- Kept the idle checkout path unchanged and added a stress test `concurrent_acquires_do_not_overshoot_max_size` that spawns many concurrent acquires against a small `max_size` and asserts `total_created()` and `active + idle` remain ≤ `max_size`. (file: `crates/mister-smith-resources/src/pool.rs`)

### Testing
- Ran `cargo test -p mister-smith-resources concurrent_acquires_do_not_overshoot_max_size`, which passed.
- Ran `cargo test -p mister-smith-resources factory_error_propagates`, which passed.
- All modified-unit tests passed locally with the above commands; no regressions observed in these validation runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fa045db88333b0b9f16067a0a58f)