### PR TITLE
fix(actor): release actor registry lock before shutdown awaits

### DIFF
--- a/crates/mister-smith-actor/src/system.rs
+++ b/crates/mister-smith-actor/src/system.rs
@@ -187,10 +187,14 @@ impl ActorSystem {
     pub async fn shutdown(&self) -> Result<(), ActorError> {
         info!("Actor system shutting down");
 
-        let mut actors = self.actors.write().await;
+        let mut entries: Vec<(AgentId, ActorHandle)> = {
+            let mut actors = self.actors.write().await;
+            let entries = actors.drain().collect();
+            drop(actors);
+            entries
+        };
 
         // Sort by start_order descending (reverse start order)
-        let mut entries: Vec<(AgentId, ActorHandle)> = actors.drain().collect();
         entries.sort_by(|a, b| b.1.start_order.cmp(&a.1.start_order));
 
         for (id, handle) in entries {
@@ -519,6 +523,45 @@ mod tests {
 
         let err = actor_ref.tell("too late".to_string()).unwrap_err();
         assert!(matches!(err, ActorError::ActorStopped));
+    }
+
+
+    // Regression: shutdown should not hold write lock while awaiting actor stops.
+    #[tokio::test]
+    async fn shutdown_does_not_starve_readers() {
+        let system = Arc::new(ActorSystem::new(ActorSystemConfig {
+            shutdown_timeout: Duration::from_millis(300),
+            ..ActorSystemConfig::default()
+        }));
+
+        for _ in 0..3 {
+            let id = AgentId::new();
+            system
+                .spawn(SimpleActor { id }, vec![], SpawnConfig::default())
+                .await
+                .unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let shutdown_system = Arc::clone(&system);
+        let shutdown_task = tokio::spawn(async move { shutdown_system.shutdown().await });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let read_task = tokio::spawn({
+            let system = Arc::clone(&system);
+            async move {
+                tokio::time::timeout(Duration::from_millis(200), system.actor_count())
+                    .await
+                    .expect("actor_count should complete while shutdown is in progress")
+            }
+        });
+
+        let count = read_task.await.unwrap();
+        assert_eq!(count, 0);
+
+        shutdown_task.await.unwrap().unwrap();
     }
 
     // T026: Reverse start order shutdown


### PR DESCRIPTION
### Motivation
- Prevent holding the actor registry write lock while awaiting actor stop/join timeouts to avoid lock starvation or deadlock when readers concurrently access the registry. 
- Preserve the existing reverse start-order shutdown semantics while making shutdown non-blocking for readers.

### Description
- Modified `ActorSystem::shutdown()` to acquire `self.actors.write().await`, `drain()` into a local `Vec<(AgentId, ActorHandle)>`, then explicitly `drop` the guard before doing async stop/join work. 
- Kept reverse shutdown ordering by sorting the drained entries by `start_order` descending before iterating. 
- Added a regression test `shutdown_does_not_starve_readers` in the `#[cfg(test)]` module that concurrently runs `shutdown()` and `actor_count()` to assert readers are not starved.
- Touched file: `crates/mister-smith-actor/src/system.rs`.

### Testing
- Ran the new regression test with `cargo test -p mister-smith-actor shutdown_does_not_starve_readers -- --nocapture` and it passed. 
- Verified existing behavior with `cargo test -p mister-smith-actor shutdown_reverse_start_order -- --nocapture` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fbdad4f88333811d28c98df24293)