### PR TITLE
fix(actor): wait for actor startup ack in ActorSystem::spawn

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,111 @@
+# Code Review: [DESCRIPTION]
+
+Review all source code, specs, and tests associated with the subject above. Read every file that was added or modified as part of this work to build a complete picture.
+
+## Scope Discovery
+
+1. Locate the spec directory under `specs/` and the corresponding crate(s) under `crates/` for the phase being reviewed
+2. Read `specs/<feature>/tasks.md` and `specs/<feature>/plan.md` to understand what was supposed to be built
+3. Read all source files in the relevant crate(s) — every `.rs` file, `Cargo.toml`, and test file
+4. Read `CLAUDE.md` and `ROADMAP.md` for project conventions and phase context
+
+## Review Dimensions
+
+### Spec Compliance
+
+- Every task in `tasks.md` marked complete — verify the implementation actually satisfies each one
+- Compare `plan.md` architectural decisions against what was built — flag deviations
+- Check that all acceptance criteria from the spec are met with corresponding tests
+- Identify anything implemented that was NOT in the spec (scope creep)
+
+### Correctness
+
+- Trace data flow end-to-end through the new code paths
+- Verify error variants are exhaustive and propagated correctly (no swallowed errors, no silent fallbacks)
+- Check concurrency primitives: Are locks held across await points? Are there potential deadlocks? Is shared state properly synchronized?
+- Validate unsafe code blocks if any exist — verify soundness invariants are documented and upheld
+- Check for off-by-one errors, integer overflow potential, and boundary conditions
+- Verify all `unwrap()` / `expect()` calls are justified (test code vs production code)
+
+### Security
+
+- Secrets: No hardcoded keys, tokens, or credentials in source (test fixtures with obviously-fake values are acceptable)
+- Input validation at system boundaries — untrusted data is validated before use
+- Authentication/authorization checks cannot be bypassed through alternate code paths
+- Cryptographic choices are current and appropriate (no deprecated algorithms, sufficient key lengths)
+- Error messages don't leak internal state or stack traces to external callers
+- Dependencies: Check for known vulnerabilities in new dependencies (`cargo audit` or equivalent)
+
+### API Design
+
+- Public API surface is minimal — only expose what consumers need
+- Types enforce invariants at compile time where possible (newtype wrappers, builder patterns, typestate)
+- Breaking changes to existing public APIs are justified and documented
+- Naming follows existing crate conventions (check 3+ examples of similar patterns in the codebase)
+- `#[must_use]`, visibility modifiers, and documentation on all public items
+
+### Error Handling
+
+- Custom error types are specific enough to be actionable by callers
+- Error chains preserve context (`source()` / `#[from]` / `.context()`)
+- No `Box<dyn Error>` in library code unless justified
+- Recovery paths exist where recovery is possible — errors don't just propagate to top-level panic
+- Distinguish between "this should never happen" (panic) and "this can happen at runtime" (Result)
+
+### Testing
+
+- Unit tests cover core logic, edge cases, and error paths — not just happy paths
+- Integration tests validate cross-crate interactions and full request/response flows
+- Test helpers and fixtures are reusable and don't duplicate setup logic
+- Tests are deterministic — no timing-dependent assertions without adequate margins
+- Test names describe the behavior being verified, not the implementation
+
+### Performance
+
+- No unnecessary allocations in hot paths (cloning where borrowing suffices, String where &str works)
+- Appropriate data structures for access patterns (HashMap vs BTreeMap, Vec vs VecDeque)
+- Async code doesn't block the runtime (no blocking I/O, no long-running compute without `spawn_blocking`)
+- Connection pools, caches, and buffers are bounded
+- No O(n^2) or worse algorithms where O(n log n) or O(n) alternatives exist
+
+### Dependency Hygiene
+
+- New dependencies are justified — not added for trivial functionality that could be a few lines of code
+- Feature flags are used to keep optional dependencies optional
+- Workspace dependencies are used consistently (no version pinning in individual crates that conflicts with workspace)
+- No duplicate dependencies at different versions (check `cargo tree -d`)
+
+### Code Organization
+
+- Module structure follows existing crate conventions
+- No circular dependencies between modules or crates
+- Public re-exports create a clean API surface (`pub use` in `lib.rs` / `mod.rs`)
+- Dead code is removed, not commented out or `#[allow(dead_code)]`
+- Files are appropriately sized — no 1000+ line modules without clear structure
+
+### Documentation
+
+- Module-level doc comments explain purpose and usage patterns
+- Complex algorithms or non-obvious design decisions have inline comments explaining WHY
+- Doc examples compile and demonstrate real usage (not just `// TODO`)
+- CLAUDE.md and ROADMAP.md are updated to reflect the new state
+
+## Output Format
+
+Structure your review as:
+
+**Summary**: 2-3 sentences on what was built and overall assessment.
+
+**Strengths**: What was done well — be specific with file:line references.
+
+**Issues**: Categorized as Critical (must fix before merge), Important (should fix soon), or Minor (nice to have). Each issue should include:
+- File and line reference
+- What the problem is
+- Why it matters
+- Suggested fix
+
+**Spec Gaps**: Anything in the spec that wasn't implemented, or implemented differently than specified.
+
+**Test Coverage Assessment**: Areas that lack test coverage or have weak assertions.
+
+**Verdict**: Ship it / Ship with fixes / Needs rework.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +539,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -908,13 +920,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1064,6 +1079,22 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1523,6 +1554,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nkeys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1697,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1827,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd9713fe2c91c3c85ac388b31b89de339365d2c995146e630b5e0da9d06526a"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -1999,6 +2062,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2111,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,11 +2167,18 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "http",
+ "pastey",
  "pin-project-lite",
+ "process-wrap",
+ "reqwest",
+ "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -2200,6 +2324,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2418,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2453,6 +2614,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,6 +2654,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2824,9 +3001,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3077,6 +3257,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3325,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3140,6 +3347,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3161,6 +3378,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,6 +3409,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3200,6 +3449,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3277,6 +3536,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/mister-smith-actor/src/actor_cell.rs
+++ b/crates/mister-smith-actor/src/actor_cell.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use mister_smith_core::{Actor, AgentId, AgentState, EventPublisher, SystemEvent};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, error, info, warn};
 
 use crate::mailbox::{Envelope, MailboxReceiver};
@@ -102,6 +102,7 @@ pub async fn run_actor<A>(
     mut receiver: MailboxReceiver<Envelope<A::Message>>,
     mut stop_rx: mpsc::Receiver<()>,
     state_tx: watch::Sender<AgentState>,
+    startup_tx: Option<oneshot::Sender<Result<(), String>>>,
     supervision_tx: Option<mpsc::UnboundedSender<SupervisionNotification>>,
     event_publisher: Option<Arc<dyn EventPublisher>>,
 ) where
@@ -116,14 +117,18 @@ pub async fn run_actor<A>(
     debug!(actor_id = %actor_id, "Actor initializing");
 
     if let Err(e) = actor.pre_start() {
+        let startup_error = e.to_string();
         error!(actor_id = %actor_id, error = %e, "pre_start failed");
         let _ = state_tx.send(AgentState::Error);
+        if let Some(tx) = startup_tx {
+            let _ = tx.send(Err(startup_error.clone()));
+        }
         emit_lifecycle_event(
             &event_publisher,
             "actor.failed",
             serde_json::json!({
                 "actor_id": actor_id.to_string(),
-                "error": e.to_string(),
+                "error": startup_error.clone(),
                 "phase": "pre_start",
             }),
         )
@@ -131,10 +136,14 @@ pub async fn run_actor<A>(
         if let Some(ref tx) = supervision_tx {
             let _ = tx.send(SupervisionNotification {
                 actor_id,
-                reason: TerminationReason::PreStartFailed(e.to_string()),
+                reason: TerminationReason::PreStartFailed(startup_error),
             });
         }
         return;
+    }
+
+    if let Some(tx) = startup_tx {
+        let _ = tx.send(Ok(()));
     }
 
     // Phase: Running
@@ -528,7 +537,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(run_actor(actor, 0u64, rx, stop_rx, state_tx, Some(sup_tx), None));
+        let handle = tokio::spawn(run_actor(actor, 0u64, rx, stop_rx, state_tx, None, Some(sup_tx), None));
 
         // Wait for Running state
         while *state_rx.borrow() != AgentState::Running {
@@ -571,7 +580,7 @@ mod tests {
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
-        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, None));
+        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, None, None));
 
         // Wait for Running
         while *state_rx.borrow() != AgentState::Running {
@@ -596,7 +605,7 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, Some(sup_tx), None));
+        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, Some(sup_tx), None));
 
         // Wait for Running
         while *state_rx.borrow() != AgentState::Running {
@@ -623,7 +632,7 @@ mod tests {
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
-        let handle = tokio::spawn(run_actor(actor, 0u64, rx, stop_rx, state_tx, None, None));
+        let handle = tokio::spawn(run_actor(actor, 0u64, rx, stop_rx, state_tx, None, None, None));
 
         while *state_rx.borrow() != AgentState::Running {
             state_rx.changed().await.unwrap();
@@ -671,7 +680,7 @@ mod tests {
         let (stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
-        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, None));
+        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, None, None));
 
         while *state_rx.borrow() != AgentState::Running {
             state_rx.changed().await.unwrap();
@@ -739,24 +748,23 @@ mod tests {
         system.shutdown().await.unwrap();
     }
 
-    // T089: pre_start failure on initial spawn — actor transitions to Error, not registered as Running
+    // T089: pre_start failure on initial spawn — spawn returns startup error and actor is not registered
     #[tokio::test]
     async fn pre_start_failure_on_spawn_transitions_to_error() {
         let system = ActorSystem::new(ActorSystemConfig::default());
         let id = AgentId::new();
 
         // Spawn an actor whose pre_start always fails
-        let _ref = system
+        let result = system
             .spawn(PreStartFailActor { id }, (), SpawnConfig::default())
-            .await
-            .unwrap();
+            .await;
 
-        // Give the actor cell time to run pre_start and transition to Error
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(matches!(result, Err(ActorError::StartupFailed(_))));
 
-        // Actor should be in Error state, not Running
+        // Startup failure should keep actor out of registry
         let state = system.get_actor_state(&id).await;
-        assert_eq!(state, Some(AgentState::Error));
+        assert_eq!(state, None);
+        assert_eq!(system.actor_count().await, 0);
 
         system.shutdown().await.unwrap();
     }
@@ -771,7 +779,7 @@ mod tests {
         let (state_tx, state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, Some(sup_tx), None));
+        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, Some(sup_tx), None));
         handle.await.unwrap();
 
         assert_eq!(*state_rx.borrow(), AgentState::Error);
@@ -795,7 +803,7 @@ mod tests {
         let (state_tx, state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, Some(sup_tx), None));
+        let handle = tokio::spawn(run_actor(actor, (), rx, stop_rx, state_tx, None, Some(sup_tx), None));
 
         tx.send(Envelope::tell(PanicMsg::Panic)).await.unwrap();
         handle.await.unwrap();
@@ -826,6 +834,7 @@ mod tests {
             rx,
             stop_rx,
             state_tx,
+            None,
             Some(sup_tx),
             Some(Arc::clone(&publisher) as Arc<dyn EventPublisher>),
         ));

--- a/crates/mister-smith-actor/src/system.rs
+++ b/crates/mister-smith-actor/src/system.rs
@@ -6,6 +6,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -147,15 +148,40 @@ impl ActorSystem {
         } else {
             None
         };
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(actor_cell::run_actor(
             actor,
             initial_state,
             receiver,
             stop_rx,
             state_tx,
+            Some(startup_tx),
             Some(sup_tx),
             event_pub,
         ));
+
+        match tokio::time::timeout(self.config.ask_timeout, startup_rx).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(err))) => {
+                let _ = stop_tx.send(()).await;
+                let _ = tokio::time::timeout(self.config.shutdown_timeout, join_handle).await;
+                return Err(ActorError::StartupFailed(Box::new(io::Error::other(err))));
+            }
+            Ok(Err(_)) => {
+                let _ = stop_tx.send(()).await;
+                let _ = tokio::time::timeout(self.config.shutdown_timeout, join_handle).await;
+                return Err(ActorError::StartupFailed(Box::new(io::Error::other(
+                    "actor task exited before startup acknowledgement",
+                ))));
+            }
+            Err(_) => {
+                let _ = stop_tx.send(()).await;
+                let _ = tokio::time::timeout(self.config.shutdown_timeout, join_handle).await;
+                return Err(ActorError::StartupFailed(Box::new(io::Error::other(
+                    "actor startup acknowledgement timed out",
+                ))));
+            }
+        }
 
         // Create actor ref
         let actor_ref = ActorRef::new(actor_id, sender.clone());


### PR DESCRIPTION
### Motivation
- Ensure `ActorSystem::spawn()` knows whether an actor's `pre_start` succeeded before registering it so the registry doesn't contain actors that failed to start.
- Surface startup failures immediately as `ActorError::StartupFailed(...)` and avoid leaving orphaned tasks in the registry.

### Description
- Added an optional oneshot `startup_tx: Option<oneshot::Sender<Result<(), String>>>` parameter to `run_actor` and send `Ok(())` after successful `pre_start` or `Err(...)` when `pre_start` fails (`crates/mister-smith-actor/src/actor_cell.rs`).
- Updated `ActorSystem::spawn()` to create and await the startup ack (`oneshot::channel()`), using `self.config.ask_timeout` as a bounded wait, and on error/timeout/early task exit send a stop signal, wait for task shutdown, return `ActorError::StartupFailed(...)`, and avoid inserting the actor into `actors` (`crates/mister-smith-actor/src/system.rs`).
- Updated tests to expect the new behavior by changing `pre_start_failure_on_spawn_transitions_to_error` to assert `spawn(...).await` returns `Err(ActorError::StartupFailed(_))` and that the actor is absent from the registry, and adjusted internal test call sites to pass the new `run_actor` parameter shapes.
- Touched files: `crates/mister-smith-actor/src/actor_cell.rs`, `crates/mister-smith-actor/src/system.rs`.

### Testing
- Ran `cargo test -p mister-smith-actor` and all unit tests passed (37 passed).
- Checked formatting with `cargo fmt --all --check` but it failed in this environment because the `rustfmt`/`cargo-fmt` component is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fbdc337c8333a32b267e8fbaa57c)