### PR TITLE
feat(actor): make ask return typed responses (Envelope<M,R>, Actor::Response)

### DIFF
--- a/crates/mister-smith-actor/src/actor_cell.rs
+++ b/crates/mister-smith-actor/src/actor_cell.rs
@@ -13,8 +13,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::mailbox::{Envelope, MailboxReceiver};
 
-enum MessageHandlingOutcome<E> {
-    Ok,
+enum MessageHandlingOutcome<R, E> {
+    Ok(R),
     Failed(E),
     Panicked(String),
 }
@@ -33,7 +33,7 @@ async fn handle_message_with_panic_capture<A>(
     actor: &mut A,
     message: A::Message,
     state: &mut A::State,
-) -> MessageHandlingOutcome<A::Error>
+) -> MessageHandlingOutcome<A::Response, A::Error>
 where
     A: Actor,
 {
@@ -41,7 +41,7 @@ where
         .catch_unwind()
         .await
     {
-        Ok(Ok(())) => MessageHandlingOutcome::Ok,
+        Ok(Ok(response)) => MessageHandlingOutcome::Ok(response),
         Ok(Err(error)) => MessageHandlingOutcome::Failed(error),
         Err(panic_payload) => MessageHandlingOutcome::Panicked(panic_payload_to_string(panic_payload)),
     }
@@ -120,7 +120,7 @@ pub enum TerminationReason {
 pub async fn run_actor<A>(
     mut actor: A,
     mut state: A::State,
-    mut receiver: MailboxReceiver<Envelope<A::Message>>,
+    mut receiver: MailboxReceiver<Envelope<A::Message, A::Response>>,
     mut stop_rx: mpsc::Receiver<()>,
     state_tx: watch::Sender<AgentState>,
     startup_tx: Option<oneshot::Sender<Result<(), String>>>,
@@ -209,9 +209,9 @@ pub async fn run_actor<A>(
                         let Envelope { message, reply_tx } = envelope;
 
                         match handle_message_with_panic_capture(&mut actor, message, &mut state).await {
-                            MessageHandlingOutcome::Ok => {
+                            MessageHandlingOutcome::Ok(response) => {
                                 if let Some(tx) = reply_tx {
-                                    let _ = tx.send(Ok(()));
+                                    let _ = tx.send(Ok(response));
                                 }
                             }
                             MessageHandlingOutcome::Failed(e) => {
@@ -261,9 +261,9 @@ pub async fn run_actor<A>(
     {
         let Envelope { message, reply_tx } = envelope;
         match handle_message_with_panic_capture(&mut actor, message, &mut state).await {
-            MessageHandlingOutcome::Ok => {
+            MessageHandlingOutcome::Ok(response) => {
                 if let Some(tx) = reply_tx {
-                    let _ = tx.send(Ok(()));
+                    let _ = tx.send(Ok(response));
                 }
             }
             MessageHandlingOutcome::Failed(e) => {
@@ -398,20 +398,21 @@ mod tests {
         type Message = CounterMsg;
         type State = u64;
         type Error = TestError;
+        type Response = u64;
 
         async fn handle_message(
             &mut self,
             message: CounterMsg,
             state: &mut u64,
-        ) -> Result<(), TestError> {
+        ) -> Result<u64, TestError> {
             match message {
                 CounterMsg::Increment => {
                     *state += 1;
-                    Ok(())
+                    Ok(*state)
                 }
                 CounterMsg::GetCount { reply } => {
                     let _ = reply.send(*state);
-                    Ok(())
+                    Ok(*state)
                 }
             }
         }
@@ -446,6 +447,7 @@ mod tests {
         type Message = FailMsg;
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -493,6 +495,7 @@ mod tests {
         type Message = PanicMsg;
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -534,6 +537,7 @@ mod tests {
         type Message = String;
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -568,6 +572,7 @@ mod tests {
         type Message = ();
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -595,7 +600,7 @@ mod tests {
     async fn actor_cell_process_tell() {
         let id = AgentId::new();
         let actor = CounterActor { id };
-        let (tx, rx) = create_mailbox::<CounterMsg>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<CounterMsg, u64>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
@@ -639,7 +644,7 @@ mod tests {
             pre_start_called: Arc::clone(&pre_start),
             post_stop_called: Arc::clone(&post_stop),
         };
-        let (tx, rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<String, ()>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
@@ -663,7 +668,7 @@ mod tests {
     async fn actor_failure_transitions_to_error() {
         let id = AgentId::new();
         let actor = FailingActor { id };
-        let (tx, rx) = create_mailbox::<FailMsg>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<FailMsg, ()>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
@@ -691,7 +696,7 @@ mod tests {
     async fn ask_pattern_reply() {
         let id = AgentId::new();
         let actor = CounterActor { id };
-        let (tx, rx) = create_mailbox::<CounterMsg>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<CounterMsg, u64>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
@@ -706,24 +711,12 @@ mod tests {
         tx.send(Envelope::tell(CounterMsg::Increment)).await.unwrap();
         tx.send(Envelope::tell(CounterMsg::Increment)).await.unwrap();
 
-        // Ask via envelope with both reply channels
-        let (ask_reply_tx, ask_reply_rx) = oneshot::channel();
-        let (count_reply_tx, count_reply_rx) = oneshot::channel();
-        tx.send(Envelope::ask(
-            CounterMsg::GetCount {
-                reply: count_reply_tx,
-            },
-            ask_reply_tx,
-        ))
-        .await
-        .unwrap();
+        // Ask via envelope with reply channel carrying typed payload
+        let (ask_reply_tx, ask_reply_rx) = oneshot::channel::<Result<u64, String>>();
+        tx.send(Envelope::ask(CounterMsg::Increment, ask_reply_tx)).await.unwrap();
 
-        // Count reply from inside the actor
-        let count = count_reply_rx.await.unwrap();
-        assert_eq!(count, 3);
-        // Ask reply from the envelope routing
-        let ask_result = ask_reply_rx.await.unwrap();
-        assert!(ask_result.is_ok());
+        let ask_result = ask_reply_rx.await.unwrap().unwrap();
+        assert_eq!(ask_result, 4);
 
         drop(tx);
         handle.await.unwrap();
@@ -739,7 +732,7 @@ mod tests {
             pre_start_called: Arc::new(AtomicBool::new(false)),
             post_stop_called: Arc::clone(&post_stop),
         };
-        let (_tx, rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (_tx, rx) = create_mailbox::<String, ()>(&MailboxConfig::bounded(10));
         let (stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, mut state_rx) = watch::channel(AgentState::Initializing);
 
@@ -767,6 +760,7 @@ mod tests {
         type Message = String;
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -837,7 +831,7 @@ mod tests {
     async fn pre_start_failure_notifies_supervisor() {
         let id = AgentId::new();
         let actor = PreStartFailActor { id };
-        let (_tx, rx) = create_mailbox::<()>(&MailboxConfig::bounded(10));
+        let (_tx, rx) = create_mailbox::<(), ()>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
@@ -861,7 +855,7 @@ mod tests {
             id,
             post_stop_called: Arc::clone(&post_stop_called),
         };
-        let (tx, rx) = create_mailbox::<PanicMsg>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<PanicMsg, ()>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, mut sup_rx) = mpsc::unbounded_channel();
@@ -885,7 +879,7 @@ mod tests {
             id,
             post_stop_called: Arc::new(AtomicBool::new(false)),
         };
-        let (tx, rx) = create_mailbox::<PanicMsg>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<PanicMsg, ()>(&MailboxConfig::bounded(10));
         let (_stop_tx, stop_rx) = mpsc::channel(1);
         let (state_tx, _state_rx) = watch::channel(AgentState::Initializing);
         let (sup_tx, _sup_rx) = mpsc::unbounded_channel();

--- a/crates/mister-smith-actor/src/actor_ref.rs
+++ b/crates/mister-smith-actor/src/actor_ref.rs
@@ -1,6 +1,6 @@
 //! Typed actor reference for sending messages to actors.
 //!
-//! `ActorRef<M>` provides `tell` (fire-and-forget) and `ask` (request-response) patterns.
+//! `ActorRef<M, R>` provides `tell` (fire-and-forget) and `ask` (request-response) patterns.
 //! It is cheaply cloneable and thread-safe (`Send + Sync`).
 
 use std::time::Duration;
@@ -15,14 +15,14 @@ use crate::mailbox::{Envelope, MailboxSender};
 /// `ActorRef` wraps a [`MailboxSender`] and provides the public API for
 /// communicating with an actor. It is `Clone`, `Send`, and `Sync`.
 #[derive(Debug, Clone)]
-pub struct ActorRef<M> {
+pub struct ActorRef<M, R> {
     actor_id: AgentId,
-    sender: MailboxSender<Envelope<M>>,
+    sender: MailboxSender<Envelope<M, R>>,
 }
 
-impl<M: Send + 'static> ActorRef<M> {
+impl<M: Send + 'static, R: Send + 'static> ActorRef<M, R> {
     /// Create a new actor reference.
-    pub fn new(actor_id: AgentId, sender: MailboxSender<Envelope<M>>) -> Self {
+    pub fn new(actor_id: AgentId, sender: MailboxSender<Envelope<M, R>>) -> Self {
         Self { actor_id, sender }
     }
 
@@ -42,13 +42,13 @@ impl<M: Send + 'static> ActorRef<M> {
         &self,
         message: M,
         timeout: Duration,
-    ) -> Result<(), ActorError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
+    ) -> Result<R, ActorError> {
+        let (reply_tx, reply_rx) = oneshot::channel::<Result<R, String>>();
         self.sender
             .try_send(Envelope::ask(message, reply_tx))?;
 
         match tokio::time::timeout(timeout, reply_rx).await {
-            Ok(Ok(Ok(()))) => Ok(()),
+            Ok(Ok(Ok(response))) => Ok(response),
             Ok(Ok(Err(e))) => Err(ActorError::MessageHandlingFailed(e)),
             Ok(Err(_)) => Err(ActorError::ActorStopped),
             Err(_) => Err(ActorError::AskTimeout),
@@ -77,7 +77,7 @@ mod tests {
     #[tokio::test]
     async fn tell_to_alive_actor() {
         let id = AgentId::new();
-        let (tx, mut rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, mut rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
 
         actor_ref.tell("hello".to_string()).unwrap();
@@ -88,7 +88,7 @@ mod tests {
     #[tokio::test]
     async fn tell_to_stopped_actor() {
         let id = AgentId::new();
-        let (tx, rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         drop(rx);
 
@@ -99,7 +99,7 @@ mod tests {
     #[tokio::test]
     async fn is_alive_when_running() {
         let id = AgentId::new();
-        let (tx, _rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, _rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         assert!(actor_ref.is_alive());
     }
@@ -107,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn is_alive_when_stopped() {
         let id = AgentId::new();
-        let (tx, rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         drop(rx);
         assert!(!actor_ref.is_alive());
@@ -116,7 +116,7 @@ mod tests {
     #[test]
     fn actor_id_returns_correct_id() {
         let id = AgentId::new();
-        let (tx, _rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, _rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         assert_eq!(actor_ref.actor_id(), id);
     }
@@ -124,7 +124,7 @@ mod tests {
     #[tokio::test]
     async fn ask_timeout() {
         let id = AgentId::new();
-        let (tx, _rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, _rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
 
         // Nobody will reply, so this should timeout
@@ -138,28 +138,28 @@ mod tests {
     #[tokio::test]
     async fn ask_with_reply() {
         let id = AgentId::new();
-        let (tx, mut rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, mut rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
 
         // Spawn a task to reply
         let handle = tokio::spawn(async move {
             let env = rx.recv().await.unwrap();
             if let Some(reply_tx) = env.reply_tx {
-                reply_tx.send(Ok(())).unwrap();
+                reply_tx.send(Ok(42)).unwrap();
             }
         });
 
         let result = actor_ref
             .ask("question".to_string(), Duration::from_secs(1))
             .await;
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
         handle.await.unwrap();
     }
 
     #[tokio::test]
     async fn ask_to_stopped_actor() {
         let id = AgentId::new();
-        let (tx, rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         drop(rx);
 
@@ -173,7 +173,7 @@ mod tests {
     #[tokio::test]
     async fn tell_to_full_mailbox() {
         let id = AgentId::new();
-        let (tx, _rx) = create_mailbox::<u32>(&MailboxConfig::bounded(2));
+        let (tx, _rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(2));
         let actor_ref = ActorRef::new(id, tx);
 
         actor_ref.tell(1).unwrap();
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn actor_ref_is_clone() {
         let id = AgentId::new();
-        let (tx, _rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, _rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         let actor_ref = ActorRef::new(id, tx);
         let cloned = actor_ref.clone();
         assert_eq!(actor_ref.actor_id(), cloned.actor_id());

--- a/crates/mister-smith-actor/src/mailbox.rs
+++ b/crates/mister-smith-actor/src/mailbox.rs
@@ -68,14 +68,14 @@ impl Default for SpawnConfig {
 /// For tell (fire-and-forget), `reply_tx` is `None`.
 /// For ask (request-response), `reply_tx` carries the oneshot sender for the response.
 #[derive(Debug)]
-pub struct Envelope<M> {
+pub struct Envelope<M, R> {
     /// The message payload.
     pub message: M,
     /// Optional reply channel for the ask pattern.
-    pub reply_tx: Option<oneshot::Sender<Result<(), String>>>,
+    pub reply_tx: Option<oneshot::Sender<Result<R, String>>>,
 }
 
-impl<M> Envelope<M> {
+impl<M, R> Envelope<M, R> {
     /// Create a tell envelope (no reply expected).
     pub fn tell(message: M) -> Self {
         Self {
@@ -85,7 +85,7 @@ impl<M> Envelope<M> {
     }
 
     /// Create an ask envelope with a reply channel.
-    pub fn ask(message: M, reply_tx: oneshot::Sender<Result<(), String>>) -> Self {
+    pub fn ask(message: M, reply_tx: oneshot::Sender<Result<R, String>>) -> Self {
         Self {
             message,
             reply_tx: Some(reply_tx),
@@ -184,9 +184,10 @@ impl<M> MailboxReceiver<M> {
 /// Create a mailbox channel pair based on the given configuration.
 ///
 /// Returns a `(MailboxSender, MailboxReceiver)` tuple.
-pub fn create_mailbox<M>(
+#[allow(clippy::type_complexity)]
+pub fn create_mailbox<M, R>(
     config: &MailboxConfig,
-) -> (MailboxSender<Envelope<M>>, MailboxReceiver<Envelope<M>>) {
+) -> (MailboxSender<Envelope<M, R>>, MailboxReceiver<Envelope<M, R>>) {
     match config.capacity {
         Some(capacity) => {
             let (tx, rx) = mpsc::channel(capacity);
@@ -210,7 +211,7 @@ mod tests {
 
     #[tokio::test]
     async fn bounded_send_receive() {
-        let (tx, mut rx) = create_mailbox::<String>(&MailboxConfig::bounded(10));
+        let (tx, mut rx) = create_mailbox::<String, u32>(&MailboxConfig::bounded(10));
         tx.send(Envelope::tell("hello".to_string())).await.unwrap();
         let env = rx.recv().await.unwrap();
         assert_eq!(env.message, "hello");
@@ -219,7 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn unbounded_send_receive() {
-        let (tx, mut rx) = create_mailbox::<String>(&MailboxConfig::unbounded());
+        let (tx, mut rx) = create_mailbox::<String, u32>(&MailboxConfig::unbounded());
         tx.send(Envelope::tell("world".to_string())).await.unwrap();
         let env = rx.recv().await.unwrap();
         assert_eq!(env.message, "world");
@@ -227,7 +228,7 @@ mod tests {
 
     #[tokio::test]
     async fn bounded_capacity_rejection() {
-        let (tx, _rx) = create_mailbox::<u32>(&MailboxConfig::bounded(2));
+        let (tx, _rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(2));
         // Fill the mailbox
         tx.try_send(Envelope::tell(1)).unwrap();
         tx.try_send(Envelope::tell(2)).unwrap();
@@ -238,7 +239,7 @@ mod tests {
 
     #[tokio::test]
     async fn fifo_ordering() {
-        let (tx, mut rx) = create_mailbox::<u32>(&MailboxConfig::bounded(10));
+        let (tx, mut rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(10));
         for i in 0..5 {
             tx.send(Envelope::tell(i)).await.unwrap();
         }
@@ -250,7 +251,7 @@ mod tests {
 
     #[tokio::test]
     async fn send_to_dropped_receiver_returns_actor_stopped() {
-        let (tx, rx) = create_mailbox::<u32>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(10));
         drop(rx);
         let err = tx.send(Envelope::tell(1)).await.unwrap_err();
         assert!(matches!(err, ActorError::ActorStopped));
@@ -258,7 +259,7 @@ mod tests {
 
     #[tokio::test]
     async fn try_send_to_dropped_receiver_returns_actor_stopped() {
-        let (tx, rx) = create_mailbox::<u32>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(10));
         drop(rx);
         let err = tx.try_send(Envelope::tell(1)).unwrap_err();
         assert!(matches!(err, ActorError::ActorStopped));
@@ -266,7 +267,7 @@ mod tests {
 
     #[tokio::test]
     async fn unbounded_never_rejects() {
-        let (tx, _rx) = create_mailbox::<u32>(&MailboxConfig::unbounded());
+        let (tx, _rx) = create_mailbox::<u32, ()>(&MailboxConfig::unbounded());
         // Send many messages — unbounded should never fail
         for i in 0..1000 {
             tx.try_send(Envelope::tell(i)).unwrap();
@@ -275,13 +276,13 @@ mod tests {
 
     #[tokio::test]
     async fn envelope_ask_has_reply_channel() {
-        let (reply_tx, reply_rx) = oneshot::channel();
+        let (reply_tx, reply_rx) = oneshot::channel::<Result<String, String>>();
         let env = Envelope::ask("question".to_string(), reply_tx);
         assert!(env.reply_tx.is_some());
         // Send reply through the channel
-        env.reply_tx.unwrap().send(Ok(())).unwrap();
+        env.reply_tx.unwrap().send(Ok("answer".to_string())).unwrap();
         let result = reply_rx.await.unwrap();
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "answer");
     }
 
     #[test]
@@ -301,7 +302,7 @@ mod tests {
 
     #[tokio::test]
     async fn is_closed_after_receiver_drop() {
-        let (tx, rx) = create_mailbox::<u32>(&MailboxConfig::bounded(10));
+        let (tx, rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(10));
         assert!(!tx.is_closed());
         drop(rx);
         assert!(tx.is_closed());
@@ -309,7 +310,7 @@ mod tests {
 
     #[tokio::test]
     async fn receiver_close_prevents_new_sends() {
-        let (tx, mut rx) = create_mailbox::<u32>(&MailboxConfig::bounded(10));
+        let (tx, mut rx) = create_mailbox::<u32, ()>(&MailboxConfig::bounded(10));
         rx.close();
         // Existing messages in buffer can still be received, but new sends fail
         // (since buffer is empty and closed, try_send should fail)

--- a/crates/mister-smith-actor/src/system.rs
+++ b/crates/mister-smith-actor/src/system.rs
@@ -119,7 +119,7 @@ impl ActorSystem {
         actor: A,
         initial_state: A::State,
         config: SpawnConfig,
-    ) -> Result<ActorRef<A::Message>, ActorError>
+    ) -> Result<ActorRef<A::Message, A::Response>, ActorError>
     where
         A: Actor,
         A::Message: Send + 'static,
@@ -128,7 +128,7 @@ impl ActorSystem {
         let actor_id = actor.actor_id();
 
         // Create mailbox
-        let (sender, receiver) = create_mailbox::<A::Message>(&config.mailbox);
+        let (sender, receiver) = create_mailbox::<A::Message, A::Response>(&config.mailbox);
 
         // Create stop signal channel
         let (stop_tx, stop_rx) = mpsc::channel(1);
@@ -405,6 +405,7 @@ mod tests {
         type Message = String;
         type State = Vec<String>;
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -444,6 +445,7 @@ mod tests {
         type Message = ();
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -473,6 +475,7 @@ mod tests {
         type Message = ();
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,
@@ -693,6 +696,7 @@ mod tests {
                 type Message = ();
                 type State = ();
                 type Error = TestError;
+                type Response = ();
 
                 async fn handle_message(
                     &mut self,

--- a/crates/mister-smith-core/src/traits.rs
+++ b/crates/mister-smith-core/src/traits.rs
@@ -83,13 +83,15 @@ pub trait Actor: Send + 'static {
     type State: Send + 'static;
     /// The error type returned by this actor's operations.
     type Error: Send + std::error::Error + 'static;
+    /// The typed response returned by `ask` requests.
+    type Response: Send + 'static;
 
     /// Handle an incoming message, potentially mutating state.
     async fn handle_message(
         &mut self,
         message: Self::Message,
         state: &mut Self::State,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<Self::Response, Self::Error>;
 
     /// Called before the actor starts processing messages.
     fn pre_start(&mut self) -> Result<(), Self::Error>;

--- a/crates/mister-smith-core/tests/trait_compilation_tests.rs
+++ b/crates/mister-smith-core/tests/trait_compilation_tests.rs
@@ -21,6 +21,7 @@ impl Actor for MockActor {
     type Message = String;
     type State = Vec<String>;
     type Error = ActorError;
+    type Response = ();
 
     async fn handle_message(
         &mut self,

--- a/crates/mister-smith-integration-tests/tests/supervision.rs
+++ b/crates/mister-smith-integration-tests/tests/supervision.rs
@@ -46,12 +46,13 @@ impl Actor for TrackingActor {
     type Message = TestMsg;
     type State = u32;
     type Error = TestError;
+    type Response = u32;
 
-    async fn handle_message(&mut self, message: TestMsg, state: &mut u32) -> Result<(), TestError> {
+    async fn handle_message(&mut self, message: TestMsg, state: &mut u32) -> Result<u32, TestError> {
         match message {
             TestMsg::Ping => {
                 *state += 1;
-                Ok(())
+                Ok(*state)
             }
             TestMsg::Fail => Err(TestError("intentional failure".into())),
         }
@@ -83,6 +84,7 @@ impl Actor for TimestampActor {
     type Message = TestMsg;
     type State = ();
     type Error = TestError;
+    type Response = ();
 
     async fn handle_message(&mut self, message: TestMsg, _state: &mut ()) -> Result<(), TestError> {
         match message {
@@ -204,6 +206,12 @@ async fn t054_one_for_one_only_failed_child_restarts() {
 
     let _handle = supervised.start_supervision();
     tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let ping_value = ref_b
+        .ask(TestMsg::Ping, Duration::from_secs(1))
+        .await
+        .unwrap();
+    assert_eq!(ping_value, 1);
 
     // Kill B
     ref_b.tell(TestMsg::Fail).unwrap();
@@ -856,14 +864,15 @@ impl Actor for SlowActor {
     type Message = TestMsg;
     type State = u32;
     type Error = TestError;
+    type Response = u32;
 
     async fn handle_message(
         &mut self,
         _message: TestMsg,
         _state: &mut u32,
-    ) -> Result<(), TestError> {
+    ) -> Result<u32, TestError> {
         tokio::time::sleep(Duration::from_secs(5)).await;
-        Ok(())
+        Ok(*_state)
     }
 
     fn pre_start(&mut self) -> Result<(), TestError> {
@@ -890,14 +899,18 @@ impl Actor for PreStartFailActor {
     type Message = TestMsg;
     type State = u32;
     type Error = TestError;
+    type Response = u32;
 
     async fn handle_message(
         &mut self,
         message: TestMsg,
-        _state: &mut u32,
-    ) -> Result<(), TestError> {
+        state: &mut u32,
+    ) -> Result<u32, TestError> {
         match message {
-            TestMsg::Ping => Ok(()),
+            TestMsg::Ping => {
+                *state += 1;
+                Ok(*state)
+            }
             TestMsg::Fail => Err(TestError("intentional failure".into())),
         }
     }

--- a/crates/mister-smith-supervision/src/health.rs
+++ b/crates/mister-smith-supervision/src/health.rs
@@ -181,6 +181,7 @@ mod tests {
         type Message = ();
         type State = ();
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,

--- a/crates/mister-smith-supervision/src/supervised.rs
+++ b/crates/mister-smith-supervision/src/supervised.rs
@@ -132,7 +132,7 @@ impl SupervisedSystem {
         supervisor_id: AgentId,
         factory: F,
         config: SpawnConfig,
-    ) -> Result<ActorRef<A::Message>, ActorError>
+    ) -> Result<ActorRef<A::Message, A::Response>, ActorError>
     where
         A: Actor + 'static,
         A::Message: Send + 'static,
@@ -468,6 +468,7 @@ mod tests {
         type Message = TestMsg;
         type State = u32;
         type Error = TestError;
+        type Response = ();
 
         async fn handle_message(
             &mut self,


### PR DESCRIPTION
### Motivation

- Convert the ask pattern from an untyped ack to real typed request/response semantics so callers receive handler-produced payloads instead of unit acknowledgements.
- Propagate typed responses through the mailbox, actor runtime, ActorRef API, and supervision surfaces while preserving existing timeout and error semantics.

### Description

- Add `type Response` to the `Actor` trait and change `handle_message` to return `Result<Self::Response, Self::Error>` so handlers can return payloads.
- Generalize mailbox `Envelope` to `Envelope<M, R>` carrying a `oneshot::Sender<Result<R, String>>` and make `create_mailbox` produce `MailboxSender/Receiver<Envelope<M, R>>`.
- Update `ActorRef` to `ActorRef<M, R>` and change `ask(...)` to return `Result<R, ActorError>` with the same timeout and stopped/failure mapping.
- Update `run_actor` to use `Envelope<A::Message, A::Response>` and route handler-returned values through reply channels (including drain-on-stop path), and adjust spawn/supervision APIs to return `ActorRef<A::Message, A::Response>`.

### Testing

- Ran `cargo test -p mister-smith-core -p mister-smith-actor -p mister-smith-supervision` and the test suites completed successfully (all tests passed).
- Attempted `cargo test -p mister-smith-core -p mister-smith-actor -p mister-smith-supervision -p mister-smith-integration-tests --test supervision` but the run failed early due to missing protobuf includes during the `mister-smith-transport` build (protoc error: `google/protobuf/*.proto` not found), preventing the integration test binary from being built in this environment.
- `cargo fmt` could not be executed here because `rustfmt` is not installed in the environment, so formatting/lint gating should be applied in CI or after installing the component.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fbfceb208333975ce2ef1234adb7)