### PR TITLE
fix(mcp): add rmcp dependency and map rmcp errors into McpError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "mister-smith-core",
  "mister-smith-nats",
  "mister-smith-transport",
+ "rmcp",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2037,6 +2038,24 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cb14cb9278a12eae884c9f3c0cfeca2cc28f361211206424a1d7abed95f090"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/mister-smith-mcp/Cargo.toml
+++ b/crates/mister-smith-mcp/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
+rmcp = { version = "1.1.0", default-features = false, features = ["client", "server", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/mister-smith-mcp/src/errors.rs
+++ b/crates/mister-smith-mcp/src/errors.rs
@@ -37,6 +37,67 @@ pub enum McpError {
     SerializationError(String),
 }
 
+// rmcp 1.1.0 deprecated the `Error` struct constructors (e.g. `Error::resource_not_found`).
+// These are still functional and the replacements are not yet stable. Track migration in a
+// follow-up once rmcp 2.x settles the new error API.
+#[allow(deprecated)]
+impl From<rmcp::Error> for McpError {
+    fn from(err: rmcp::Error) -> Self {
+        let code = err.code.0;
+        let message = err.message.to_string();
+        let context = format!("rmcp error (code {code}): {message}");
+        let lowered = message.to_ascii_lowercase();
+
+        if lowered.contains("session") {
+            return McpError::SessionError(context);
+        }
+
+        if lowered.contains("timeout") || lowered.contains("timed out") {
+            return McpError::BridgeTimeout(context);
+        }
+
+        if err.code == rmcp::model::ErrorCode::PARSE_ERROR {
+            return McpError::SerializationError(context);
+        }
+
+        if err.code == rmcp::model::ErrorCode::RESOURCE_NOT_FOUND
+            || (err.code == rmcp::model::ErrorCode::METHOD_NOT_FOUND
+                && lowered.contains("tool"))
+            || lowered.contains("tool not found")
+        {
+            return McpError::ToolNotFound(context);
+        }
+
+        if lowered.contains("connect")
+            || lowered.contains("connection")
+            || lowered.contains("transport")
+            || lowered.contains("network")
+            || lowered.contains("refused")
+        {
+            return McpError::ConnectionFailed(context);
+        }
+
+        McpError::ToolCallFailed(context)
+    }
+}
+
+impl From<rmcp::RmcpError> for McpError {
+    fn from(err: rmcp::RmcpError) -> Self {
+        match err {
+            rmcp::RmcpError::TransportCreation { error, .. } => {
+                McpError::ConnectionFailed(format!("rmcp transport creation failed: {error}"))
+            }
+            rmcp::RmcpError::Runtime(join_error) => {
+                McpError::SessionError(format!("rmcp runtime/session task failed: {join_error}"))
+            }
+            rmcp::RmcpError::TaskError(message) => {
+                McpError::ToolCallFailed(format!("rmcp task error during tool call: {message}"))
+            }
+            _ => McpError::ToolCallFailed(format!("rmcp error: {err}")),
+        }
+    }
+}
+
 impl From<McpError> for mister_smith_transport::TransportError {
     fn from(err: McpError) -> Self {
         match err {
@@ -67,5 +128,44 @@ mod tests {
             transport_err,
             mister_smith_transport::TransportError::ConnectionFailed(_)
         ));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn rmcp_error_maps_to_tool_not_found() {
+        let rmcp_err = rmcp::Error::resource_not_found("tool not found: read_file", None);
+        let converted = McpError::from(rmcp_err);
+
+        assert!(matches!(converted, McpError::ToolNotFound(msg) if msg.contains("tool not found")));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn rmcp_error_maps_to_session_error() {
+        let rmcp_err = rmcp::Error::invalid_request("session expired", None);
+        let converted = McpError::from(rmcp_err);
+
+        assert!(matches!(converted, McpError::SessionError(msg) if msg.contains("session expired")));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn rmcp_error_maps_to_connection_failure() {
+        let rmcp_err = rmcp::Error::internal_error("transport connection refused", None);
+        let converted = McpError::from(rmcp_err);
+
+        assert!(matches!(
+            converted,
+            McpError::ConnectionFailed(msg) if msg.contains("connection refused")
+        ));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn rmcp_error_maps_to_serialization_error() {
+        let rmcp_err = rmcp::Error::parse_error("invalid JSON", None);
+        let converted = McpError::from(rmcp_err);
+
+        assert!(matches!(converted, McpError::SerializationError(msg) if msg.contains("invalid JSON")));
     }
 }


### PR DESCRIPTION
### Motivation
- Surface `rmcp` errors must be translated into the crate-local `McpError` so the `mister-smith-mcp` public API does not leak `rmcp` types or require callers to depend on `thiserror` 2.x.
- Categorize common RMCP failure modes (connectivity, session, tool-not-found, timeouts, serialization) into existing `McpError` variants for clearer handling by higher layers.

### Description
- Added `rmcp` dependency to `crates/mister-smith-mcp/Cargo.toml` with `default-features = false` to limit feature surface.
- Implemented `impl From<rmcp::Error> for McpError` that inspects `rmcp::Error` code/message and maps it into `ConnectionFailed`, `SessionError`, `ToolNotFound`, `ToolCallFailed`, `BridgeTimeout`, or `SerializationError` with informative context.
- Implemented `impl From<rmcp::RmcpError> for McpError` to map transport creation, runtime/join, and task errors into appropriate `McpError` variants.
- Added unit tests that construct representative `rmcp::Error` values and assert the expected `McpError` conversions; verified source scan to ensure no `rmcp` types leak from public signatures.

### Testing
- Ran `cargo test -p mister-smith-mcp`, which attempted to compile and run tests but failed in this environment due to a dependent crate build error (`mister-smith-transport` build script could not find protobuf well-known types such as `google/protobuf/timestamp.proto`), so the new unit tests could not be executed here (build failed).
- The repository was scanned for public API leaks (`rg` checks) and found no public `rmcp` types exposed from `crates/mister-smith-mcp/src`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fcf729688333960af47646e6ae19)