### PR TITLE
feat(transport): generate and expose gRPC health protobuf module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "protoc-bin-vendored",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -1827,6 +1828,70 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "quote"

--- a/crates/mister-smith-transport/Cargo.toml
+++ b/crates/mister-smith-transport/Cargo.toml
@@ -27,6 +27,7 @@ prost-types = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }
 prost-build = { workspace = true }
+protoc-bin-vendored = "3"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/mister-smith-transport/build.rs
+++ b/crates/mister-smith-transport/build.rs
@@ -1,17 +1,29 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proto_dir = "proto";
 
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    let protoc_include = protoc_bin_vendored::include_path()?;
+
+    std::env::set_var("PROTOC", protoc);
+
+    // Keep `proto/` in the include search path so shared imports such as
+    // `import "common.proto";` resolve for all generated modules.
+    let include_paths = [
+        std::path::PathBuf::from(proto_dir),
+        protoc_include,
+    ];
+
     // Compile protobuf message types only (no gRPC service generation).
     // gRPC service code generation is handled in mister-smith-grpc/build.rs.
-    prost_build::Config::new()
-        .compile_protos(
-            &[
-                format!("{proto_dir}/common.proto"),
-                format!("{proto_dir}/agent_service.proto"),
-                format!("{proto_dir}/system_service.proto"),
-            ],
-            &[proto_dir],
-        )?;
+    prost_build::Config::new().compile_protos(
+        &[
+            format!("{proto_dir}/common.proto"),
+            format!("{proto_dir}/agent_service.proto"),
+            format!("{proto_dir}/system_service.proto"),
+            format!("{proto_dir}/health_service.proto"),
+        ],
+        &include_paths,
+    )?;
 
     Ok(())
 }

--- a/crates/mister-smith-transport/src/lib.rs
+++ b/crates/mister-smith-transport/src/lib.rs
@@ -28,12 +28,43 @@ pub use serialization::{from_json, from_msgpack, to_json, to_msgpack};
 pub use subject::SubjectTaxonomy;
 pub use transport::{ReceivedMessage, Subscription, Transport};
 
-/// Generated protobuf types from `common.proto`, `agent_service.proto`, and `system_service.proto`.
+/// Generated protobuf types from `common.proto`, `agent_service.proto`, `system_service.proto`, and `health_service.proto`.
 pub mod proto {
-    /// Types from the `mister_smith.v1` package.
+    /// Types from the `mister_smith.v1` package (`common`, `agent_service`, and `system_service`).
     pub mod mister_smith {
         pub mod v1 {
             include!(concat!(env!("OUT_DIR"), "/mister_smith.v1.rs"));
         }
+    }
+
+    /// Types from the `grpc.health.v1` package (`health_service`).
+    pub mod grpc {
+        pub mod health {
+            pub mod v1 {
+                include!(concat!(env!("OUT_DIR"), "/grpc.health.v1.rs"));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod proto_tests {
+    use super::proto;
+
+    #[test]
+    fn health_proto_types_are_accessible() {
+        let request = proto::grpc::health::v1::HealthCheckRequest {
+            service: "transport".to_string(),
+        };
+
+        let response = proto::grpc::health::v1::HealthCheckResponse {
+            status: proto::grpc::health::v1::health_check_response::ServingStatus::Serving.into(),
+        };
+
+        assert_eq!(request.service, "transport");
+        assert_eq!(
+            response.status,
+            proto::grpc::health::v1::health_check_response::ServingStatus::Serving as i32
+        );
     }
 }


### PR DESCRIPTION
### Motivation

- Add transport-level access to the gRPC Health proto so health types can be referenced from the transport crate without duplicating types.  
- Ensure proto compilation resolves shared imports from `common.proto` and standard well-known types (e.g. `google/protobuf/timestamp.proto`).  
- Provide a lightweight compile-time smoke assertion that health proto types are reachable from the crate root.

### Description

- Updated `crates/mister-smith-transport/build.rs` to compile `proto/health_service.proto` and to pass explicit include paths that include both the local `proto/` directory and the vendored `protoc` include path.  
- Wired in `protoc-bin-vendored` and set `PROTOC` in the build script so well-known protobuf imports are available during `prost_build` generation.  
- Updated `crates/mister-smith-transport/Cargo.toml` to add `protoc-bin-vendored` as a build-dependency.  
- Updated `crates/mister-smith-transport/src/lib.rs` to document and expose the generated `proto::grpc::health::v1` module and added a small compile-level unit test `health_proto_types_are_accessible` that constructs `HealthCheckRequest`/`HealthCheckResponse` to assert types are accessible.

### Testing

- Ran `cargo test -p mister-smith-transport`, and all unit tests passed; the suite completed with 55 tests passing and the new `proto_tests::health_proto_types_are_accessible` test included and successful.  
- The build-time issue caused by missing well-known includes was resolved by adding `protoc-bin-vendored`, enabling the proto compilation step to complete during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fd1abcb08333849cf354026e100a)