### PR TITLE
feat(http): wire transport health into health endpoint

### DIFF
--- a/crates/mister-smith-http/src/handlers.rs
+++ b/crates/mister-smith-http/src/handlers.rs
@@ -127,7 +127,9 @@ pub struct AgentListQuery {
 // ---------------------------------------------------------------------------
 
 /// `GET /api/v1/health` — System health with component details.
-pub async fn health_check(State(_state): State<AppState>) -> Json<HealthResponse> {
+pub async fn health_check(State(state): State<AppState>) -> Json<HealthResponse> {
+    let transport_connected = state.transport_health.is_connected();
+
     let components = vec![
         ComponentHealth {
             name: "http_server".to_string(),
@@ -135,9 +137,17 @@ pub async fn health_check(State(_state): State<AppState>) -> Json<HealthResponse
             message: None,
         },
         ComponentHealth {
-            name: "event_bus".to_string(),
-            status: "healthy".to_string(),
-            message: None,
+            name: "nats_transport".to_string(),
+            status: if transport_connected {
+                "healthy".to_string()
+            } else {
+                "unhealthy".to_string()
+            },
+            message: if transport_connected {
+                None
+            } else {
+                Some("NATS transport disconnected".to_string())
+            },
         },
     ];
 
@@ -296,18 +306,37 @@ fn mock_agents() -> Vec<AgentSummary> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::AppState;
+    use crate::server::{AppState, NatsHealthCheck};
 
     fn test_state() -> AppState {
         AppState::new()
     }
 
     #[tokio::test]
-    async fn health_check_returns_healthy() {
-        let state = test_state();
+    async fn health_check_returns_healthy_when_transport_connected() {
+        let state = test_state().with_transport_health(std::sync::Arc::new(NatsHealthCheck::new(true)));
         let Json(response) = health_check(State(state)).await;
+
         assert_eq!(response.status, "healthy");
-        assert!(!response.components.is_empty());
+        assert_eq!(response.components.len(), 2);
+        assert_eq!(response.components[0].name, "http_server");
+        assert_eq!(response.components[0].status, "healthy");
+        assert_eq!(response.components[1].name, "nats_transport");
+        assert_eq!(response.components[1].status, "healthy");
+    }
+
+    #[tokio::test]
+    async fn health_check_returns_unhealthy_when_transport_disconnected() {
+        let state = test_state().with_transport_health(std::sync::Arc::new(NatsHealthCheck::new(false)));
+        let Json(response) = health_check(State(state)).await;
+
+        assert_eq!(response.status, "unhealthy");
+        assert_eq!(response.components[1].name, "nats_transport");
+        assert_eq!(response.components[1].status, "unhealthy");
+        assert_eq!(
+            response.components[1].message.as_deref(),
+            Some("NATS transport disconnected")
+        );
     }
 
     #[tokio::test]

--- a/crates/mister-smith-http/src/routes.rs
+++ b/crates/mister-smith-http/src/routes.rs
@@ -24,8 +24,8 @@ pub fn api_router() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::AppState;
-    use axum::body::Body;
+    use crate::server::{AppState, NatsHealthCheck};
+    use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
@@ -33,9 +33,15 @@ mod tests {
         api_router().with_state(AppState::new())
     }
 
+    fn test_app_with_transport(connected: bool) -> Router {
+        api_router().with_state(
+            AppState::new().with_transport_health(std::sync::Arc::new(NatsHealthCheck::new(connected))),
+        )
+    }
+
     #[tokio::test]
-    async fn health_route_responds_ok() {
-        let app = test_app();
+    async fn health_route_responds_healthy_when_transport_connected() {
+        let app = test_app_with_transport(true);
         let request = Request::builder()
             .uri("/api/v1/health")
             .body(Body::empty())
@@ -43,6 +49,32 @@ mod tests {
 
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["status"], "healthy");
+        assert_eq!(payload["components"][0]["name"], "http_server");
+        assert_eq!(payload["components"][1]["name"], "nats_transport");
+        assert_eq!(payload["components"][1]["status"], "healthy");
+    }
+
+    #[tokio::test]
+    async fn health_route_responds_unhealthy_when_transport_disconnected() {
+        let app = test_app_with_transport(false);
+        let request = Request::builder()
+            .uri("/api/v1/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["status"], "unhealthy");
+        assert_eq!(payload["components"][0]["name"], "http_server");
+        assert_eq!(payload["components"][1]["name"], "nats_transport");
+        assert_eq!(payload["components"][1]["status"], "unhealthy");
     }
 
     #[tokio::test]

--- a/crates/mister-smith-http/src/server.rs
+++ b/crates/mister-smith-http/src/server.rs
@@ -7,6 +7,7 @@
 use axum::middleware as axum_mw;
 use axum::Router;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::broadcast;
 use tracing::info;
 
@@ -20,11 +21,45 @@ use crate::websocket::WsEvent;
 /// Default broadcast channel capacity for WebSocket events.
 const EVENT_CHANNEL_CAPACITY: usize = 1024;
 
+/// Runtime health interface for the transport dependency backing this HTTP server.
+pub trait TransportHealth: Send + Sync {
+    /// Return true when the underlying transport is connected and serving traffic.
+    fn is_connected(&self) -> bool;
+}
+
+/// NATS transport health check implementation backed by an atomic connection flag.
+#[derive(Debug, Default)]
+pub struct NatsHealthCheck {
+    connected: AtomicBool,
+}
+
+impl NatsHealthCheck {
+    /// Build a new check with explicit initial connectivity.
+    pub fn new(connected: bool) -> Self {
+        Self {
+            connected: AtomicBool::new(connected),
+        }
+    }
+
+    /// Update the observed NATS connectivity.
+    pub fn set_connected(&self, connected: bool) {
+        self.connected.store(connected, Ordering::Relaxed);
+    }
+}
+
+impl TransportHealth for NatsHealthCheck {
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+}
+
 /// Shared application state accessible by all handlers.
 #[derive(Clone)]
 pub struct AppState {
     /// Broadcast sender for WebSocket events.
     pub event_tx: broadcast::Sender<WsEvent>,
+    /// Transport health dependency used by readiness/liveness handlers.
+    pub transport_health: Arc<dyn TransportHealth>,
     /// Optional security layer for JWT authentication.
     #[cfg(feature = "security")]
     pub security: Option<Arc<mister_smith_security::middleware::SecurityLayer>>,
@@ -36,6 +71,7 @@ impl AppState {
         let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         Self {
             event_tx,
+            transport_health: Arc::new(NatsHealthCheck::new(true)),
             #[cfg(feature = "security")]
             security: None,
         }
@@ -46,9 +82,16 @@ impl AppState {
         let (event_tx, _) = broadcast::channel(capacity);
         Self {
             event_tx,
+            transport_health: Arc::new(NatsHealthCheck::new(true)),
             #[cfg(feature = "security")]
             security: None,
         }
+    }
+
+    /// Set a custom transport health checker implementation.
+    pub fn with_transport_health(mut self, transport_health: Arc<dyn TransportHealth>) -> Self {
+        self.transport_health = transport_health;
+        self
     }
 
     /// Set the security layer for JWT authentication enforcement.
@@ -143,6 +186,14 @@ mod tests {
     fn app_state_with_capacity() {
         let state = AppState::with_capacity(64);
         let _rx = state.event_tx.subscribe();
+    }
+
+    #[test]
+    fn nats_health_check_tracks_connectivity() {
+        let check = NatsHealthCheck::new(true);
+        assert!(check.is_connected());
+        check.set_connected(false);
+        assert!(!check.is_connected());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide accurate HTTP health responses by observing the transport layer rather than returning hardcoded component statuses.
- Allow injection of a transport health dependency for testing and runtime composition.
- Surface transport connectivity (NATS) as a first-class component in the health API so overall status can be computed from component health.

### Description
- Introduced a `TransportHealth` trait and a default `NatsHealthCheck` (atomic boolean) implementation in `crates/mister-smith-http/src/server.rs`.
- Extended `AppState` with a `transport_health: Arc<dyn TransportHealth>` field and added `with_transport_health(...)` for dependency injection and tests; default state uses `NatsHealthCheck::new(true)`.
- Updated `handlers::health_check` to read `state.transport_health.is_connected()` and report two components: `http_server` and `nats_transport`, deriving overall `status` from component statuses and including a message when the transport is disconnected.
- Added unit tests covering the `NatsHealthCheck` behavior and handler-level tests that assert health responses for connected vs disconnected transport, and route-level tests that exercise `/api/v1/health` with injected transport connectivity.

### Testing
- Ran `cargo fmt --all` but it failed because `rustfmt` is not installed in this environment (toolchain component missing).
- Ran `cargo test -p mister-smith-http` but the test run failed during dependency build due to missing protobuf includes required by `mister-smith-transport` build script (`google/protobuf/*.proto` not found), so the crate's tests could not complete here.
- Included tests in the HTTP crate covering both handler and route behaviors for transport connected/disconnected scenarios; these tests are present but could not be fully executed end-to-end in this environment due to the dependency build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fd2106b48333b3d2d6030b203955)