### PR TITLE
feat: add env-gated NATS cross-transport integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -278,6 +278,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1366,8 +1372,10 @@ dependencies = [
 name = "mister-smith-integration-tests"
 version = "0.1.0"
 dependencies = [
+ "async-nats",
  "async-trait",
  "axum",
+ "chrono",
  "futures",
  "mister-smith-actor",
  "mister-smith-async",
@@ -1387,6 +1395,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.24.0",
  "tonic",
  "tonic-health",
  "tower",
@@ -2827,6 +2837,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -2834,7 +2856,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3116,6 +3138,24 @@ checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
 dependencies = [
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]

--- a/crates/mister-smith-integration-tests/Cargo.toml
+++ b/crates/mister-smith-integration-tests/Cargo.toml
@@ -33,3 +33,7 @@ async-trait = { workspace = true }
 uuid = { workspace = true }
 tonic = { workspace = true }
 tonic-health = { workspace = true }
+chrono = { workspace = true }
+async-nats = { workspace = true }
+tokio-stream = { version = "0.1", features = ["net"] }
+tokio-tungstenite = "0.24"


### PR DESCRIPTION
### Motivation
- Provide acceptance-level coverage for T047/T049 using a real NATS server, HTTP, WebSocket, and gRPC surfaces while keeping fast unit-style `InMemoryTransport` tests separate.
- Ensure the HTTP health endpoint and gRPC health service can reflect actual transport connectivity for runtime monitoring and readiness checks.
- Avoid running external-service integration tests by default and make them clearly gated so CI and local devs opt-in explicitly.

### Description
- Added environment-gated external tests in `crates/mister-smith-integration-tests/tests/transport_e2e.rs` that exercise: a NATS-backed publish->process->reply flow, HTTP health reflecting NATS state, WebSocket event streaming bridged from transport messages, and gRPC health transitions based on transport connectivity, gated by `MISTER_SMITH_RUN_EXTERNAL_INTEGRATION` and configured via `MISTER_SMITH_NATS_URL`.
- Kept and clarified `InMemoryTransport` tests in the same file as fast, unit-style verification and updated comments to state they do not satisfy cross-transport/NATS acceptance on their own.
- Extended HTTP app state with a pluggable `TransportHealthProvider` and `TransportHealthStatus` in `crates/mister-smith-http/src/server.rs` and wired health output in `crates/mister-smith-http/src/handlers.rs` to reflect the provider's runtime status.
- Added test-only dependencies required for the new acceptance tests in `crates/mister-smith-integration-tests/Cargo.toml` (including `tonic`, `tonic-health`, `chrono`, `async-nats`, `tokio-stream`, `tokio-tungstenite`).

### Testing
- Ran `cargo test -p mister-smith-integration-tests --test transport_e2e`, which started compilation but failed in this environment because the `mister-smith-transport` build script invoked `protoc` and `google/protobuf/*.proto` includes were not available, causing the build to error (test run blocked).
- Attempted `cargo fmt --all` but `rustfmt`/`cargo-fmt` is not installed in the current toolchain so formatting could not be validated here.
- All new external tests are skip-gated by default; to run them locally set `MISTER_SMITH_RUN_EXTERNAL_INTEGRATION=1` and point `MISTER_SMITH_NATS_URL` to a reachable NATS instance (JetStream enabled where required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fcf80704833391231cbe70be4dd8)