### PR TITLE
fix(grpc): enforce auth interceptor on secure server path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tonic",
+ "tonic-health",
  "tower",
  "uuid",
 ]

--- a/crates/mister-smith-grpc/src/server.rs
+++ b/crates/mister-smith-grpc/src/server.rs
@@ -117,8 +117,24 @@ impl GrpcServer {
             "starting gRPC server"
         );
 
-        Server::builder()
-            .add_service(health_service)
+        let mut builder = Server::builder();
+
+        #[cfg(feature = "security")]
+        let builder = if let Some(security) = self.security.as_ref().filter(|layer| layer.is_enabled())
+        {
+            let interceptor =
+                mister_smith_security::middleware::tonic_mw::grpc_auth_interceptor(
+                    std::sync::Arc::clone(security),
+                );
+            builder.add_service(tonic::service::interceptor::InterceptedService::new(health_service, interceptor))
+        } else {
+            builder.add_service(health_service)
+        };
+
+        #[cfg(not(feature = "security"))]
+        let builder = builder.add_service(health_service);
+
+        builder
             .serve_with_shutdown(addr, shutdown_signal)
             .await
             .map_err(|e| {

--- a/crates/mister-smith-integration-tests/Cargo.toml
+++ b/crates/mister-smith-integration-tests/Cargo.toml
@@ -31,3 +31,5 @@ serde_json = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { workspace = true }

--- a/crates/mister-smith-integration-tests/tests/security_integration.rs
+++ b/crates/mister-smith-integration-tests/tests/security_integration.rs
@@ -214,6 +214,159 @@ fn audit_chain_integrity_integration() {
     assert_eq!(events.len(), 3);
 }
 
+
+
+// -- gRPC auth interceptor integration --------------------------------------
+
+async fn spawn_secure_grpc_server(
+    security: Arc<SecurityLayer>,
+) -> (tokio::task::JoinHandle<Result<(), mister_smith_grpc::errors::TransportError>>, String, tokio::sync::oneshot::Sender<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let mut server = mister_smith_grpc::server::GrpcServer::new(
+        mister_smith_grpc::config::GrpcTransportConfig::new(addr.to_string()),
+    )
+    .with_security(security);
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        server
+            .serve(async {
+                let _ = rx.await;
+            })
+            .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    (handle, format!("http://{addr}"), tx)
+}
+
+#[tokio::test]
+async fn grpc_request_without_authorization_returns_unauthenticated() {
+    let security = Arc::new(
+        SecurityLayer::new(
+            true,
+            &test_jwt_config(),
+            &RbacConfig::default(),
+            &AuditConfig::default(),
+        )
+        .unwrap(),
+    );
+
+    let (handle, endpoint, shutdown_tx) = spawn_secure_grpc_server(security).await;
+
+    let channel = tonic::transport::Endpoint::from_shared(endpoint)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = tonic_health::pb::health_client::HealthClient::new(channel);
+    let err = client
+        .check(tonic_health::pb::HealthCheckRequest {
+            service: "".to_string(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+    let _ = shutdown_tx.send(());
+    let result = handle.await.unwrap();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn grpc_request_with_invalid_token_returns_unauthenticated() {
+    let security = Arc::new(
+        SecurityLayer::new(
+            true,
+            &test_jwt_config(),
+            &RbacConfig::default(),
+            &AuditConfig::default(),
+        )
+        .unwrap(),
+    );
+
+    let (handle, endpoint, shutdown_tx) = spawn_secure_grpc_server(security).await;
+
+    let channel = tonic::transport::Endpoint::from_shared(endpoint)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = tonic_health::pb::health_client::HealthClient::new(channel);
+    let mut request = tonic::Request::new(tonic_health::pb::HealthCheckRequest {
+        service: "".to_string(),
+    });
+    request.metadata_mut().insert(
+        "authorization",
+        tonic::metadata::MetadataValue::from_static("Bearer not-a-valid-token"),
+    );
+
+    let err = client.check(request).await.unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+    let _ = shutdown_tx.send(());
+    let result = handle.await.unwrap();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn grpc_request_with_valid_token_succeeds() {
+    let security = Arc::new(
+        SecurityLayer::new(
+            true,
+            &test_jwt_config(),
+            &RbacConfig::default(),
+            &AuditConfig::default(),
+        )
+        .unwrap(),
+    );
+
+    let token = security
+        .jwt
+        .generate_token_pair(&AgentClaims {
+            sub: "grpc-int-test".to_string(),
+            agent_id: "grpc-int-test".to_string(),
+            ..Default::default()
+        })
+        .unwrap()
+        .access_token;
+
+    let (handle, endpoint, shutdown_tx) = spawn_secure_grpc_server(security).await;
+
+    let channel = tonic::transport::Endpoint::from_shared(endpoint)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let mut client = tonic_health::pb::health_client::HealthClient::new(channel);
+    let mut request = tonic::Request::new(tonic_health::pb::HealthCheckRequest {
+        service: "".to_string(),
+    });
+    request.metadata_mut().insert(
+        "authorization",
+        tonic::metadata::MetadataValue::try_from(format!("Bearer {token}")).unwrap(),
+    );
+
+    let response = client.check(request).await.unwrap();
+    assert_eq!(
+        response.into_inner().status,
+        tonic_health::ServingStatus::Serving as i32
+    );
+
+    let _ = shutdown_tx.send(());
+    let result = handle.await.unwrap();
+    assert!(result.is_ok());
+}
+
 // -- Middleware integration with Axum -------------------------------------
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation

- Prevent registered gRPC services from bypassing authentication by centralizing service registration and ensuring the auth interceptor is applied whenever a configured security layer is present and enabled.
- Make the secure vs non-secure registration explicit in one place so alternate code paths cannot accidentally skip middleware enforcement.

### Description

- Refactored `GrpcServer::serve` to build a single `Server::builder()` and then branch to add services either wrapped with `mister_smith_security::middleware::tonic_mw::grpc_auth_interceptor` (via `tonic::service::interceptor::InterceptedService::new`) when `self.security` is present and enabled, or added directly when security is absent/disabled.
- Kept the health service registration in that single assembly flow so auth cannot be skipped by alternate flows in `serve`.
- Added end-to-end gRPC integration tests in `crates/mister-smith-integration-tests/tests/security_integration.rs` that spawn a secure `GrpcServer` and assert the three cases: missing `authorization` metadata → `Unauthenticated`, invalid token → `Unauthenticated`, and valid token → success.
- Added `tonic` and `tonic-health` workspace dependencies to `crates/mister-smith-integration-tests/Cargo.toml` and updated `Cargo.lock` to support the new tests.

### Testing

- Ran `cargo test -p mister-smith-integration-tests --test security_integration -- --nocapture` and the integration security tests passed (10 passed).
- Ran `cargo test -p mister-smith-grpc -- --nocapture` and the gRPC crate test-suite passed (67 passed).
- Attempted `cargo fmt --package mister-smith-grpc --package mister-smith-integration-tests` but `rustfmt` component was not installed in the environment so formatting check was not run locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9058432fc8333861ecbb01d69374b)