### PR TITLE
fix(security): enforce RBAC policy checks in Axum and Tonic middleware

### DIFF
--- a/crates/mister-smith-security/src/middleware/axum_mw.rs
+++ b/crates/mister-smith-security/src/middleware/axum_mw.rs
@@ -12,6 +12,8 @@ use axum::response::{IntoResponse, Response};
 
 use crate::jwt::AgentClaims;
 use crate::middleware::SecurityLayer;
+#[cfg(feature = "rbac")]
+use crate::rbac::AuthorizationRequest;
 
 /// Axum middleware that validates JWT Bearer tokens.
 ///
@@ -20,7 +22,8 @@ use crate::middleware::SecurityLayer;
 /// 1. Checks rate limiter — returns 429 if exceeded.
 /// 2. Extracts Bearer token from `Authorization` header — returns 401 if missing.
 /// 3. Validates the token via `JwtManager` — returns 401 if invalid/expired/revoked.
-/// 4. Inserts `AgentClaims` into request extensions for downstream handlers.
+/// 4. Evaluates RBAC policy (when enabled) — returns 403 if unauthorized.
+/// 5. Inserts `AgentClaims` into request extensions for downstream handlers.
 pub async fn auth_middleware(
     State(security): State<Arc<SecurityLayer>>,
     mut request: Request<axum::body::Body>,
@@ -84,6 +87,31 @@ pub async fn auth_middleware(
                     std::collections::HashMap::new(),
                 );
             }
+            #[cfg(feature = "rbac")]
+            {
+                let authz_request = build_http_authorization_request(&request, &claims);
+                let decision = security.policy.evaluate(&authz_request);
+
+                #[cfg(feature = "audit")]
+                {
+                    use crate::audit::events::AuditOutcome;
+                    security.audit.record_authz(
+                        &claims.sub,
+                        &authz_request.action,
+                        &authz_request.resource,
+                        if decision.allowed {
+                            AuditOutcome::Success
+                        } else {
+                            AuditOutcome::Failure
+                        },
+                    );
+                }
+
+                if !decision.allowed {
+                    return forbidden_response("forbidden");
+                }
+            }
+
             request.extensions_mut().insert(claims);
             next.run(request).await
         }
@@ -101,6 +129,30 @@ pub async fn auth_middleware(
             }
             unauthorized_response(&e.to_string())
         }
+    }
+}
+
+#[cfg(feature = "rbac")]
+fn build_http_authorization_request<B>(request: &Request<B>, claims: &AgentClaims) -> AuthorizationRequest {
+    let route = request
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map(axum::extract::MatchedPath::as_str)
+        .unwrap_or_else(|| request.uri().path());
+    let action = request.method().as_str().to_ascii_lowercase();
+
+    AuthorizationRequest {
+        principal: claims.clone(),
+        action,
+        resource: route.to_string(),
+        resource_id: Some(route.to_string()),
+        context: [
+            ("scope".to_string(), route.to_string()),
+            ("http_method".to_string(), request.method().as_str().to_string()),
+            ("transport".to_string(), "http".to_string()),
+        ]
+        .into_iter()
+        .collect(),
     }
 }
 
@@ -148,6 +200,12 @@ fn extract_bearer_token<B>(request: &Request<B>) -> Option<String> {
 fn unauthorized_response(message: &str) -> Response {
     let body = serde_json::json!({ "error": message });
     (StatusCode::UNAUTHORIZED, axum::Json(body)).into_response()
+}
+
+/// Build a 403 Forbidden JSON response.
+fn forbidden_response(message: &str) -> Response {
+    let body = serde_json::json!({ "error": message });
+    (StatusCode::FORBIDDEN, axum::Json(body)).into_response()
 }
 
 /// Build a 429 Too Many Requests JSON response.

--- a/crates/mister-smith-security/src/middleware/tonic_mw.rs
+++ b/crates/mister-smith-security/src/middleware/tonic_mw.rs
@@ -8,12 +8,15 @@ use std::sync::Arc;
 use tonic::{Request, Status};
 
 use crate::middleware::SecurityLayer;
+#[cfg(feature = "rbac")]
+use crate::rbac::AuthorizationRequest;
 
 /// Create a Tonic interceptor closure that validates JWT tokens.
 ///
 /// When security is disabled, all requests pass through unchanged.
 /// When enabled, extracts the token from `authorization` metadata,
-/// validates it, and inserts `AgentClaims` into request extensions.
+/// validates it, evaluates RBAC policy (when enabled), and inserts
+/// `AgentClaims` into request extensions.
 ///
 /// # Usage
 ///
@@ -66,6 +69,31 @@ pub fn grpc_auth_interceptor(
                         std::collections::HashMap::new(),
                     );
                 }
+                #[cfg(feature = "rbac")]
+                {
+                    let authz_request = build_grpc_authorization_request(&request, &claims);
+                    let decision = security.policy.evaluate(&authz_request);
+
+                    #[cfg(feature = "audit")]
+                    {
+                        use crate::audit::events::AuditOutcome;
+                        security.audit.record_authz(
+                            &claims.sub,
+                            &authz_request.action,
+                            &authz_request.resource,
+                            if decision.allowed {
+                                AuditOutcome::Success
+                            } else {
+                                AuditOutcome::Failure
+                            },
+                        );
+                    }
+
+                    if !decision.allowed {
+                        return Err(Status::permission_denied("forbidden"));
+                    }
+                }
+
                 request.extensions_mut().insert(claims);
                 Ok(request)
             }
@@ -84,5 +112,30 @@ pub fn grpc_auth_interceptor(
                 Err(Status::unauthenticated(e.to_string()))
             }
         }
+    }
+}
+
+#[cfg(feature = "rbac")]
+fn build_grpc_authorization_request(
+    request: &Request<()>,
+    claims: &crate::jwt::AgentClaims,
+) -> AuthorizationRequest {
+    let grpc_method = request.extensions().get::<tonic::GrpcMethod<'static>>();
+    let service = grpc_method.map(|m| m.service()).unwrap_or("unknown");
+    let method = grpc_method.map(|m| m.method()).unwrap_or("unknown");
+    let path = format!("/{service}/{method}");
+
+    AuthorizationRequest {
+        principal: claims.clone(),
+        action: "grpc_call".to_string(),
+        resource: path.clone(),
+        resource_id: Some(path.clone()),
+        context: [
+            ("scope".to_string(), path.clone()),
+            ("grpc_method".to_string(), path),
+            ("transport".to_string(), "grpc".to_string()),
+        ]
+        .into_iter()
+        .collect(),
     }
 }

--- a/crates/mister-smith-security/tests/middleware_tests.rs
+++ b/crates/mister-smith-security/tests/middleware_tests.rs
@@ -41,15 +41,20 @@ fn test_security_layer(enabled: bool) -> Arc<SecurityLayer> {
     )
 }
 
-fn test_token(security: &SecurityLayer) -> String {
+fn test_token_with_permissions(security: &SecurityLayer, permissions: Vec<String>) -> String {
     let claims = AgentClaims {
         sub: "test-agent".to_string(),
         agent_id: "test-agent".to_string(),
         agent_type: "worker".to_string(),
+        permissions,
         ..Default::default()
     };
     let pair = security.jwt.generate_token_pair(&claims).unwrap();
     pair.access_token
+}
+
+fn test_token(security: &SecurityLayer) -> String {
+    test_token_with_permissions(security, Vec::new())
 }
 
 async fn test_handler() -> impl IntoResponse {
@@ -70,7 +75,7 @@ fn test_app(security: Arc<SecurityLayer>) -> Router {
 #[tokio::test]
 async fn valid_bearer_token_passes() {
     let security = test_security_layer(true);
-    let token = test_token(&security);
+    let token = test_token_with_permissions(&security, vec!["get:/protected:/protected".to_string()]);
     let app = test_app(security);
 
     let request = Request::builder()
@@ -162,7 +167,7 @@ async fn rate_limiter_returns_429() {
         )
         .unwrap(),
     );
-    let token = test_token(&security);
+    let token = test_token_with_permissions(&security, vec!["get:/protected:/protected".to_string()]);
 
     // The SecurityLayer creates a rate limiter with 100 requests/60s.
     // Let's test the rate limiter directly instead.
@@ -195,7 +200,7 @@ async fn authenticated_agent_extractor_works() {
     use mister_smith_security::middleware::axum_mw::AuthenticatedAgent;
 
     let security = test_security_layer(true);
-    let token = test_token(&security);
+    let token = test_token_with_permissions(&security, vec!["get:/me:/me".to_string()]);
 
     async fn handler(AuthenticatedAgent(claims): AuthenticatedAgent) -> impl IntoResponse {
         format!("Hello, {}", claims.agent_id)
@@ -258,4 +263,136 @@ async fn revoked_token_returns_401() {
 
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+
+// -- Authorization failures return 403 -------------------------------------
+
+#[tokio::test]
+async fn authenticated_but_unauthorized_http_request_returns_403() {
+    let security = test_security_layer(true);
+    let token = test_token(&security);
+    let app = test_app(security);
+
+    let request = Request::builder()
+        .uri("/protected")
+        .method("GET")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn authorized_http_request_succeeds() {
+    let security = test_security_layer(true);
+    let token = test_token_with_permissions(
+        &security,
+        vec!["get:/protected:/protected".to_string()],
+    );
+    let app = test_app(security);
+
+    let request = Request::builder()
+        .uri("/protected")
+        .method("GET")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[test]
+fn authenticated_but_unauthorized_grpc_request_returns_permission_denied() {
+    let security = test_security_layer(true);
+    let token = test_token(&security);
+    let interceptor = mister_smith_security::middleware::tonic_mw::grpc_auth_interceptor(security);
+
+    let mut request = tonic::Request::new(());
+    request
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    request
+        .extensions_mut()
+        .insert(tonic::GrpcMethod::new("mistersmith.SecurityService", "Check"));
+
+    let result = interceptor(request);
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert_eq!(err.code(), tonic::Code::PermissionDenied);
+}
+
+#[test]
+fn authorized_grpc_request_succeeds() {
+    let security = test_security_layer(true);
+    let token = test_token_with_permissions(
+        &security,
+        vec!["grpc_call:/mistersmith.SecurityService/Check:/mistersmith.SecurityService/Check"
+            .to_string()],
+    );
+    let interceptor =
+        mister_smith_security::middleware::tonic_mw::grpc_auth_interceptor(security.clone());
+
+    let mut request = tonic::Request::new(());
+    request
+        .metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+    request
+        .extensions_mut()
+        .insert(tonic::GrpcMethod::new("mistersmith.SecurityService", "Check"));
+
+    let result = interceptor(request);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn audit_log_contains_authz_events_for_allow_and_deny() {
+    use mister_smith_security::audit::events::{AuditEventType, AuditOutcome};
+
+    let security = test_security_layer(true);
+    let denied_token = test_token(&security);
+    let allowed_token = test_token_with_permissions(
+        &security,
+        vec!["get:/protected:/protected".to_string()],
+    );
+
+    let app = test_app(security.clone());
+
+    let denied_request = Request::builder()
+        .uri("/protected")
+        .method("GET")
+        .header("authorization", format!("Bearer {denied_token}"))
+        .body(Body::empty())
+        .unwrap();
+    let denied_response = app.clone().oneshot(denied_request).await.unwrap();
+    assert_eq!(denied_response.status(), StatusCode::FORBIDDEN);
+
+    let allowed_request = Request::builder()
+        .uri("/protected")
+        .method("GET")
+        .header("authorization", format!("Bearer {allowed_token}"))
+        .body(Body::empty())
+        .unwrap();
+    let allowed_response = app.oneshot(allowed_request).await.unwrap();
+    assert_eq!(allowed_response.status(), StatusCode::OK);
+
+    let events = security.audit.recent_events(32);
+    let authz_events: Vec<_> = events
+        .iter()
+        .filter(|event| event.event_type == AuditEventType::Authorization)
+        .collect();
+
+    assert!(
+        authz_events
+            .iter()
+            .any(|event| event.outcome == AuditOutcome::Failure)
+    );
+    assert!(
+        authz_events
+            .iter()
+            .any(|event| event.outcome == AuditOutcome::Success)
+    );
 }


### PR DESCRIPTION
### Motivation
- Enforce authorization after successful JWT validation so valid tokens are still subject to RBAC policy decisions.
- Provide a consistent mapping from transport metadata to `AuthorizationRequest` to enable coherent policy evaluation across HTTP and gRPC.
- Surface transport-appropriate authorization responses (HTTP 403, gRPC permission denied) and record authorization outcomes in the audit log.

### Description
- Axum middleware: build an `AuthorizationRequest` from the HTTP method and matched route (action = lowercase method, resource = route/path, scope in context), evaluate `security.policy.evaluate(...)`, call `audit.record_authz(...)` for allow/deny, return `403` JSON when denied, and only insert `AgentClaims` on allow. (file: `crates/mister-smith-security/src/middleware/axum_mw.rs`)
- Tonic interceptor: construct an `AuthorizationRequest` from the gRPC method extension (`tonic::GrpcMethod`) (action = `grpc_call`, resource = `/<service>/<method>`), evaluate `security.policy`, call `audit.record_authz(...)`, and return `Status::permission_denied("forbidden")` on denial. (file: `crates/mister-smith-security/src/middleware/tonic_mw.rs`)
- Tests: expanded `crates/mister-smith-security/tests/middleware_tests.rs` with cases for authenticated-but-unauthorized HTTP => 403, authenticated-but-unauthorized gRPC => permission denied, authorized HTTP/gRPC paths that succeed, and audit log assertions to ensure authz events are recorded.

### Testing
- Ran the middleware test suite: `cargo test -p mister-smith-security --test middleware_tests -- --nocapture`, and the tests completed successfully (all middleware tests passed).
- Verified the integrated unit/integration test run for the crate completed without failures for the modified tests (middleware-related tests exercised authorized/denied flows and audit recordings).
- Attempted to run `cargo fmt --all` but the `rustfmt` component is not installed in this environment, so formatting check was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a905f1a3348333891ae9d53fc8b55c)