### PR TITLE
fix(security): sanitize middleware auth error responses

### DIFF
--- a/crates/mister-smith-security/src/middleware/axum_mw.rs
+++ b/crates/mister-smith-security/src/middleware/axum_mw.rs
@@ -14,6 +14,7 @@ use crate::jwt::AgentClaims;
 use crate::middleware::SecurityLayer;
 #[cfg(feature = "rbac")]
 use crate::rbac::AuthorizationRequest;
+use mister_smith_core::SecurityError;
 
 /// Axum middleware that validates JWT Bearer tokens.
 ///
@@ -127,7 +128,7 @@ pub async fn auth_middleware(
                         .collect(),
                 );
             }
-            unauthorized_response(&e.to_string())
+            unauthorized_response(map_auth_error_message(&e))
         }
     }
 }
@@ -153,6 +154,14 @@ fn build_http_authorization_request<B>(request: &Request<B>, claims: &AgentClaim
         ]
         .into_iter()
         .collect(),
+    }
+}
+
+fn map_auth_error_message(error: &SecurityError) -> &'static str {
+    match error {
+        SecurityError::TokenExpired => "token expired",
+        SecurityError::TokenRevoked => "token revoked",
+        _ => "unauthorized",
     }
 }
 

--- a/crates/mister-smith-security/src/middleware/tonic_mw.rs
+++ b/crates/mister-smith-security/src/middleware/tonic_mw.rs
@@ -10,6 +10,7 @@ use tonic::{Request, Status};
 use crate::middleware::SecurityLayer;
 #[cfg(feature = "rbac")]
 use crate::rbac::AuthorizationRequest;
+use mister_smith_core::SecurityError;
 
 /// Create a Tonic interceptor closure that validates JWT tokens.
 ///
@@ -49,9 +50,12 @@ pub fn grpc_auth_interceptor(
                     security.audit.record_auth(
                         "unknown",
                         AuditOutcome::Failure,
-                        [("reason".to_string(), "missing_authorization_metadata".to_string())]
-                            .into_iter()
-                            .collect(),
+                        [(
+                            "reason".to_string(),
+                            "missing_authorization_metadata".to_string(),
+                        )]
+                        .into_iter()
+                        .collect(),
                     );
                 }
                 return Err(Status::unauthenticated("missing authorization metadata"));
@@ -109,7 +113,7 @@ pub fn grpc_auth_interceptor(
                             .collect(),
                     );
                 }
-                Err(Status::unauthenticated(e.to_string()))
+                Err(Status::unauthenticated(map_auth_error_message(&e)))
             }
         }
     }
@@ -137,5 +141,13 @@ fn build_grpc_authorization_request(
         ]
         .into_iter()
         .collect(),
+    }
+}
+
+fn map_auth_error_message(error: &SecurityError) -> &'static str {
+    match error {
+        SecurityError::TokenExpired => "token expired",
+        SecurityError::TokenRevoked => "token revoked",
+        _ => "unauthorized",
     }
 }

--- a/crates/mister-smith-security/tests/middleware_tests.rs
+++ b/crates/mister-smith-security/tests/middleware_tests.rs
@@ -9,6 +9,8 @@ use axum::middleware as axum_mw;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
+use tonic::metadata::MetadataValue;
+use tonic::{Code, Request as GrpcRequest};
 use tower::ServiceExt;
 
 use mister_smith_security::config::{AuditConfig, JwtConfig, KeySource, RbacConfig};
@@ -68,6 +70,20 @@ fn test_app(security: Arc<SecurityLayer>) -> Router {
             security,
             mister_smith_security::middleware::axum_mw::auth_middleware,
         ))
+}
+
+fn latest_auth_failure_reason(security: &SecurityLayer) -> String {
+    security
+        .audit
+        .recent_events(20)
+        .into_iter()
+        .rev()
+        .find(|event| {
+            event.event_type == mister_smith_security::audit::AuditEventType::Authentication
+                && event.outcome == mister_smith_security::audit::AuditOutcome::Failure
+        })
+        .and_then(|event| event.details.get("reason").cloned())
+        .expect("expected auth failure audit reason")
 }
 
 // -- Valid Bearer token passes (US3-AS1) -----------------------------------
@@ -265,7 +281,6 @@ async fn revoked_token_returns_401() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
-
 // -- Authorization failures return 403 -------------------------------------
 
 #[tokio::test]
@@ -395,4 +410,80 @@ async fn audit_log_contains_authz_events_for_allow_and_deny() {
             .iter()
             .any(|event| event.outcome == AuditOutcome::Success)
     );
+}
+
+// -- Error response sanitization ------------------------------------------
+
+#[tokio::test]
+async fn invalid_token_response_is_sanitized_and_audit_keeps_details() {
+    let security = test_security_layer(true);
+    let app = test_app(security.clone());
+
+    let request = Request::builder()
+        .uri("/protected")
+        .header("authorization", "Bearer invalid.token.here")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "unauthorized");
+
+    let audit_reason = latest_auth_failure_reason(&security);
+    assert!(audit_reason.contains("Invalid token:"));
+    assert_ne!(audit_reason, "unauthorized");
+}
+
+#[tokio::test]
+async fn revoked_token_response_is_sanitized_and_audit_keeps_details() {
+    let security = test_security_layer(true);
+    let token = test_token(&security);
+
+    let claims = security.jwt.validate_token(&token).unwrap();
+    security.jwt.revoke_token(&claims.jti);
+
+    let app = test_app(security.clone());
+    let request = Request::builder()
+        .uri("/protected")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(response.into_body(), 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "token revoked");
+
+    let audit_reason = latest_auth_failure_reason(&security);
+    assert_eq!(audit_reason, "Token revoked");
+}
+
+#[test]
+fn tonic_invalid_token_is_sanitized_and_audit_keeps_details() {
+    let security = test_security_layer(true);
+    let interceptor =
+        mister_smith_security::middleware::tonic_mw::grpc_auth_interceptor(security.clone());
+
+    let mut request = GrpcRequest::new(());
+    request.metadata_mut().insert(
+        "authorization",
+        MetadataValue::from_static("Bearer invalid.token.here"),
+    );
+
+    let error = interceptor(request).expect_err("expected unauthenticated error");
+    assert_eq!(error.code(), Code::Unauthenticated);
+    assert_eq!(error.message(), "unauthorized");
+
+    let audit_reason = latest_auth_failure_reason(&security);
+    assert!(audit_reason.contains("Invalid token:"));
+    assert_ne!(audit_reason, "unauthorized");
 }


### PR DESCRIPTION
### Motivation
- Prevent leaking parser/crypto internals in client-facing auth errors by replacing raw `e.to_string()` responses with a constrained set of messages.
- Keep full diagnostic detail available to operators via the audit log so failures remain debuggable.

### Description
- Replaced direct `e.to_string()` usages in HTTP middleware with `map_auth_error_message` mapping to `unauthorized`, `token expired`, or `token revoked` in `crates/mister-smith-security/src/middleware/axum_mw.rs`.
- Applied the same constrained mapping in the Tonic gRPC interceptor in `crates/mister-smith-security/src/middleware/tonic_mw.rs`.
- Continued recording full `e.to_string()` details into `AuditLogger` events so audit trails retain complete failure reasons.
- Added integration tests in `crates/mister-smith-security/tests/middleware_tests.rs` asserting sanitized client responses and detailed audit entries.

### Testing
- Ran `cargo test -p mister-smith-security --test middleware_tests` and all middleware tests passed (`13 passed`).
- Test suite verifies HTTP `401` and gRPC `Unauthenticated` responses are sanitized while `AuditLogger` events retain detailed `reason` strings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90695391c8333b561523ed5d57545)