### PR TITLE
fix(llm): reconcile budget reservations on all completion paths

### DIFF
--- a/crates/mister-smith-llm/src/budget.rs
+++ b/crates/mister-smith-llm/src/budget.rs
@@ -127,6 +127,8 @@ pub struct BudgetEnforcer {
     store: Box<dyn BudgetStore>,
 }
 
+const CAS_RETRY_LIMIT: usize = 3;
+
 impl BudgetEnforcer {
     pub fn new(store: Box<dyn BudgetStore>) -> Self {
         Self { store }
@@ -179,21 +181,40 @@ impl BudgetEnforcer {
         reservation: &BudgetReservation,
         actual_tokens: u64,
     ) -> Result<(), LlmError> {
-        let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
-            LlmError::InvalidRequest(format!(
-                "Budget key '{}' not found during reconciliation",
-                reservation.budget_key
-            ))
-        })?;
-
         let adjustment = actual_tokens as i64 - reservation.estimated_tokens as i64;
-        let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
 
-        let mut updated = node.clone();
-        updated.used_tokens = new_used;
+        for attempt in 0..=CAS_RETRY_LIMIT {
+            let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
+                LlmError::InvalidRequest(format!(
+                    "Budget key '{}' not found during reconciliation",
+                    reservation.budget_key
+                ))
+            })?;
 
-        self.store.cas_update(&updated, node.revision).await?;
-        Ok(())
+            let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
+            let mut updated = node.clone();
+            updated.used_tokens = new_used;
+
+            match self.store.cas_update(&updated, node.revision).await {
+                Ok(_) => return Ok(()),
+                Err(err)
+                    if attempt < CAS_RETRY_LIMIT
+                        && Self::is_cas_conflict(&err) =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(LlmError::InvalidRequest(format!(
+            "Failed to reconcile budget key '{}' due to repeated CAS conflicts",
+            reservation.budget_key
+        )))
+    }
+
+    fn is_cas_conflict(error: &LlmError) -> bool {
+        matches!(error, LlmError::InvalidRequest(message) if message.contains("CAS conflict"))
     }
 
     /// Get the current budget state for a key.

--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -264,7 +264,17 @@ impl ModelRouter {
                 None
             };
 
-        let idx = self.select_provider(None).await?;
+        let idx = match self.select_provider(None).await {
+            Ok(idx) => idx,
+            Err(err) => {
+                if let Some(reservation) = &reservation {
+                    if let Some(enforcer) = &self.budget_enforcer {
+                        enforcer.reconcile(reservation, 0).await?;
+                    }
+                }
+                return Err(err);
+            }
+        };
         let providers = self.providers.read().await;
         let entry = &providers[idx];
 
@@ -292,9 +302,9 @@ impl ModelRouter {
                 // Reconcile budget
                 if let Some(reservation) = &reservation {
                     if let Some(enforcer) = &self.budget_enforcer {
-                        let _ = enforcer
+                        enforcer
                             .reconcile(reservation, response.usage.total_tokens)
-                            .await;
+                            .await?;
                     }
                 }
 
@@ -307,6 +317,14 @@ impl ModelRouter {
                 };
                 let mut providers = self.providers.write().await;
                 providers[idx].circuit_breaker.record_failure(retry_after);
+                drop(providers);
+
+                if let Some(reservation) = &reservation {
+                    if let Some(enforcer) = &self.budget_enforcer {
+                        enforcer.reconcile(reservation, 0).await?;
+                    }
+                }
+
                 Err(err)
             }
         }

--- a/crates/mister-smith-llm/tests/budget_tests.rs
+++ b/crates/mister-smith-llm/tests/budget_tests.rs
@@ -1,6 +1,74 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use mister_smith_core::LlmError;
 use mister_smith_llm::budget::{
-    BudgetEnforcer, BudgetNode, BudgetPolicy, InMemoryBudgetStore,
+    BudgetEnforcer, BudgetNode, BudgetPolicy, BudgetReservation, BudgetStore,
+    InMemoryBudgetStore,
 };
+
+
+struct FlakyCasStore {
+    node: Mutex<BudgetNode>,
+    conflicts_remaining: AtomicUsize,
+}
+
+impl FlakyCasStore {
+    fn new(node: BudgetNode, conflicts: usize) -> Self {
+        Self {
+            node: Mutex::new(node),
+            conflicts_remaining: AtomicUsize::new(conflicts),
+        }
+    }
+}
+
+#[async_trait]
+impl BudgetStore for FlakyCasStore {
+    async fn get(&self, key: &str) -> Result<Option<BudgetNode>, LlmError> {
+        let node = self.node.lock().unwrap();
+        if node.key == key {
+            Ok(Some(node.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn cas_update(
+        &self,
+        node: &BudgetNode,
+        expected_revision: u64,
+    ) -> Result<u64, LlmError> {
+        let mut current = self.node.lock().unwrap();
+
+        if current.revision != expected_revision {
+            return Err(LlmError::InvalidRequest(format!(
+                "CAS conflict on budget key '{}': expected revision {}, actual {}",
+                node.key, expected_revision, current.revision
+            )));
+        }
+
+        if self
+            .conflicts_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                if remaining > 0 { Some(remaining - 1) } else { None }
+            })
+            .is_ok()
+        {
+            current.revision += 1;
+            return Err(LlmError::InvalidRequest(format!(
+                "CAS conflict on budget key '{}': expected revision {}, actual {}",
+                node.key, expected_revision, current.revision
+            )));
+        }
+
+        let new_revision = expected_revision + 1;
+        let mut updated = node.clone();
+        updated.revision = new_revision;
+        *current = updated;
+        Ok(new_revision)
+    }
+}
 
 fn test_store() -> InMemoryBudgetStore {
     let store = InMemoryBudgetStore::new();
@@ -235,4 +303,56 @@ fn budget_policy_serde_round_trip() {
         let deserialized: BudgetPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(*policy, deserialized);
     }
+}
+
+#[tokio::test]
+async fn reconcile_retries_on_cas_conflict_and_succeeds() {
+    let store = FlakyCasStore::new(
+        BudgetNode {
+            key: "budget/retry".to_string(),
+            limit_tokens: 10_000,
+            used_tokens: 500,
+            period: "test".to_string(),
+            policy: BudgetPolicy::HardCap,
+            revision: 1,
+        },
+        2,
+    );
+    let enforcer = BudgetEnforcer::new(Box::new(store));
+
+    let reservation = BudgetReservation {
+        budget_key: "budget/retry".to_string(),
+        estimated_tokens: 500,
+        revision: 2,
+    };
+
+    enforcer.reconcile(&reservation, 200).await.unwrap();
+
+    let node = enforcer.get_budget("budget/retry").await.unwrap().unwrap();
+    assert_eq!(node.used_tokens, 200);
+}
+
+#[tokio::test]
+async fn reconcile_returns_error_after_retry_limit_exhausted() {
+    let store = FlakyCasStore::new(
+        BudgetNode {
+            key: "budget/retry-fail".to_string(),
+            limit_tokens: 10_000,
+            used_tokens: 500,
+            period: "test".to_string(),
+            policy: BudgetPolicy::HardCap,
+            revision: 1,
+        },
+        10,
+    );
+    let enforcer = BudgetEnforcer::new(Box::new(store));
+
+    let reservation = BudgetReservation {
+        budget_key: "budget/retry-fail".to_string(),
+        estimated_tokens: 500,
+        revision: 2,
+    };
+
+    let err = enforcer.reconcile(&reservation, 0).await.unwrap_err();
+    assert!(matches!(err, LlmError::InvalidRequest(message) if message.contains("CAS conflict")));
 }

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream;
 use std::time::Instant;
 
 use mister_smith_llm::{
+    budget::{BudgetNode, BudgetPolicy, BudgetStore, InMemoryBudgetStore},
     CascadePolicy, CascadeTier, CircuitBreakerConfig, CircuitState, CompletionRequest,
     ModelRouter, MockProvider, ModelProvider, ProviderConfig, ProviderKind, RoutingPolicy,
 };
@@ -340,4 +344,125 @@ mod cascade {
         // Short text (< 10 chars) should reduce confidence
         assert!(signal.score < 1.0);
     }
+}
+
+
+#[derive(Clone)]
+struct SharedBudgetStore(Arc<InMemoryBudgetStore>);
+
+#[async_trait]
+impl BudgetStore for SharedBudgetStore {
+    async fn get(&self, key: &str) -> Result<Option<BudgetNode>, mister_smith_core::LlmError> {
+        self.0.get(key).await
+    }
+
+    async fn cas_update(
+        &self,
+        node: &BudgetNode,
+        expected_revision: u64,
+    ) -> Result<u64, mister_smith_core::LlmError> {
+        self.0.cas_update(node, expected_revision).await
+    }
+}
+
+struct FailingProvider;
+
+#[async_trait]
+impl ModelProvider for FailingProvider {
+    async fn complete(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<mister_smith_llm::CompletionResponse, mister_smith_core::LlmError> {
+        Err(mister_smith_core::LlmError::Network(
+            "simulated provider failure".to_string(),
+        ))
+    }
+
+    fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+        Box::pin(stream::empty())
+    }
+
+    async fn embed(
+        &self,
+        _input: Vec<String>,
+    ) -> Result<mister_smith_llm::EmbeddingResponse, mister_smith_core::LlmError> {
+        Ok(mister_smith_llm::EmbeddingResponse {
+            embeddings: Vec::new(),
+            model_id: "failing-model".to_string(),
+            usage: mister_smith_llm::Usage::new(0, 0),
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "failing-model"
+    }
+
+    fn capabilities(&self) -> mister_smith_llm::ModelCapabilities {
+        mister_smith_llm::ModelCapabilities::all()
+    }
+}
+
+#[tokio::test]
+async fn provider_failure_after_reserve_reverts_budget_usage() {
+    let store = Arc::new(InMemoryBudgetStore::new());
+    store.insert(BudgetNode {
+        key: "budget/router-failure".to_string(),
+        limit_tokens: 10_000,
+        used_tokens: 0,
+        period: "test".to_string(),
+        policy: BudgetPolicy::HardCap,
+        revision: 1,
+    });
+
+    let enforcer = mister_smith_llm::BudgetEnforcer::new(Box::new(SharedBudgetStore(store.clone())));
+    let router =
+        ModelRouter::new(RoutingPolicy::RoundRobin).with_budget(enforcer, "budget/router-failure");
+
+    let provider: Arc<dyn ModelProvider> = Arc::new(FailingProvider);
+    router
+        .add_provider(
+            mock_config("failing-model"),
+            provider,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let result = router.route_completion(mock_request()).await;
+    assert!(matches!(result, Err(mister_smith_core::LlmError::Network(_))));
+
+    let budget = store.get("budget/router-failure").await.unwrap().unwrap();
+    assert_eq!(budget.used_tokens, 0);
+}
+
+#[tokio::test]
+async fn failed_requests_have_no_net_token_leak() {
+    let store = Arc::new(InMemoryBudgetStore::new());
+    store.insert(BudgetNode {
+        key: "budget/router-no-leak".to_string(),
+        limit_tokens: 10_000,
+        used_tokens: 0,
+        period: "test".to_string(),
+        policy: BudgetPolicy::HardCap,
+        revision: 1,
+    });
+
+    let enforcer = mister_smith_llm::BudgetEnforcer::new(Box::new(SharedBudgetStore(store.clone())));
+    let router =
+        ModelRouter::new(RoutingPolicy::RoundRobin).with_budget(enforcer, "budget/router-no-leak");
+
+    let provider: Arc<dyn ModelProvider> = Arc::new(FailingProvider);
+    router
+        .add_provider(
+            mock_config("failing-model"),
+            provider,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    for _ in 0..3 {
+        let _ = router.route_completion(mock_request()).await;
+    }
+
+    let budget = store.get("budget/router-no-leak").await.unwrap().unwrap();
+    assert_eq!(budget.used_tokens, 0);
 }


### PR DESCRIPTION
### Motivation
- Prevent token-budget drift by ensuring every successful `reserve()` is reconciled on both success and failure paths. 
- Make reconciliation robust to transient CAS races so short-lived conflicts do not permanently leak or double-count tokens.

### Description
- Implement bounded CAS-retry in `BudgetEnforcer::reconcile()` (constant `CAS_RETRY_LIMIT = 3`) and re-read state on each attempt, retrying only on CAS-conflict errors and failing fast on other errors, in `crates/mister-smith-llm/src/budget.rs`.
- Update `ModelRouter::route_completion()` to always reconcile a prior reservation: reconcile with actual usage on success and propagate reconciliation errors, and reconcile with `actual_tokens = 0` when provider selection or provider request fails, in `crates/mister-smith-llm/src/router.rs`.
- Add tests covering CAS-conflict recovery and retry-limit exhaustion in `crates/mister-smith-llm/tests/budget_tests.rs` (adds `FlakyCasStore`), and add router-level tests for provider failure after reserve and repeated failed requests not leaking tokens in `crates/mister-smith-llm/tests/router_tests.rs` (adds `SharedBudgetStore` and `FailingProvider`).

### Testing
- Ran `cargo test -p mister-smith-llm --test budget_tests --test router_tests` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf234b6c48333b93c6af7e291860c)