### PR TITLE
fix(llm): enforce and reconcile budget for cascade routing

### DIFF
--- a/crates/mister-smith-llm/src/budget.rs
+++ b/crates/mister-smith-llm/src/budget.rs
@@ -128,6 +128,8 @@ pub struct BudgetEnforcer {
 }
 
 impl BudgetEnforcer {
+    const RECONCILE_MAX_RETRIES: usize = 3;
+
     pub fn new(store: Box<dyn BudgetStore>) -> Self {
         Self { store }
     }
@@ -179,21 +181,36 @@ impl BudgetEnforcer {
         reservation: &BudgetReservation,
         actual_tokens: u64,
     ) -> Result<(), LlmError> {
-        let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
-            LlmError::InvalidRequest(format!(
-                "Budget key '{}' not found during reconciliation",
-                reservation.budget_key
-            ))
-        })?;
+        for attempt in 0..=Self::RECONCILE_MAX_RETRIES {
+            let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
+                LlmError::InvalidRequest(format!(
+                    "Budget key '{}' not found during reconciliation",
+                    reservation.budget_key
+                ))
+            })?;
 
-        let adjustment = actual_tokens as i64 - reservation.estimated_tokens as i64;
-        let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
+            let adjustment = actual_tokens as i64 - reservation.estimated_tokens as i64;
+            let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
 
-        let mut updated = node.clone();
-        updated.used_tokens = new_used;
+            let mut updated = node.clone();
+            updated.used_tokens = new_used;
 
-        self.store.cas_update(&updated, node.revision).await?;
-        Ok(())
+            match self.store.cas_update(&updated, node.revision).await {
+                Ok(_) => return Ok(()),
+                Err(err)
+                    if Self::is_cas_conflict(&err) && attempt < Self::RECONCILE_MAX_RETRIES =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        unreachable!("reconcile loop exits via return")
+    }
+
+    fn is_cas_conflict(err: &LlmError) -> bool {
+        matches!(err, LlmError::InvalidRequest(message) if message.contains("CAS conflict"))
     }
 
     /// Get the current budget state for a key.
@@ -217,6 +234,7 @@ impl BudgetEnforcer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn test_store() -> InMemoryBudgetStore {
         let store = InMemoryBudgetStore::new();
@@ -297,6 +315,67 @@ mod tests {
         // SoftCap allows the request even though it would exceed
         let result = enforcer.reserve("budget/soft", 500).await;
         assert!(result.is_ok());
+    }
+
+    struct ConflictOnceStore {
+        inner: InMemoryBudgetStore,
+        cas_attempts: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl BudgetStore for ConflictOnceStore {
+        async fn get(&self, key: &str) -> Result<Option<BudgetNode>, LlmError> {
+            self.inner.get(key).await
+        }
+
+        async fn cas_update(
+            &self,
+            node: &BudgetNode,
+            expected_revision: u64,
+        ) -> Result<u64, LlmError> {
+            let attempt = self.cas_attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt == 1 {
+                // First reconcile CAS update fails once to simulate contention.
+                return Err(LlmError::InvalidRequest(
+                    "CAS conflict on budget key 'budget/org1/team-alpha': expected revision 2, actual 3"
+                        .to_string(),
+                ));
+            }
+
+            self.inner.cas_update(node, expected_revision).await
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_retries_transient_cas_conflicts() {
+        let store = InMemoryBudgetStore::new();
+        store.insert(BudgetNode {
+            key: "budget/org1/team-alpha".to_string(),
+            limit_tokens: 10000,
+            used_tokens: 0,
+            period: "2026-03-daily".to_string(),
+            policy: BudgetPolicy::HardCap,
+            revision: 1,
+        });
+
+        let store = ConflictOnceStore {
+            inner: store,
+            cas_attempts: AtomicUsize::new(0),
+        };
+        let enforcer = BudgetEnforcer::new(Box::new(store));
+
+        let reservation = enforcer
+            .reserve("budget/org1/team-alpha", 500)
+            .await
+            .unwrap();
+        enforcer.reconcile(&reservation, 300).await.unwrap();
+
+        let node = enforcer
+            .get_budget("budget/org1/team-alpha")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(node.used_tokens, 300);
     }
 
     #[test]

--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -132,6 +132,17 @@ pub struct ModelRouter {
     round_robin_counter: std::sync::atomic::AtomicUsize,
 }
 
+struct BudgetReservationContext<'a> {
+    enforcer: &'a BudgetEnforcer,
+    reservation: crate::budget::BudgetReservation,
+}
+
+impl<'a> BudgetReservationContext<'a> {
+    async fn reconcile(self, actual_tokens: u64) {
+        let _ = self.enforcer.reconcile(&self.reservation, actual_tokens).await;
+    }
+}
+
 impl ModelRouter {
     /// Create a new router with the given policy.
     pub fn new(routing_policy: RoutingPolicy) -> Self {
@@ -248,21 +259,18 @@ impl ModelRouter {
         &self,
         request: CompletionRequest,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
+        let estimated = Self::estimate_tokens(&request);
+        let reservation = self.reserve_budget(estimated).await?;
+
         // Delegate to cascade routing when policy is Cascade
         if let RoutingPolicy::Cascade(ref policy) = self.routing_policy {
             let policy = policy.clone();
-            return self.route_cascade(request, &policy).await;
+            let result = self.route_cascade(request, &policy, estimated).await;
+            if let (Ok((response, _)), Some(context)) = (&result, reservation) {
+                context.reconcile(response.usage.total_tokens).await;
+            }
+            return result;
         }
-
-        let estimated = Self::estimate_tokens(&request);
-
-        // Budget check
-        let reservation =
-            if let (Some(enforcer), Some(root)) = (&self.budget_enforcer, &self.budget_root) {
-                Some(enforcer.reserve(root, estimated).await?)
-            } else {
-                None
-            };
 
         let idx = self.select_provider(None).await?;
         let providers = self.providers.read().await;
@@ -290,12 +298,8 @@ impl ModelRouter {
                 drop(providers);
 
                 // Reconcile budget
-                if let Some(reservation) = &reservation {
-                    if let Some(enforcer) = &self.budget_enforcer {
-                        let _ = enforcer
-                            .reconcile(reservation, response.usage.total_tokens)
-                            .await;
-                    }
+                if let Some(context) = reservation {
+                    context.reconcile(response.usage.total_tokens).await;
                 }
 
                 Ok((response, decision))
@@ -321,6 +325,7 @@ impl ModelRouter {
         &self,
         request: CompletionRequest,
         policy: &CascadePolicy,
+        estimated_tokens: u64,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
         let provider_count = self.providers.read().await.len();
         let max_attempts = provider_count.min(policy.max_escalations as usize + 1);
@@ -384,7 +389,7 @@ impl ModelRouter {
                                 tier_label, confidence.score, policy.escalation_threshold
                             )
                         },
-                        estimated_cost_tokens: None,
+                        estimated_cost_tokens: Some(estimated_tokens),
                     };
 
                     if confidence.score >= policy.escalation_threshold || is_last_tier {
@@ -414,6 +419,22 @@ impl ModelRouter {
     /// Get the number of registered providers.
     pub async fn provider_count(&self) -> usize {
         self.providers.read().await.len()
+    }
+
+    async fn reserve_budget(
+        &self,
+        estimated_tokens: u64,
+    ) -> Result<Option<BudgetReservationContext<'_>>, LlmError> {
+        match (&self.budget_enforcer, &self.budget_root) {
+            (Some(enforcer), Some(root)) => {
+                let reservation = enforcer.reserve(root, estimated_tokens).await?;
+                Ok(Some(BudgetReservationContext {
+                    enforcer,
+                    reservation,
+                }))
+            }
+            _ => Ok(None),
+        }
     }
 }
 

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use mister_smith_llm::{
+    budget::{BudgetEnforcer, BudgetNode, BudgetPolicy},
     CascadePolicy, CascadeTier, CircuitBreakerConfig, CircuitState, CompletionRequest,
     ModelRouter, MockProvider, ModelProvider, ProviderConfig, ProviderKind, RoutingPolicy,
 };
@@ -222,6 +223,67 @@ mod circuit_breaker {
 // Cascade routing tests (T051-T053)
 mod cascade {
     use super::*;
+    use async_trait::async_trait;
+    use mister_smith_core::LlmError;
+    use mister_smith_llm::budget::BudgetStore;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct SharedBudgetStore {
+        nodes: Arc<Mutex<HashMap<String, BudgetNode>>>,
+    }
+
+    impl SharedBudgetStore {
+        fn with_budget() -> (Self, Arc<Mutex<HashMap<String, BudgetNode>>>) {
+            let nodes = Arc::new(Mutex::new(HashMap::new()));
+            nodes.lock().unwrap().insert(
+                "budget/test".to_string(),
+                BudgetNode {
+                    key: "budget/test".to_string(),
+                    limit_tokens: 50_000,
+                    used_tokens: 0,
+                    period: "test".to_string(),
+                    policy: BudgetPolicy::HardCap,
+                    revision: 1,
+                },
+            );
+
+            (
+                Self {
+                    nodes: nodes.clone(),
+                },
+                nodes,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl BudgetStore for SharedBudgetStore {
+        async fn get(&self, key: &str) -> Result<Option<BudgetNode>, LlmError> {
+            Ok(self.nodes.lock().unwrap().get(key).cloned())
+        }
+
+        async fn cas_update(
+            &self,
+            node: &BudgetNode,
+            expected_revision: u64,
+        ) -> Result<u64, LlmError> {
+            let mut nodes = self.nodes.lock().unwrap();
+            if let Some(existing) = nodes.get(&node.key) {
+                if existing.revision != expected_revision {
+                    return Err(LlmError::InvalidRequest(format!(
+                        "CAS conflict on budget key '{}': expected revision {}, actual {}",
+                        node.key, expected_revision, existing.revision
+                    )));
+                }
+            }
+
+            let mut updated = node.clone();
+            updated.revision = expected_revision + 1;
+            nodes.insert(node.key.clone(), updated);
+            Ok(expected_revision + 1)
+        }
+    }
 
     fn cascade_policy(threshold: f32, max_escalations: u32) -> CascadePolicy {
         CascadePolicy {
@@ -310,6 +372,71 @@ mod cascade {
 
         // max_escalations=0 means 1 attempt total, so it returns the first tier's response
         assert_eq!(decision.tier_label.as_deref(), Some("only-tier"));
+    }
+
+    #[tokio::test]
+    async fn cascade_reserves_and_reconciles_budget_on_accept() {
+        let policy = cascade_policy(0.3, 1);
+
+        let (store, nodes) = SharedBudgetStore::with_budget();
+
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_budget(BudgetEnforcer::new(Box::new(store)), "budget/test");
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let (response, _decision) = router.route_completion(mock_request()).await.unwrap();
+
+        let used_tokens = nodes
+            .lock()
+            .unwrap()
+            .get("budget/test")
+            .unwrap()
+            .used_tokens;
+
+        assert_eq!(used_tokens, response.usage.total_tokens);
+        assert!(response.usage.total_tokens < 1024);
+    }
+
+    #[tokio::test]
+    async fn cascade_reconciles_budget_when_escalating_to_second_tier() {
+        let policy = cascade_policy(1.1, 1);
+
+        let (store, nodes) = SharedBudgetStore::with_budget();
+        let enforcer = BudgetEnforcer::new(Box::new(store));
+
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_budget(enforcer, "budget/test");
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let (response, decision) = router.route_completion(mock_request()).await.unwrap();
+        assert_eq!(decision.tier_label.as_deref(), Some("llm-tier"));
+
+        let used_tokens = nodes
+            .lock()
+            .unwrap()
+            .get("budget/test")
+            .unwrap()
+            .used_tokens;
+        assert_eq!(used_tokens, response.usage.total_tokens);
+        assert_eq!(decision.estimated_cost_tokens, Some(1027));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Ensure budget accounting wraps both single-provider and cascade execution paths so reservations are never skipped for cascade flows.
- Make reconciliation resilient to transient CAS contention so accounting updates are not lost under concurrent updates.

### Description
- Move token estimation (`estimate_tokens`) and budget reservation to the top of `ModelRouter::route_completion` so a reservation is taken before branching on `RoutingPolicy` and is visible to both normal and cascade paths (`router.rs`).
- Pass the precomputed estimate into cascade routing and attach `estimated_cost_tokens` to cascade `RoutingDecision` so cost visibility is consistent across routes (`router.rs`).
- Introduce a `BudgetReservationContext` helper to hold reservation + enforcer and perform reconciliation after success for both normal and cascade responses (`router.rs`).
- Add bounded retry logic to `BudgetEnforcer::reconcile` to detect CAS conflicts and retry up to a small limit, plus a CAS-conflict detection helper (`budget.rs`).
- Add/extend tests: a transient CAS-conflict simulation for reconcile retries and cascade routing tests that use a shared in-memory budget store to assert reservation and reconciliation behavior (`tests/router_tests.rs`, `src/budget.rs` tests).

### Testing
- Ran `cargo test -p mister-smith-llm --test router_tests` and all router cascade tests passed (18 passed, 0 failed).
- Ran the specific budget reconcile test with `cargo test -p mister-smith-llm budget::tests::reconcile_retries_transient_cas_conflicts` which passed.
- Note: attempted `cargo fmt --all` in this environment reported `rustfmt` component not installed (formatting step not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf239969c8333952e2fd469347277)