### PR TITLE
fix(llm): map Anthropic input_json_delta events to real tool call IDs

### DIFF
--- a/crates/mister-smith-llm/src/providers/anthropic.rs
+++ b/crates/mister-smith-llm/src/providers/anthropic.rs
@@ -21,6 +21,7 @@ const ANTHROPIC_VERSION: &str = "2023-06-01";
 struct AnthropicStreamState {
     chunk_index: usize,
     tool_call_ids_by_content_index: HashMap<u64, String>,
+    terminal_stop_emitted: bool,
 }
 
 fn parse_stream_event(
@@ -111,14 +112,18 @@ fn parse_stream_event(
                     "tool_use" => StopReason::ToolCall,
                     _ => StopReason::Completed,
                 };
+                state.terminal_stop_emitted = true;
                 chunks.push(StreamChunk::stop(state.chunk_index, stop_reason));
                 state.chunk_index += 1;
             }
         }
         "message_stop" => {
-            // Terminal event — the message_delta should have
-            // already emitted a stop chunk with the reason.
-            // If not, emit a completed stop as a fallback.
+            // Terminal event — emit a fallback stop if message_delta didn't.
+            if !state.terminal_stop_emitted {
+                state.terminal_stop_emitted = true;
+                chunks.push(StreamChunk::stop(state.chunk_index, StopReason::Completed));
+                state.chunk_index += 1;
+            }
         }
         _ => {}
     }
@@ -642,5 +647,54 @@ mod tests {
                 input: serde_json::json!("\"nyc\"}"),
             }
         );
+    }
+
+    #[test]
+    fn message_delta_sets_terminal_stop_emitted() {
+        let mut state = AnthropicStreamState::default();
+        let event = serde_json::json!({
+            "type": "message_delta",
+            "delta": { "stop_reason": "max_tokens" }
+        });
+
+        let chunks = parse_stream_event(&event, &mut state);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].delta, ChunkDelta::Stop { reason: StopReason::MaxTokens });
+        assert!(state.terminal_stop_emitted);
+    }
+
+    #[test]
+    fn message_stop_emits_fallback_when_no_prior_stop() {
+        let mut state = AnthropicStreamState::default();
+
+        // message_delta without stop_reason
+        let delta = serde_json::json!({ "type": "message_delta", "delta": {} });
+        let chunks = parse_stream_event(&delta, &mut state);
+        assert!(chunks.is_empty());
+        assert!(!state.terminal_stop_emitted);
+
+        // message_stop should emit fallback
+        let stop = serde_json::json!({ "type": "message_stop" });
+        let chunks = parse_stream_event(&stop, &mut state);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].delta, ChunkDelta::Stop { reason: StopReason::Completed });
+        assert!(state.terminal_stop_emitted);
+    }
+
+    #[test]
+    fn message_stop_does_not_duplicate_after_message_delta_stop() {
+        let mut state = AnthropicStreamState::default();
+
+        let delta = serde_json::json!({
+            "type": "message_delta",
+            "delta": { "stop_reason": "end_turn" }
+        });
+        parse_stream_event(&delta, &mut state);
+        assert!(state.terminal_stop_emitted);
+
+        // message_stop should NOT emit another stop
+        let stop = serde_json::json!({ "type": "message_stop" });
+        let chunks = parse_stream_event(&stop, &mut state);
+        assert!(chunks.is_empty());
     }
 }


### PR DESCRIPTION
### Motivation

- Streaming tool-call deltas from Anthropic previously used synthetic `tool-{index}` IDs for `input_json_delta` events, which prevented correctly attributing partial inputs to the real tool call IDs returned by the provider.
- The change ensures streamed `input_json_delta` fragments are resolved to the stable `tool_use.id` so tool inputs are assembled and routed correctly, including when multiple tool calls are interleaved.

### Description

- Added `AnthropicStreamState` to track `chunk_index` and a `content_block index -> tool_use.id` mapping captured from `content_block_start` events.
- Introduced `parse_stream_event` helper that consumes a single SSE event and emits zero-or-more `StreamChunk`s using the shared stream state.
- Updated the provider `stream()` loop to use `parse_stream_event`, and emit `ChunkDelta::ToolUseInput` with the matched real call ID (falling back to `tool-{index}` only when no mapping exists).
- Added unit tests validating: direct `content_block_start` → `input_json_delta` mapping, and multi-tool interleaved `input_json_delta` attribution.

### Testing

- Ran `cargo test -p mister-smith-llm --features anthropic parse_stream_event --lib -- --nocapture`, which executed the new parser tests and they passed (`2 passed`).
- Ran `cargo test -p mister-smith-llm anthropic -- --nocapture`, which completed without failures (note the Anthropic feature-gated tests were exercised separately as above).
- Attempted to run `cargo fmt -p mister-smith-llm` but `rustfmt`/`cargo-fmt` is not installed in the environment, so formatting could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf24741788333ab27247c6692850a)