### PR TITLE
feat(llm): add routing_hint to CompletionRequest and honor hints in ModelRouter

### DIFF
--- a/crates/mister-smith-llm/src/lib.rs
+++ b/crates/mister-smith-llm/src/lib.rs
@@ -40,12 +40,11 @@ pub use provider::{CompletionStream, ModelProvider};
 ))]
 pub use providers::*;
 pub use router::{
-    CascadePolicy, CascadeTier, ConfidenceSignal, ModelRouter, RoutingDecision, RoutingHint,
-    RoutingPolicy,
+    CascadePolicy, CascadeTier, ConfidenceSignal, ModelRouter, RoutingDecision, RoutingPolicy,
 };
 pub use streaming::{ChunkDelta, StreamChunk};
 pub use tool_schema::{ToolCall, ToolDefinition, ToolResult};
 pub use types::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentBlock, EmbeddingResponse,
-    ModelCapabilities, StopReason, Usage,
+    ModelCapabilities, RoutingHint, StopReason, Usage,
 };

--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -11,6 +11,7 @@ use crate::health::{CircuitBreaker, CircuitBreakerConfig, HealthStatus};
 use crate::provider::{CompletionStream, ModelProvider};
 use crate::types::{
     ChatMessage, CompletionRequest, CompletionResponse, EmbeddingResponse, ModelCapabilities,
+    RoutingHint,
 };
 
 /// Routing policy for provider selection.
@@ -27,18 +28,6 @@ pub enum RoutingPolicy {
     CapabilityMatched,
     /// Multi-tier escalation (SLM-default, LLM-fallback).
     Cascade(CascadePolicy),
-}
-
-
-/// Caller-provided routing preferences.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct RoutingHint {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub preferred_tier: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_cost_tokens: Option<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_capabilities: Vec<String>,
 }
 
 /// Multi-tier routing configuration for SLM-default / LLM-fallback.
@@ -176,7 +165,11 @@ impl ModelRouter {
     }
 
     /// Select a healthy provider based on routing policy.
-    async fn select_provider(&self, _hint: Option<&RoutingHint>) -> Result<usize, LlmError> {
+    async fn select_provider(
+        &self,
+        hint: Option<&RoutingHint>,
+        estimated_tokens: u64,
+    ) -> Result<usize, LlmError> {
         let mut providers = self.providers.write().await;
 
         // First, transition any expired Open circuits to HalfOpen
@@ -199,23 +192,93 @@ impl ModelRouter {
             ));
         }
 
+        let filtered_indices: Vec<usize> = healthy_indices
+            .iter()
+            .copied()
+            .filter(|idx| {
+                let entry = &providers[*idx];
+                if let Some(hint) = hint {
+                    if hint.required_capabilities.iter().any(|cap| {
+                        !Self::provider_supports_capability(entry.provider.as_ref(), cap)
+                    }) {
+                        return false;
+                    }
+                    if let Some(max_cost_tokens) = hint.max_cost_tokens {
+                        if estimated_tokens > max_cost_tokens {
+                            return false;
+                        }
+                    }
+                }
+                true
+            })
+            .collect();
+
+        if filtered_indices.is_empty() {
+            return Err(LlmError::NoHealthyProvider(
+                "No healthy provider matched routing hint constraints".to_string(),
+            ));
+        }
+
         match &self.routing_policy {
             RoutingPolicy::RoundRobin => {
                 let idx = self
                     .round_robin_counter
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                Ok(healthy_indices[idx % healthy_indices.len()])
+                Ok(filtered_indices[idx % filtered_indices.len()])
             }
             RoutingPolicy::CostOptimized => {
                 // For now, prefer providers earlier in the list (assumed cheaper)
-                Ok(healthy_indices[0])
+                Ok(filtered_indices[0])
             }
-            RoutingPolicy::CapabilityMatched => Ok(healthy_indices[0]),
+            RoutingPolicy::CapabilityMatched => Ok(filtered_indices[0]),
             RoutingPolicy::Cascade(_) => {
                 // Cascade routing is handled separately in route_cascade
-                Ok(healthy_indices[0])
+                Ok(filtered_indices[0])
             }
         }
+    }
+
+    fn provider_supports_capability(provider: &dyn ModelProvider, capability: &str) -> bool {
+        let capabilities = provider.capabilities();
+        match capability {
+            "completion" => capabilities.completion,
+            "streaming" => capabilities.streaming,
+            "embeddings" => capabilities.embeddings,
+            "tool_calling" => capabilities.tool_calling,
+            _ => false,
+        }
+    }
+
+    fn provider_matches_hint(
+        provider: &dyn ModelProvider,
+        hint: Option<&RoutingHint>,
+        estimated_tokens: u64,
+    ) -> bool {
+        let Some(hint) = hint else {
+            return true;
+        };
+
+        if hint
+            .required_capabilities
+            .iter()
+            .any(|cap| !Self::provider_supports_capability(provider, cap))
+        {
+            return false;
+        }
+
+        if let Some(max_cost_tokens) = hint.max_cost_tokens {
+            if estimated_tokens > max_cost_tokens {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn provider_request(request: &CompletionRequest) -> CompletionRequest {
+        let mut provider_request = request.clone();
+        provider_request.routing_hint = None;
+        provider_request
     }
 
     /// Estimate token cost for a request.
@@ -264,7 +327,8 @@ impl ModelRouter {
                 None
             };
 
-        let idx = self.select_provider(None).await?;
+        let hint = request.routing_hint.as_ref();
+        let idx = self.select_provider(hint, estimated).await?;
         let providers = self.providers.read().await;
         let entry = &providers[idx];
 
@@ -277,7 +341,8 @@ impl ModelRouter {
         };
 
         let start = std::time::Instant::now();
-        let result = entry.provider.complete(request).await;
+        let provider_request = Self::provider_request(&request);
+        let result = entry.provider.complete(provider_request).await;
         let latency_ms = start.elapsed().as_millis() as u64;
 
         drop(providers);
@@ -322,19 +387,40 @@ impl ModelRouter {
         request: CompletionRequest,
         policy: &CascadePolicy,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
+        let estimated = Self::estimate_tokens(&request);
+        let hint = request.routing_hint.as_ref();
         let provider_count = self.providers.read().await.len();
-        let max_attempts = provider_count.min(policy.max_escalations as usize + 1);
 
-        for tier_idx in 0..max_attempts {
+        let mut attempt_indices: Vec<usize> = (0..provider_count).collect();
+        if let Some(preferred_tier) = hint.and_then(|h| h.preferred_tier.as_deref()) {
+            if let Some(preferred_idx) = policy
+                .tiers
+                .iter()
+                .position(|tier| tier.label == preferred_tier)
+                .filter(|idx| *idx < attempt_indices.len())
+            {
+                let preferred = attempt_indices.remove(preferred_idx);
+                attempt_indices.insert(0, preferred);
+            }
+        }
+
+        let max_attempts = attempt_indices
+            .len()
+            .min(policy.max_escalations as usize + 1);
+        attempt_indices.truncate(max_attempts);
+
+        for (attempt_idx, provider_idx) in attempt_indices.into_iter().enumerate() {
             // Read provider info under a short-lived lock
             let (provider, config_model_id, model_id, allowed) = {
-                let providers = self.providers.read().await;
-                if tier_idx >= providers.len() {
+                let mut providers = self.providers.write().await;
+                if provider_idx >= providers.len() {
                     break;
                 }
-                let entry = &providers[tier_idx];
-                let allowed =
-                    entry.circuit_breaker.is_allowed() && !entry.circuit_breaker.is_rate_limited();
+                let entry = &mut providers[provider_idx];
+                entry.circuit_breaker.maybe_transition_to_half_open();
+                let allowed = entry.circuit_breaker.is_allowed()
+                    && !entry.circuit_breaker.is_rate_limited()
+                    && Self::provider_matches_hint(entry.provider.as_ref(), hint, estimated);
                 (
                     entry.provider.clone(),
                     entry.config.model_id.clone(),
@@ -349,25 +435,28 @@ impl ModelRouter {
 
             let tier_label = policy
                 .tiers
-                .get(tier_idx)
+                .get(provider_idx)
                 .map(|t| t.label.clone())
-                .unwrap_or_else(|| format!("tier-{tier_idx}"));
+                .unwrap_or_else(|| format!("tier-{provider_idx}"));
 
             let start = std::time::Instant::now();
-            let result = provider.complete(request.clone()).await;
+            let provider_request = Self::provider_request(&request);
+            let result = provider.complete(provider_request).await;
             let latency_ms = start.elapsed().as_millis() as u64;
 
             match result {
                 Ok(response) => {
                     {
                         let mut providers = self.providers.write().await;
-                        if tier_idx < providers.len() {
-                            providers[tier_idx].circuit_breaker.record_success(latency_ms);
+                        if provider_idx < providers.len() {
+                            providers[provider_idx]
+                                .circuit_breaker
+                                .record_success(latency_ms);
                         }
                     }
 
                     let confidence = ConfidenceSignal::from_response(&response);
-                    let is_last_tier = tier_idx + 1 >= max_attempts;
+                    let is_last_tier = attempt_idx + 1 >= max_attempts;
 
                     let decision = RoutingDecision {
                         provider_id: config_model_id,
@@ -384,7 +473,7 @@ impl ModelRouter {
                                 tier_label, confidence.score, policy.escalation_threshold
                             )
                         },
-                        estimated_cost_tokens: None,
+                        estimated_cost_tokens: Some(estimated),
                     };
 
                     if confidence.score >= policy.escalation_threshold || is_last_tier {
@@ -398,8 +487,10 @@ impl ModelRouter {
                         _ => None,
                     };
                     let mut providers = self.providers.write().await;
-                    if tier_idx < providers.len() {
-                        providers[tier_idx].circuit_breaker.record_failure(retry_after);
+                    if provider_idx < providers.len() {
+                        providers[provider_idx]
+                            .circuit_breaker
+                            .record_failure(retry_after);
                     }
                     // Continue to next tier on error
                 }
@@ -457,7 +548,7 @@ impl ModelProvider for ModelRouter {
     }
 
     async fn embed(&self, input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
-        let idx = self.select_provider(None).await?;
+        let idx = self.select_provider(None, 0).await?;
         let providers = self.providers.read().await;
         providers[idx].provider.embed(input).await
     }

--- a/crates/mister-smith-llm/src/types.rs
+++ b/crates/mister-smith-llm/src/types.rs
@@ -25,6 +25,9 @@ pub struct CompletionRequest {
     /// Extra provider-neutral request metadata.
     #[serde(default = "default_metadata")]
     pub metadata: serde_json::Value,
+    /// Optional routing-only preferences for provider selection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_hint: Option<RoutingHint>,
 }
 
 impl Default for CompletionRequest {
@@ -37,8 +40,20 @@ impl Default for CompletionRequest {
             max_tokens: None,
             stop_sequences: None,
             metadata: default_metadata(),
+            routing_hint: None,
         }
     }
+}
+
+/// Caller-provided routing preferences.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingHint {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_capabilities: Vec<String>,
 }
 
 /// Unified chat message roles consumed by completion requests.

--- a/crates/mister-smith-llm/tests/mock_tests.rs
+++ b/crates/mister-smith-llm/tests/mock_tests.rs
@@ -17,6 +17,7 @@ fn request_with_user(prompt: &str) -> CompletionRequest {
         max_tokens: None,
         stop_sequences: None,
         metadata: json!({}),
+        routing_hint: None,
     }
 }
 

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -1,9 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use mister_smith_llm::{
     CascadePolicy, CascadeTier, CircuitBreakerConfig, CircuitState, CompletionRequest,
-    ModelRouter, MockProvider, ModelProvider, ProviderConfig, ProviderKind, RoutingPolicy,
+    CompletionResponse, ContentBlock, LlmError, MockProvider, ModelCapabilities, ModelProvider,
+    ModelRouter, ProviderConfig, ProviderKind, RoutingHint, RoutingPolicy, StopReason, Usage,
 };
 
 fn mock_request() -> CompletionRequest {
@@ -20,6 +21,71 @@ fn mock_config(model_id: &str) -> ProviderConfig {
         provider_kind: ProviderKind::Mock,
         model_id: model_id.to_string(),
         ..Default::default()
+    }
+}
+
+#[derive(Debug)]
+struct RecordingProvider {
+    model_id: String,
+    capabilities: ModelCapabilities,
+    observed_requests: Arc<Mutex<Vec<CompletionRequest>>>,
+}
+
+impl RecordingProvider {
+    fn new(
+        model_id: &str,
+        capabilities: ModelCapabilities,
+        observed_requests: Arc<Mutex<Vec<CompletionRequest>>>,
+    ) -> Self {
+        Self {
+            model_id: model_id.to_string(),
+            capabilities,
+            observed_requests,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ModelProvider for RecordingProvider {
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        self.observed_requests.lock().unwrap().push(request);
+        Ok(CompletionResponse {
+            content: vec![ContentBlock::Text {
+                text: "recorded-response".to_string(),
+            }],
+            model_id: self.model_id.clone(),
+            usage: Usage::new(10, 5),
+            stop_reason: StopReason::Completed,
+            tool_calls: vec![],
+        })
+    }
+
+    fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+        let model_id = self.model_id.clone();
+        Box::pin(futures::stream::once(async move {
+            Err(LlmError::UnsupportedCapability {
+                capability: "streaming".to_string(),
+                model: model_id,
+            })
+        }))
+    }
+
+    async fn embed(
+        &self,
+        _input: Vec<String>,
+    ) -> Result<mister_smith_llm::EmbeddingResponse, LlmError> {
+        Err(LlmError::UnsupportedCapability {
+            capability: "embeddings".to_string(),
+            model: self.model_id.clone(),
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn capabilities(&self) -> ModelCapabilities {
+        self.capabilities
     }
 }
 
@@ -97,6 +163,98 @@ async fn cost_optimized_selects_first_healthy() {
 }
 
 #[tokio::test]
+async fn required_capabilities_hint_filters_providers() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    let no_tools_caps = ModelCapabilities {
+        tool_calling: false,
+        ..ModelCapabilities::all()
+    };
+
+    let p1: Arc<dyn ModelProvider> =
+        Arc::new(MockProvider::new("no-tools").with_capabilities(no_tools_caps));
+    let p2: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("with-tools"));
+
+    router
+        .add_provider(mock_config("no-tools"), p1, CircuitBreakerConfig::default())
+        .await;
+    router
+        .add_provider(
+            mock_config("with-tools"),
+            p2,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let mut request = mock_request();
+    request.routing_hint = Some(RoutingHint {
+        required_capabilities: vec!["tool_calling".to_string()],
+        ..Default::default()
+    });
+
+    let (_, decision) = router.route_completion(request).await.unwrap();
+    assert_eq!(decision.provider_id, "with-tools");
+}
+
+#[tokio::test]
+async fn max_cost_tokens_hint_blocks_over_budget_estimate() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    let provider: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("model-a"));
+
+    router
+        .add_provider(
+            mock_config("model-a"),
+            provider,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let mut request = mock_request();
+    request.max_tokens = Some(200);
+    request.routing_hint = Some(RoutingHint {
+        max_cost_tokens: Some(1),
+        ..Default::default()
+    });
+
+    let result = router.route_completion(request).await;
+    assert!(matches!(
+        result,
+        Err(mister_smith_core::LlmError::NoHealthyProvider(_))
+    ));
+}
+
+#[tokio::test]
+async fn route_completion_strips_routing_hint_before_provider_dispatch() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    let observed_requests = Arc::new(Mutex::new(Vec::new()));
+    let provider: Arc<dyn ModelProvider> = Arc::new(RecordingProvider::new(
+        "recording-model",
+        ModelCapabilities::all(),
+        observed_requests.clone(),
+    ));
+
+    router
+        .add_provider(
+            mock_config("recording-model"),
+            provider,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let mut request = mock_request();
+    request.routing_hint = Some(RoutingHint {
+        preferred_tier: Some("gold".to_string()),
+        max_cost_tokens: None,
+        required_capabilities: vec!["completion".to_string()],
+    });
+
+    let _ = router.route_completion(request).await.unwrap();
+
+    let requests = observed_requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].routing_hint.is_none());
+}
+
+#[tokio::test]
 async fn no_healthy_provider_returns_error() {
     let router = ModelRouter::new(RoutingPolicy::RoundRobin);
     // No providers registered
@@ -134,7 +292,11 @@ async fn provider_count() {
 
     let provider: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("test"));
     router
-        .add_provider(mock_config("test"), provider, CircuitBreakerConfig::default())
+        .add_provider(
+            mock_config("test"),
+            provider,
+            CircuitBreakerConfig::default(),
+        )
         .await;
     assert_eq!(router.provider_count().await, 1);
 }
@@ -290,12 +452,10 @@ mod cascade {
     async fn cascade_honors_max_escalations() {
         // max_escalations=0 means only first tier is tried
         let policy = CascadePolicy {
-            tiers: vec![
-                CascadeTier {
-                    provider_config: mock_config("tier-0"),
-                    label: "only-tier".to_string(),
-                },
-            ],
+            tiers: vec![CascadeTier {
+                provider_config: mock_config("tier-0"),
+                label: "only-tier".to_string(),
+            }],
             escalation_threshold: 1.1, // impossibly high
             max_escalations: 0,
         };
@@ -310,6 +470,31 @@ mod cascade {
 
         // max_escalations=0 means 1 attempt total, so it returns the first tier's response
         assert_eq!(decision.tier_label.as_deref(), Some("only-tier"));
+    }
+
+    #[tokio::test]
+    async fn cascade_preferred_tier_hint_is_prioritized() {
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let mut request = mock_request();
+        request.routing_hint = Some(RoutingHint {
+            preferred_tier: Some("llm-tier".to_string()),
+            ..Default::default()
+        });
+
+        let (_response, decision) = router.route_completion(request).await.unwrap();
+        assert_eq!(decision.tier_label.as_deref(), Some("llm-tier"));
     }
 
     #[tokio::test]

--- a/crates/mister-smith-llm/tests/types_tests.rs
+++ b/crates/mister-smith-llm/tests/types_tests.rs
@@ -29,6 +29,7 @@ fn completion_request_roundtrip_preserves_tools_and_metadata() {
         max_tokens: Some(256),
         stop_sequences: Some(vec!["END".to_string()]),
         metadata: json!({ "trace_id": "abc123" }),
+        routing_hint: None,
     };
 
     let encoded = serde_json::to_string(&request).unwrap();


### PR DESCRIPTION
### Motivation

- Provide callers a backward-compatible way to influence provider selection (preferred tier, capability requirements, and max cost tokens) without changing provider payload shapes.
- Enforce routing constraints early in the router so requests don't reach incompatible or over-budget providers.
- Keep providers receiving only provider-neutral payloads by stripping routing-only fields before dispatch.

### Description

- Added `routing_hint: Option<RoutingHint>` to `CompletionRequest` with serde defaults and `Default` initialization, and moved `RoutingHint` into the shared `types` module for reuse and re-export.  
- Updated `ModelRouter` to accept hints: `select_provider` now takes `Option<&RoutingHint>` and `estimated_tokens` and filters providers by `required_capabilities` and `max_cost_tokens`, and helper functions `provider_supports_capability` and `provider_matches_hint` were added.  
- Cascade routing now honors `preferred_tier` by prioritizing the hinted tier during escalation, carries estimated token cost into `RoutingDecision`, and all dispatch paths call a sanitizer that clears `routing_hint` before invoking the concrete `ModelProvider`.  
- Tests and ctor sites were updated: added tests in `crates/mister-smith-llm/tests/router_tests.rs` covering required capability filtering, max-cost blocking, preferred-tier prioritization in cascade, and verification that routing hints are stripped before provider dispatch, and updated request literals in `mock_tests.rs` and `types_tests.rs` to include `routing_hint: None` where full initializers are used.  
- Touched files: `crates/mister-smith-llm/src/types.rs`, `crates/mister-smith-llm/src/router.rs`, `crates/mister-smith-llm/src/lib.rs`, `crates/mister-smith-llm/tests/router_tests.rs`, `crates/mister-smith-llm/tests/mock_tests.rs`, `crates/mister-smith-llm/tests/types_tests.rs`.

### Testing

- Ran formatting with `cargo fmt --all` and it completed successfully.  
- Ran router unit tests with `cargo test -p mister-smith-llm --test router_tests -- --nocapture` and all router tests passed (`20 passed; 0 failed`).  
- Ran types/unit tests with `cargo test -p mister-smith-llm --test types_tests` and they passed (`7 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf24b3ba88333b20c728f1263fd1c)