### PR TITLE
fix(agents): propagate ToolBus boundary errors for LLM tool calls

### DIFF
--- a/crates/mister-smith-agents/src/tool_bus.rs
+++ b/crates/mister-smith-agents/src/tool_bus.rs
@@ -484,9 +484,11 @@ impl ToolBus {
     /// Execute a model-emitted [`mister_smith_llm::ToolCall`] through the ToolBus,
     /// preserving all existing security, timeout, metrics, and audit boundaries.
     ///
-    /// Returns `Ok(ToolResult)` in both success and tool-error cases (the error is
-    /// captured inside `ToolResult::error`). Returns `Err` only for structural
-    /// problems such as an invalid tool name format.
+    /// Returns `Ok(ToolResult)` only for successful execution payloads.
+    ///
+    /// Structural and execution-boundary failures (invalid tool name format,
+    /// authorization denial, timeout, missing/unavailable tool, etc.) are
+    /// returned as `Err(AgentSystemError)` to preserve ToolBus semantics.
     #[cfg(feature = "llm")]
     pub async fn execute_tool_call(
         &self,
@@ -501,19 +503,30 @@ impl ToolBus {
             ))
         })?;
 
-        // Delegate to existing invoke() with same security/timeout/metrics boundaries
-        match self
+        // Delegate to existing invoke() with same security/timeout/metrics boundaries.
+        // Boundary failures intentionally propagate as Err to preserve ToolBus semantics.
+        let output = self
             .invoke(principal, namespace, name, call.input.clone(), None)
-            .await
-        {
-            Ok(output) => Ok(mister_smith_llm::ToolResult::success(
-                call.call_id.clone(),
-                output,
-            )),
-            Err(err) => Ok(mister_smith_llm::ToolResult::failure(
-                call.call_id.clone(),
-                err.to_string(),
-            )),
+            .await?;
+        Ok(mister_smith_llm::ToolResult::success(
+            call.call_id.clone(),
+            output,
+        ))
+    }
+
+    /// Provider-facing adapter that preserves protocol expectations of always
+    /// returning a [`mister_smith_llm::ToolResult`], even on ToolBus failures.
+    #[cfg(feature = "llm")]
+    pub async fn execute_tool_call_provider_result(
+        &self,
+        principal: Option<&ToolPrincipal>,
+        call: &mister_smith_llm::ToolCall,
+    ) -> mister_smith_llm::ToolResult {
+        match self.execute_tool_call(principal, call).await {
+            Ok(result) => result,
+            Err(err) => {
+                mister_smith_llm::ToolResult::failure(call.call_id.clone(), err.to_string())
+            }
         }
     }
 }

--- a/crates/mister-smith-agents/tests/gate9_tests.rs
+++ b/crates/mister-smith-agents/tests/gate9_tests.rs
@@ -121,8 +121,8 @@ async fn tool_bus_round_trip_with_mock_provider() {
         name: "data.analyzer".into(),
         input: serde_json::json!({"query": "test"}),
     };
-    let result = bus.execute_tool_call(None, &call).await.unwrap();
-    // No backend registered, so we get an error result (not a panic)
+    let result = bus.execute_tool_call_provider_result(None, &call).await;
+    // No backend registered, so provider adapter returns a failure payload.
     assert!(result.error.is_some());
     assert_eq!(result.call_id, "call-gate9");
 }

--- a/crates/mister-smith-agents/tests/tool_bus_llm_tests.rs
+++ b/crates/mister-smith-agents/tests/tool_bus_llm_tests.rs
@@ -4,9 +4,93 @@
 
 #![cfg(feature = "llm")]
 
-use mister_smith_agents::tool_bus::ToolBus;
-use mister_smith_core::AgentId;
-use mister_smith_llm::ToolCall;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use mister_smith_agents::tool_bus::{ToolBus, ToolPrincipal};
+use mister_smith_agents::AgentSystemError;
+use mister_smith_core::{AgentId, Tool, ToolCapabilities, ToolError, ToolId, ToolSchema};
+use mister_smith_llm::ToolCall as LlmToolCall;
+use mister_smith_security::config::RbacConfig;
+use mister_smith_security::jwt::AgentClaims;
+use mister_smith_security::rbac::PolicyEngine;
+
+#[derive(Clone)]
+struct EchoTool {
+    id: ToolId,
+}
+
+#[async_trait]
+impl Tool for EchoTool {
+    async fn execute(&self, params: serde_json::Value) -> Result<serde_json::Value, ToolError> {
+        Ok(serde_json::json!({ "echo": params }))
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema
+    }
+
+    fn capabilities(&self) -> ToolCapabilities {
+        ToolCapabilities
+    }
+
+    fn tool_id(&self) -> ToolId {
+        self.id
+    }
+
+    fn version(&self) -> semver::Version {
+        semver::Version::new(0, 1, 0)
+    }
+}
+
+#[derive(Clone)]
+struct SlowTool {
+    id: ToolId,
+    delay: Duration,
+}
+
+#[async_trait]
+impl Tool for SlowTool {
+    async fn execute(&self, _params: serde_json::Value) -> Result<serde_json::Value, ToolError> {
+        tokio::time::sleep(self.delay).await;
+        Ok(serde_json::json!({ "status": "slow-ok" }))
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema
+    }
+
+    fn capabilities(&self) -> ToolCapabilities {
+        ToolCapabilities
+    }
+
+    fn tool_id(&self) -> ToolId {
+        self.id
+    }
+
+    fn version(&self) -> semver::Version {
+        semver::Version::new(0, 1, 0)
+    }
+}
+
+fn claims(agent_id: AgentId, permissions: &[&str]) -> AgentClaims {
+    let now = chrono::Utc::now().timestamp() as u64;
+    AgentClaims {
+        sub: agent_id.to_string(),
+        exp: now + 3600,
+        iat: now,
+        jti: uuid::Uuid::new_v4().to_string(),
+        agent_id: agent_id.to_string(),
+        agent_type: "worker".to_string(),
+        permissions: permissions
+            .iter()
+            .map(|permission| permission.to_string())
+            .collect(),
+        token_use: "access".to_string(),
+        ..Default::default()
+    }
+}
 
 #[test]
 fn to_tool_definitions_exports_registered_tools() {
@@ -33,12 +117,10 @@ fn to_tool_definitions_exports_registered_tools() {
     let defs = bus.to_tool_definitions();
     assert_eq!(defs.len(), 2);
 
-    // Find the analyzer definition
     let analyzer = defs.iter().find(|d| d.name == "data.analyzer").unwrap();
     assert_eq!(analyzer.description, "Analyzes data");
     assert!(analyzer.input_schema.is_object());
 
-    // Find the formatter definition
     let formatter = defs.iter().find(|d| d.name == "text.formatter").unwrap();
     assert_eq!(formatter.description, "Formats text");
 }
@@ -79,9 +161,9 @@ fn to_tool_definitions_preserves_input_schema() {
 #[tokio::test]
 async fn execute_tool_call_invalid_format() {
     let bus = ToolBus::new();
-    let call = ToolCall {
+    let call = LlmToolCall {
         call_id: "call-1".into(),
-        name: "no-namespace".into(), // Missing namespace.name format
+        name: "no-namespace".into(),
         input: serde_json::json!({}),
     };
 
@@ -95,19 +177,100 @@ async fn execute_tool_call_invalid_format() {
 }
 
 #[tokio::test]
-async fn execute_tool_call_tool_not_found() {
+async fn execute_tool_call_tool_not_found_returns_typed_error() {
     let bus = ToolBus::new();
-    let call = ToolCall {
+    let call = LlmToolCall {
         call_id: "call-1".into(),
         name: "ns.nonexistent".into(),
         input: serde_json::json!({}),
     };
 
-    let result = bus.execute_tool_call(None, &call).await;
-    // execute_tool_call returns Ok with error field when invoke fails
-    assert!(result.is_ok());
-    let tool_result = result.unwrap();
-    assert!(tool_result.error.is_some());
-    assert!(tool_result.output.is_none());
-    assert_eq!(tool_result.call_id, "call-1");
+    let err = bus.execute_tool_call(None, &call).await.unwrap_err();
+    assert!(matches!(err, AgentSystemError::Tool(ToolError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn execute_tool_call_permission_denied_returns_typed_error() {
+    let bus = ToolBus::with_security(Some(Arc::new(PolicyEngine::new(&RbacConfig::default()))), None);
+    let agent_id = AgentId::new();
+    let principal = ToolPrincipal::new(agent_id, claims(agent_id, &[]));
+
+    bus.register_native_tool(
+        "echo",
+        "data",
+        agent_id,
+        "Echoes payload",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+        Arc::new(EchoTool { id: ToolId::new() }),
+    );
+
+    let call = LlmToolCall {
+        call_id: "call-denied".into(),
+        name: "data.echo".into(),
+        input: serde_json::json!({"v": 1}),
+    };
+
+    let err = bus
+        .execute_tool_call(Some(&principal), &call)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AgentSystemError::PermissionDenied(_)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn execute_tool_call_timeout_returns_typed_error() {
+    let bus = ToolBus::new();
+    let agent_id = AgentId::new();
+
+    bus.register_native_tool(
+        "slow",
+        "data",
+        agent_id,
+        "Sleeps before returning",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+        Arc::new(SlowTool {
+            id: ToolId::new(),
+            delay: Duration::from_secs(3600),
+        }),
+    );
+
+    let call = LlmToolCall {
+        call_id: "call-timeout".into(),
+        name: "data.slow".into(),
+        input: serde_json::json!({}),
+    };
+
+    let pending = tokio::spawn({
+        let bus = bus;
+        async move { bus.execute_tool_call(None, &call).await }
+    });
+
+    tokio::time::advance(Duration::from_secs(31)).await;
+
+    let err = pending.await.unwrap().unwrap_err();
+    assert!(matches!(err, AgentSystemError::Timeout(_)));
+}
+
+#[tokio::test]
+async fn execute_tool_call_tool_unavailable_returns_typed_error() {
+    let bus = ToolBus::new();
+    bus.register(
+        "analyzer",
+        "data",
+        AgentId::new(),
+        "Analyzer",
+        serde_json::json!({"type": "object"}),
+        serde_json::json!({"type": "object"}),
+    );
+
+    let call = LlmToolCall {
+        call_id: "call-unavailable".into(),
+        name: "data.analyzer".into(),
+        input: serde_json::json!({}),
+    };
+
+    let err = bus.execute_tool_call(None, &call).await.unwrap_err();
+    assert!(matches!(err, AgentSystemError::ToolUnavailable(_)));
 }


### PR DESCRIPTION
### Motivation
- Ensure ToolBus preserves its error semantics at the LLM boundary by returning typed `AgentSystemError` for structural and execution-boundary failures instead of embedding those failures inside `ToolResult` payloads.

### Description
- Change `ToolBus::execute_tool_call` to return `Ok(ToolResult)` only on successful execution and to propagate structural/execution-boundary failures (invalid name format, permission denied, timeout, tool missing/unavailable, etc.) as `Err(AgentSystemError)` via `invoke()` propagation.
- Add `ToolBus::execute_tool_call_provider_result` as a provider-facing adapter which converts `Err(AgentSystemError)` into a protocol-friendly `mister_smith_llm::ToolResult::failure` for callers that require an always-`ToolResult` contract.
- Update tests in `crates/mister-smith-agents/tests/tool_bus_llm_tests.rs` to assert typed `Err` variants for not-found, permission-denied, timeout, and tool-unavailable scenarios.
- Update `crates/mister-smith-agents/tests/gate9_tests.rs` to use the new provider adapter where an always-`ToolResult` payload is expected.

### Testing
- Ran `cargo test -p mister-smith-agents --features llm --test tool_bus_llm_tests` and all `tool_bus_llm_tests` passed (`8 passed`).
- Ran `cargo test -p mister-smith-agents --features llm --test gate9_tests` and all `gate9_tests` passed (`5 passed`).
- Ran `cargo fmt --all --check` but the environment lacks the `rustfmt` component, so formatting check was not performed (`rustfmt` not installed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf265a65c833393e68323212441c8)