### PR TITLE
fix(llm): enforce cascade tier-to-provider routing order

### DIFF
--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -123,6 +123,13 @@ struct ProviderEntry {
     circuit_breaker: CircuitBreaker,
 }
 
+#[derive(Debug, Clone)]
+struct CascadeAttempt {
+    tier_order: usize,
+    tier_label: String,
+    provider_index: usize,
+}
+
 /// Data-plane router that selects a provider per-request based on policy, health, and budget.
 pub struct ModelRouter {
     providers: RwLock<Vec<ProviderEntry>>,
@@ -314,25 +321,29 @@ impl ModelRouter {
 
     /// Route a completion via cascade (SLM-default / LLM-fallback).
     ///
-    /// Attempts providers in registration order (cheapest first). Each response
-    /// is scored with [`ConfidenceSignal`]; if the score meets the escalation
-    /// threshold or all tiers are exhausted, the response is returned.
+    /// Attempts providers in declared tier order (`CascadePolicy::tiers`), which
+    /// is authoritative for cheapest-first escalation. Each response is scored
+    /// with [`ConfidenceSignal`]; if the score meets the escalation threshold or
+    /// all tiers are exhausted, the response is returned.
     pub async fn route_cascade(
         &self,
         request: CompletionRequest,
         policy: &CascadePolicy,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
-        let provider_count = self.providers.read().await.len();
-        let max_attempts = provider_count.min(policy.max_escalations as usize + 1);
+        let attempt_plan = {
+            let providers = self.providers.read().await;
+            Self::build_cascade_attempt_plan(&providers, policy)?
+        };
+        let max_attempts = attempt_plan.len().min(policy.max_escalations as usize + 1);
 
-        for tier_idx in 0..max_attempts {
+        for (attempt_idx, attempt) in attempt_plan.iter().take(max_attempts).enumerate() {
             // Read provider info under a short-lived lock
             let (provider, config_model_id, model_id, allowed) = {
                 let providers = self.providers.read().await;
-                if tier_idx >= providers.len() {
+                if attempt.provider_index >= providers.len() {
                     break;
                 }
-                let entry = &providers[tier_idx];
+                let entry = &providers[attempt.provider_index];
                 let allowed =
                     entry.circuit_breaker.is_allowed() && !entry.circuit_breaker.is_rate_limited();
                 (
@@ -347,11 +358,7 @@ impl ModelRouter {
                 continue;
             }
 
-            let tier_label = policy
-                .tiers
-                .get(tier_idx)
-                .map(|t| t.label.clone())
-                .unwrap_or_else(|| format!("tier-{tier_idx}"));
+            let tier_label = attempt.tier_label.clone();
 
             let start = std::time::Instant::now();
             let result = provider.complete(request.clone()).await;
@@ -361,13 +368,15 @@ impl ModelRouter {
                 Ok(response) => {
                     {
                         let mut providers = self.providers.write().await;
-                        if tier_idx < providers.len() {
-                            providers[tier_idx].circuit_breaker.record_success(latency_ms);
+                        if attempt.provider_index < providers.len() {
+                            providers[attempt.provider_index]
+                                .circuit_breaker
+                                .record_success(latency_ms);
                         }
                     }
 
                     let confidence = ConfidenceSignal::from_response(&response);
-                    let is_last_tier = tier_idx + 1 >= max_attempts;
+                    let is_last_tier = attempt_idx + 1 >= max_attempts;
 
                     let decision = RoutingDecision {
                         provider_id: config_model_id,
@@ -375,13 +384,16 @@ impl ModelRouter {
                         tier_label: Some(tier_label.clone()),
                         reason: if confidence.score >= policy.escalation_threshold || is_last_tier {
                             format!(
-                                "Cascade accepted at tier '{}' (confidence: {:.2})",
-                                tier_label, confidence.score
+                                "Cascade accepted at tier '{}' (order {}, confidence: {:.2})",
+                                tier_label, attempt.tier_order, confidence.score
                             )
                         } else {
                             format!(
-                                "Cascade escalating from tier '{}' (confidence: {:.2} < threshold: {:.2})",
-                                tier_label, confidence.score, policy.escalation_threshold
+                                "Cascade escalating from tier '{}' (order {}, confidence: {:.2} < threshold: {:.2})",
+                                tier_label,
+                                attempt.tier_order,
+                                confidence.score,
+                                policy.escalation_threshold
                             )
                         },
                         estimated_cost_tokens: None,
@@ -398,8 +410,10 @@ impl ModelRouter {
                         _ => None,
                     };
                     let mut providers = self.providers.write().await;
-                    if tier_idx < providers.len() {
-                        providers[tier_idx].circuit_breaker.record_failure(retry_after);
+                    if attempt.provider_index < providers.len() {
+                        providers[attempt.provider_index]
+                            .circuit_breaker
+                            .record_failure(retry_after);
                     }
                     // Continue to next tier on error
                 }
@@ -414,6 +428,43 @@ impl ModelRouter {
     /// Get the number of registered providers.
     pub async fn provider_count(&self) -> usize {
         self.providers.read().await.len()
+    }
+
+    fn build_cascade_attempt_plan(
+        providers: &[ProviderEntry],
+        policy: &CascadePolicy,
+    ) -> Result<Vec<CascadeAttempt>, LlmError> {
+        // The declared order in `policy.tiers` is authoritative and represents
+        // "cheapest first" preference for cascade routing.
+        let mut ordered_tiers: Vec<(usize, &CascadeTier)> = policy.tiers.iter().enumerate().collect();
+        ordered_tiers.sort_by_key(|(declared_order, _)| *declared_order);
+
+        let mut attempts = Vec::with_capacity(ordered_tiers.len());
+        for (tier_order, tier) in ordered_tiers {
+            let provider_index = providers
+                .iter()
+                .position(|entry| {
+                    entry.config.model_id == tier.provider_config.model_id
+                        && entry.config.provider_kind == tier.provider_config.provider_kind
+                })
+                .ok_or_else(|| {
+                    LlmError::InvalidRequest(format!(
+                        "Cascade tier '{}' (order {}) has no matching registered provider for model_id='{}' provider_kind='{}'",
+                        tier.label,
+                        tier_order,
+                        tier.provider_config.model_id,
+                        tier.provider_config.provider_kind
+                    ))
+                })?;
+
+            attempts.push(CascadeAttempt {
+                tier_order,
+                tier_label: tier.label.clone(),
+                provider_index,
+            });
+        }
+
+        Ok(attempts)
     }
 }
 

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -313,6 +313,29 @@ mod cascade {
     }
 
     #[tokio::test]
+    async fn cascade_uses_declared_tier_order_over_registration_order() {
+        // Tier order is slm -> llm, but providers are intentionally registered llm -> slm.
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
+
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+
+        let (_response, decision) = router.route_completion(mock_request()).await.unwrap();
+
+        // Should still execute tier 0 (slm-tier) first based on declared tier order.
+        assert_eq!(decision.tier_label.as_deref(), Some("slm-tier"));
+        assert_eq!(decision.provider_id, "slm");
+    }
+
+    #[tokio::test]
     async fn cascade_returns_error_when_all_tiers_unhealthy() {
         let policy = cascade_policy(0.5, 1);
         let router = ModelRouter::new(RoutingPolicy::Cascade(policy));


### PR DESCRIPTION
### Motivation
- Cascade routing previously iterated providers by registration/insertion order which could mismatch the intended tier escalation order declared in `CascadePolicy::tiers`.
- The change makes the declared tier order authoritative for cheapest-first cascade behavior and surfaces mismatches as typed errors to fail fast.

### Description
- Build an explicit tier-to-provider mapping before cascade execution by matching each `CascadeTier.provider_config` (by `model_id` and `provider_kind`) to a registered provider index and represent attempts with a new `CascadeAttempt` struct.
- Fail fast with `LlmError::InvalidRequest` when a configured cascade tier has no matching registered provider.
- Execute cascade attempts according to the declared tier order from `CascadePolicy::tiers` (documented as authoritative) rather than provider registration order, and include tier order in decision reason text for observability.
- Add a regression test `cascade_uses_declared_tier_order_over_registration_order` ensuring correct tier execution when registration order differs from tier order.

### Testing
- Ran `cargo test -p mister-smith-llm --test router_tests` and all router tests passed (17 passed, 0 failed).
- Ran `cargo test -p mister-smith-llm router_tests` which compiled the crate and completed successfully (tests filtered as expected for that invocation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf2719e3c8333bb374d39167cec13)