### PR TITLE
feat(router): emit ModelEvent::RoutingDecision for each cascade tier attempt

### DIFF
--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 use crate::budget::BudgetEnforcer;
 use crate::config::ProviderConfig;
 use crate::health::{CircuitBreaker, CircuitBreakerConfig, HealthStatus};
+use crate::model_event::ModelEvent;
 use crate::provider::{CompletionStream, ModelProvider};
 use crate::types::{
     ChatMessage, CompletionRequest, CompletionResponse, EmbeddingResponse, ModelCapabilities,
@@ -116,6 +117,11 @@ pub struct RoutingDecision {
     pub estimated_cost_tokens: Option<u64>,
 }
 
+/// Sink interface for router-emitted model events.
+pub trait ModelEventSink: Send + Sync {
+    fn publish(&self, event: ModelEvent);
+}
+
 /// Registered provider entry with its circuit breaker.
 struct ProviderEntry {
     config: ProviderConfig,
@@ -130,6 +136,7 @@ pub struct ModelRouter {
     budget_enforcer: Option<BudgetEnforcer>,
     budget_root: Option<String>,
     round_robin_counter: std::sync::atomic::AtomicUsize,
+    model_event_sink: Option<Arc<dyn ModelEventSink>>,
 }
 
 impl ModelRouter {
@@ -141,6 +148,7 @@ impl ModelRouter {
             budget_enforcer: None,
             budget_root: None,
             round_robin_counter: std::sync::atomic::AtomicUsize::new(0),
+            model_event_sink: None,
         }
     }
 
@@ -149,6 +157,22 @@ impl ModelRouter {
         self.budget_enforcer = Some(enforcer);
         self.budget_root = Some(root_key.into());
         self
+    }
+
+    /// Set an optional sink to receive routing model events.
+    pub fn with_model_event_sink(mut self, sink: Arc<dyn ModelEventSink>) -> Self {
+        self.model_event_sink = Some(sink);
+        self
+    }
+
+    fn emit_routing_event(&self, model_id: String, tier: String, reason: String) {
+        if let Some(sink) = &self.model_event_sink {
+            sink.publish(ModelEvent::RoutingDecision {
+                model_id,
+                tier,
+                reason,
+            });
+        }
     }
 
     /// Register a provider.
@@ -371,7 +395,7 @@ impl ModelRouter {
 
                     let decision = RoutingDecision {
                         provider_id: config_model_id,
-                        model_id,
+                        model_id: model_id.clone(),
                         tier_label: Some(tier_label.clone()),
                         reason: if confidence.score >= policy.escalation_threshold || is_last_tier {
                             format!(
@@ -387,12 +411,31 @@ impl ModelRouter {
                         estimated_cost_tokens: None,
                     };
 
-                    if confidence.score >= policy.escalation_threshold || is_last_tier {
+                    let accepted = confidence.score >= policy.escalation_threshold || is_last_tier;
+                    let reason = if accepted {
+                        format!(
+                            "accepted (confidence: {:.2}, threshold: {:.2}, last_tier: {})",
+                            confidence.score, policy.escalation_threshold, is_last_tier
+                        )
+                    } else {
+                        format!(
+                            "escalated (confidence: {:.2} < threshold: {:.2})",
+                            confidence.score, policy.escalation_threshold
+                        )
+                    };
+                    self.emit_routing_event(model_id.clone(), tier_label.clone(), reason);
+
+                    if accepted {
                         return Ok((response, decision));
                     }
                     // Below threshold — escalate to next tier
                 }
                 Err(err) => {
+                    self.emit_routing_event(
+                        model_id,
+                        tier_label,
+                        format!("failed ({err})"),
+                    );
                     let retry_after = match &err {
                         LlmError::RateLimited { retry_after_secs } => *retry_after_secs,
                         _ => None,

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -1,10 +1,14 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use async_trait::async_trait;
+use mister_smith_core::LlmError;
 use mister_smith_llm::{
     CascadePolicy, CascadeTier, CircuitBreakerConfig, CircuitState, CompletionRequest,
-    ModelRouter, MockProvider, ModelProvider, ProviderConfig, ProviderKind, RoutingPolicy,
+    CompletionResponse, EmbeddingResponse, ModelCapabilities, ModelEvent, ModelProvider,
+    ModelRouter, MockProvider, ProviderConfig, ProviderKind, RoutingPolicy,
 };
+use mister_smith_llm::router::ModelEventSink;
 
 fn mock_request() -> CompletionRequest {
     CompletionRequest {
@@ -223,6 +227,74 @@ mod circuit_breaker {
 mod cascade {
     use super::*;
 
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Mutex<Vec<ModelEvent>>,
+    }
+
+    impl RecordingSink {
+        fn events(&self) -> Vec<ModelEvent> {
+            self.events
+                .lock()
+                .expect("recording sink lock poisoned")
+                .clone()
+        }
+    }
+
+    impl ModelEventSink for RecordingSink {
+        fn publish(&self, event: ModelEvent) {
+            self.events
+                .lock()
+                .expect("recording sink lock poisoned")
+                .push(event);
+        }
+    }
+
+    struct FailingProvider {
+        model_id: String,
+    }
+
+    impl FailingProvider {
+        fn new(model_id: impl Into<String>) -> Self {
+            Self {
+                model_id: model_id.into(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for FailingProvider {
+        async fn complete(&self, _request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+            Err(LlmError::Network("synthetic provider failure".to_string()))
+        }
+
+        fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+            Box::pin(futures::stream::once(async {
+                Err(LlmError::Network("streaming not supported".to_string()))
+            }))
+        }
+
+        async fn embed(&self, _input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
+            Err(LlmError::UnsupportedCapability {
+                capability: "embeddings".to_string(),
+                model: self.model_id.clone(),
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            &self.model_id
+        }
+
+        fn capabilities(&self) -> ModelCapabilities {
+            ModelCapabilities {
+                completion: true,
+                streaming: false,
+                embeddings: false,
+                tool_calling: false,
+            }
+        }
+    }
+
     fn cascade_policy(threshold: f32, max_escalations: u32) -> CascadePolicy {
         CascadePolicy {
             tiers: vec![
@@ -339,5 +411,71 @@ mod cascade {
         let signal = ConfidenceSignal::from_response(&short_response);
         // Short text (< 10 chars) should reduce confidence
         assert!(signal.score < 1.0);
+    }
+
+    #[tokio::test]
+    async fn cascade_emits_routing_events_for_escalation_and_acceptance() {
+        let policy = cascade_policy(1.1, 1);
+        let sink = Arc::new(RecordingSink::default());
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_model_event_sink(sink.clone());
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let _ = router.route_completion(mock_request()).await.unwrap();
+
+        let events = sink.events();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            ModelEvent::RoutingDecision { model_id, tier, reason }
+                if model_id == "slm-model" && tier == "slm-tier" && reason.contains("escalated")
+        ));
+        assert!(matches!(
+            &events[1],
+            ModelEvent::RoutingDecision { model_id, tier, reason }
+                if model_id == "llm-model" && tier == "llm-tier" && reason.contains("accepted")
+        ));
+    }
+
+    #[tokio::test]
+    async fn cascade_emits_routing_events_for_failure_then_acceptance() {
+        let policy = cascade_policy(0.3, 1);
+        let sink = Arc::new(RecordingSink::default());
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_model_event_sink(sink.clone());
+
+        let failing: Arc<dyn ModelProvider> = Arc::new(FailingProvider::new("slm-failure"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), failing, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let _ = router.route_completion(mock_request()).await.unwrap();
+
+        let events = sink.events();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(
+            &events[0],
+            ModelEvent::RoutingDecision { model_id, tier, reason }
+                if model_id == "slm-failure" && tier == "slm-tier" && reason.contains("failed")
+        ));
+        assert!(matches!(
+            &events[1],
+            ModelEvent::RoutingDecision { model_id, tier, reason }
+                if model_id == "llm-model" && tier == "llm-tier" && reason.contains("accepted")
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide observability for cascade routing by emitting a canonical `ModelEvent::RoutingDecision` on every tier attempt, covering accepted, escalated, and failed outcomes.
- Expose a lightweight router-side sink so callers can subscribe to routing events without changing core completion APIs.
- Ensure tests validate event emission order and coverage for escalation and failure paths.

### Description
- Introduced a router-side sink trait `ModelEventSink` and an optional field on `ModelRouter`, plus a builder helper `with_model_event_sink` and helper `emit_routing_event` to publish events.
- Wired cascade routing (`route_cascade`) to emit a `ModelEvent::RoutingDecision` for every tier attempt, including accepted attempts, escalations (confidence < threshold), and failures (provider errors), embedding `model_id`, `tier`, and a human-readable `reason` string.
- Added tests in `crates/mister-smith-llm/tests/router_tests.rs` that add a `RecordingSink` and `FailingProvider` test double and assert the emitted event sequence and outcome strings.
- Touched files: `crates/mister-smith-llm/src/router.rs` and `crates/mister-smith-llm/tests/router_tests.rs`.

### Testing
- Ran `cargo test -p mister-smith-llm --test router_tests -- --nocapture` and all router tests passed successfully.
- Ran full crate tests for `mister-smith-llm` and the test suite completed with the new tests passing.
- Ran `cargo fmt --all --check` in the environment but it failed due to a missing `rustfmt` component; code compiles and tests pass but formatting check should be run in CI or a dev environment with `rustfmt` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf273911083338c15c07ea1168d16)