### PR TITLE
fix(llm): unified router megamerge (#118+#119+#121+#124+#127)

### DIFF
--- a/crates/mister-smith-llm/src/budget.rs
+++ b/crates/mister-smith-llm/src/budget.rs
@@ -127,6 +127,8 @@ pub struct BudgetEnforcer {
     store: Box<dyn BudgetStore>,
 }
 
+const CAS_RETRY_LIMIT: usize = 3;
+
 impl BudgetEnforcer {
     pub fn new(store: Box<dyn BudgetStore>) -> Self {
         Self { store }
@@ -174,26 +176,40 @@ impl BudgetEnforcer {
     }
 
     /// Reconcile actual usage after completion. Adjusts the budget if actual differs from estimated.
+    /// Retries up to `CAS_RETRY_LIMIT` times on CAS conflicts.
     pub async fn reconcile(
         &self,
         reservation: &BudgetReservation,
         actual_tokens: u64,
     ) -> Result<(), LlmError> {
-        let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
-            LlmError::InvalidRequest(format!(
-                "Budget key '{}' not found during reconciliation",
-                reservation.budget_key
-            ))
-        })?;
+        for _attempt in 0..=CAS_RETRY_LIMIT {
+            let node = self.store.get(&reservation.budget_key).await?.ok_or_else(|| {
+                LlmError::InvalidRequest(format!(
+                    "Budget key '{}' not found during reconciliation",
+                    reservation.budget_key
+                ))
+            })?;
 
-        let adjustment = actual_tokens as i64 - reservation.estimated_tokens as i64;
-        let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
+            let adjustment = actual_tokens as i64 - reservation.estimated_tokens as i64;
+            let new_used = (node.used_tokens as i64 + adjustment).max(0) as u64;
 
-        let mut updated = node.clone();
-        updated.used_tokens = new_used;
+            let mut updated = node.clone();
+            updated.used_tokens = new_used;
 
-        self.store.cas_update(&updated, node.revision).await?;
-        Ok(())
+            match self.store.cas_update(&updated, node.revision).await {
+                Ok(_) => return Ok(()),
+                Err(err) if Self::is_cas_conflict(&err) => continue,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Err(LlmError::InvalidRequest(
+            "Reconcile failed: exceeded CAS conflict retry limit".to_string(),
+        ))
+    }
+
+    fn is_cas_conflict(err: &LlmError) -> bool {
+        matches!(err, LlmError::InvalidRequest(msg) if msg.contains("CAS conflict"))
     }
 
     /// Get the current budget state for a key.

--- a/crates/mister-smith-llm/src/lib.rs
+++ b/crates/mister-smith-llm/src/lib.rs
@@ -40,12 +40,11 @@ pub use provider::{CompletionStream, ModelProvider};
 ))]
 pub use providers::*;
 pub use router::{
-    CascadePolicy, CascadeTier, ConfidenceSignal, ModelRouter, RoutingDecision, RoutingHint,
-    RoutingPolicy,
+    CascadePolicy, CascadeTier, ConfidenceSignal, ModelRouter, RoutingDecision, RoutingPolicy,
 };
 pub use streaming::{ChunkDelta, StreamChunk};
 pub use tool_schema::{ToolCall, ToolDefinition, ToolResult};
 pub use types::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentBlock, EmbeddingResponse,
-    ModelCapabilities, StopReason, Usage,
+    ModelCapabilities, RoutingHint, StopReason, Usage,
 };

--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -5,12 +5,14 @@ use mister_smith_core::LlmError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-use crate::budget::BudgetEnforcer;
+use crate::budget::{BudgetEnforcer, BudgetReservation};
 use crate::config::ProviderConfig;
 use crate::health::{CircuitBreaker, CircuitBreakerConfig, HealthStatus};
+use crate::model_event::ModelEvent;
 use crate::provider::{CompletionStream, ModelProvider};
 use crate::types::{
     ChatMessage, CompletionRequest, CompletionResponse, EmbeddingResponse, ModelCapabilities,
+    RoutingHint,
 };
 
 /// Routing policy for provider selection.
@@ -27,18 +29,6 @@ pub enum RoutingPolicy {
     CapabilityMatched,
     /// Multi-tier escalation (SLM-default, LLM-fallback).
     Cascade(CascadePolicy),
-}
-
-
-/// Caller-provided routing preferences.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct RoutingHint {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub preferred_tier: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_cost_tokens: Option<u64>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_capabilities: Vec<String>,
 }
 
 /// Multi-tier routing configuration for SLM-default / LLM-fallback.
@@ -116,11 +106,38 @@ pub struct RoutingDecision {
     pub estimated_cost_tokens: Option<u64>,
 }
 
+/// Sink interface for router-emitted model events.
+pub trait ModelEventSink: Send + Sync {
+    fn publish(&self, event: ModelEvent);
+}
+
 /// Registered provider entry with its circuit breaker.
 struct ProviderEntry {
     config: ProviderConfig,
     provider: Arc<dyn ModelProvider>,
     circuit_breaker: CircuitBreaker,
+}
+
+/// Cascade attempt binding a declared tier to a registered provider.
+#[derive(Debug, Clone)]
+struct CascadeAttempt {
+    tier_order: usize,
+    tier_label: String,
+    provider_index: usize,
+}
+
+/// Budget reservation context for consistent reconciliation.
+struct BudgetReservationContext<'a> {
+    enforcer: &'a BudgetEnforcer,
+    reservation: BudgetReservation,
+}
+
+impl<'a> BudgetReservationContext<'a> {
+    async fn reconcile(self, actual_tokens: u64) -> Result<(), LlmError> {
+        self.enforcer
+            .reconcile(&self.reservation, actual_tokens)
+            .await
+    }
 }
 
 /// Data-plane router that selects a provider per-request based on policy, health, and budget.
@@ -130,6 +147,7 @@ pub struct ModelRouter {
     budget_enforcer: Option<BudgetEnforcer>,
     budget_root: Option<String>,
     round_robin_counter: std::sync::atomic::AtomicUsize,
+    model_event_sink: Option<Arc<dyn ModelEventSink>>,
 }
 
 impl ModelRouter {
@@ -141,6 +159,7 @@ impl ModelRouter {
             budget_enforcer: None,
             budget_root: None,
             round_robin_counter: std::sync::atomic::AtomicUsize::new(0),
+            model_event_sink: None,
         }
     }
 
@@ -149,6 +168,22 @@ impl ModelRouter {
         self.budget_enforcer = Some(enforcer);
         self.budget_root = Some(root_key.into());
         self
+    }
+
+    /// Set the model event sink for routing observability.
+    pub fn with_model_event_sink(mut self, sink: Arc<dyn ModelEventSink>) -> Self {
+        self.model_event_sink = Some(sink);
+        self
+    }
+
+    fn emit_routing_event(&self, model_id: String, tier: String, reason: String) {
+        if let Some(sink) = &self.model_event_sink {
+            sink.publish(ModelEvent::RoutingDecision {
+                model_id,
+                tier,
+                reason,
+            });
+        }
     }
 
     /// Register a provider.
@@ -176,7 +211,12 @@ impl ModelRouter {
     }
 
     /// Select a healthy provider based on routing policy.
-    async fn select_provider(&self, _hint: Option<&RoutingHint>) -> Result<usize, LlmError> {
+    /// Filters by hint capabilities and cost estimate when provided.
+    async fn select_provider(
+        &self,
+        hint: Option<&RoutingHint>,
+        estimated_tokens: u64,
+    ) -> Result<usize, LlmError> {
         let mut providers = self.providers.write().await;
 
         // First, transition any expired Open circuits to HalfOpen
@@ -199,23 +239,76 @@ impl ModelRouter {
             ));
         }
 
+        // Filter by hint capabilities and cost
+        let filtered_indices: Vec<usize> = if let Some(hint) = hint {
+            healthy_indices
+                .into_iter()
+                .filter(|&i| {
+                    Self::provider_matches_hint(
+                        providers[i].provider.as_ref(),
+                        Some(hint),
+                        estimated_tokens,
+                    )
+                })
+                .collect()
+        } else {
+            healthy_indices
+        };
+
+        if filtered_indices.is_empty() {
+            return Err(LlmError::NoHealthyProvider(
+                "No providers match routing hint requirements".to_string(),
+            ));
+        }
+
         match &self.routing_policy {
             RoutingPolicy::RoundRobin => {
                 let idx = self
                     .round_robin_counter
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                Ok(healthy_indices[idx % healthy_indices.len()])
+                Ok(filtered_indices[idx % filtered_indices.len()])
             }
-            RoutingPolicy::CostOptimized => {
-                // For now, prefer providers earlier in the list (assumed cheaper)
-                Ok(healthy_indices[0])
-            }
-            RoutingPolicy::CapabilityMatched => Ok(healthy_indices[0]),
-            RoutingPolicy::Cascade(_) => {
-                // Cascade routing is handled separately in route_cascade
-                Ok(healthy_indices[0])
+            RoutingPolicy::CostOptimized => Ok(filtered_indices[0]),
+            RoutingPolicy::CapabilityMatched => Ok(filtered_indices[0]),
+            RoutingPolicy::Cascade(_) => Ok(filtered_indices[0]),
+        }
+    }
+
+    fn provider_supports_capability(provider: &dyn ModelProvider, capability: &str) -> bool {
+        let caps = provider.capabilities();
+        match capability {
+            "completion" => caps.completion,
+            "streaming" => caps.streaming,
+            "embeddings" => caps.embeddings,
+            "tool_calling" => caps.tool_calling,
+            _ => false,
+        }
+    }
+
+    fn provider_matches_hint(
+        provider: &dyn ModelProvider,
+        hint: Option<&RoutingHint>,
+        estimated_tokens: u64,
+    ) -> bool {
+        let Some(hint) = hint else { return true };
+        for cap in &hint.required_capabilities {
+            if !Self::provider_supports_capability(provider, cap) {
+                return false;
             }
         }
+        if let Some(max_cost) = hint.max_cost_tokens {
+            if estimated_tokens > max_cost {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Clone the request with routing_hint stripped before dispatch to a provider.
+    fn provider_request(request: &CompletionRequest) -> CompletionRequest {
+        let mut clean = request.clone();
+        clean.routing_hint = None;
+        clean
     }
 
     /// Estimate token cost for a request.
@@ -243,28 +336,89 @@ impl ModelRouter {
         input_estimate + output_estimate
     }
 
+    /// Reserve budget tokens. Returns None if no enforcer is configured.
+    async fn reserve_budget(
+        &self,
+        estimated_tokens: u64,
+    ) -> Result<Option<BudgetReservationContext<'_>>, LlmError> {
+        if let (Some(enforcer), Some(root)) = (&self.budget_enforcer, &self.budget_root) {
+            let reservation = enforcer.reserve(root, estimated_tokens).await?;
+            Ok(Some(BudgetReservationContext {
+                enforcer,
+                reservation,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Build a tier-to-provider mapping from the cascade policy.
+    fn build_cascade_attempt_plan(
+        providers: &[ProviderEntry],
+        policy: &CascadePolicy,
+    ) -> Result<Vec<CascadeAttempt>, LlmError> {
+        let mut plan = Vec::with_capacity(policy.tiers.len());
+        for (order, tier) in policy.tiers.iter().enumerate() {
+            let provider_index = providers
+                .iter()
+                .position(|entry| {
+                    entry.config.model_id == tier.provider_config.model_id
+                        && entry.config.provider_kind == tier.provider_config.provider_kind
+                })
+                .ok_or_else(|| {
+                    LlmError::InvalidRequest(format!(
+                        "Cascade tier '{}' has no matching registered provider \
+                         (model_id: '{}', provider_kind: {:?})",
+                        tier.label, tier.provider_config.model_id, tier.provider_config.provider_kind
+                    ))
+                })?;
+            plan.push(CascadeAttempt {
+                tier_order: order,
+                tier_label: tier.label.clone(),
+                provider_index,
+            });
+        }
+        Ok(plan)
+    }
+
     /// Route a completion request through the data plane.
     pub async fn route_completion(
         &self,
         request: CompletionRequest,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
+        let estimated = Self::estimate_tokens(&request);
+        let hint = request.routing_hint.as_ref();
+
+        // Budget reservation — covers both cascade and non-cascade paths
+        let reservation = self.reserve_budget(estimated).await?;
+
         // Delegate to cascade routing when policy is Cascade
         if let RoutingPolicy::Cascade(ref policy) = self.routing_policy {
             let policy = policy.clone();
-            return self.route_cascade(request, &policy).await;
+            let result = self.route_cascade(request, &policy, estimated).await;
+
+            // Reconcile budget after cascade
+            if let Some(ctx) = reservation {
+                match &result {
+                    Ok((response, _)) => ctx.reconcile(response.usage.total_tokens).await?,
+                    Err(_) => ctx.reconcile(0).await?,
+                }
+            }
+            return result;
         }
 
-        let estimated = Self::estimate_tokens(&request);
+        // Non-cascade path
+        let idx = match self.select_provider(hint, estimated).await {
+            Ok(idx) => idx,
+            Err(err) => {
+                // Reconcile budget on selection failure
+                if let Some(ctx) = reservation {
+                    ctx.reconcile(0).await?;
+                }
+                return Err(err);
+            }
+        };
 
-        // Budget check
-        let reservation =
-            if let (Some(enforcer), Some(root)) = (&self.budget_enforcer, &self.budget_root) {
-                Some(enforcer.reserve(root, estimated).await?)
-            } else {
-                None
-            };
-
-        let idx = self.select_provider(None).await?;
         let providers = self.providers.read().await;
         let entry = &providers[idx];
 
@@ -277,7 +431,7 @@ impl ModelRouter {
         };
 
         let start = std::time::Instant::now();
-        let result = entry.provider.complete(request).await;
+        let result = entry.provider.complete(Self::provider_request(&request)).await;
         let latency_ms = start.elapsed().as_millis() as u64;
 
         drop(providers);
@@ -289,13 +443,9 @@ impl ModelRouter {
                 providers[idx].circuit_breaker.record_success(latency_ms);
                 drop(providers);
 
-                // Reconcile budget
-                if let Some(reservation) = &reservation {
-                    if let Some(enforcer) = &self.budget_enforcer {
-                        let _ = enforcer
-                            .reconcile(reservation, response.usage.total_tokens)
-                            .await;
-                    }
+                // Reconcile budget — propagate errors
+                if let Some(ctx) = reservation {
+                    ctx.reconcile(response.usage.total_tokens).await?;
                 }
 
                 Ok((response, decision))
@@ -307,6 +457,13 @@ impl ModelRouter {
                 };
                 let mut providers = self.providers.write().await;
                 providers[idx].circuit_breaker.record_failure(retry_after);
+                drop(providers);
+
+                // Reconcile budget on provider failure
+                if let Some(ctx) = reservation {
+                    ctx.reconcile(0).await?;
+                }
+
                 Err(err)
             }
         }
@@ -314,25 +471,49 @@ impl ModelRouter {
 
     /// Route a completion via cascade (SLM-default / LLM-fallback).
     ///
-    /// Attempts providers in registration order (cheapest first). Each response
-    /// is scored with [`ConfidenceSignal`]; if the score meets the escalation
-    /// threshold or all tiers are exhausted, the response is returned.
-    pub async fn route_cascade(
+    /// Attempts providers in declared tier order (CascadePolicy::tiers), which is
+    /// authoritative for cheapest-first escalation. Budget is managed by the caller
+    /// (`route_completion`).
+    async fn route_cascade(
         &self,
         request: CompletionRequest,
         policy: &CascadePolicy,
+        estimated_tokens: u64,
     ) -> Result<(CompletionResponse, RoutingDecision), LlmError> {
-        let provider_count = self.providers.read().await.len();
-        let max_attempts = provider_count.min(policy.max_escalations as usize + 1);
+        let hint = request.routing_hint.as_ref();
 
-        for tier_idx in 0..max_attempts {
-            // Read provider info under a short-lived lock
+        let providers = self.providers.read().await;
+        let attempt_plan = Self::build_cascade_attempt_plan(&providers, policy)?;
+        drop(providers);
+
+        // Build attempt indices, optionally reordering by preferred_tier hint
+        let mut attempt_indices: Vec<usize> = (0..attempt_plan.len()).collect();
+        if let Some(hint) = hint {
+            if let Some(preferred) = &hint.preferred_tier {
+                if let Some(pos) = attempt_plan
+                    .iter()
+                    .position(|a| a.tier_label == *preferred)
+                {
+                    attempt_indices.retain(|&i| i != pos);
+                    attempt_indices.insert(0, pos);
+                }
+            }
+        }
+
+        let max_attempts = attempt_indices.len().min(policy.max_escalations as usize + 1);
+
+        for (attempt_idx, plan_idx) in attempt_indices.into_iter().take(max_attempts).enumerate() {
+            let attempt = &attempt_plan[plan_idx];
+            let provider_index = attempt.provider_index;
+
+            // Read provider info under a short-lived write lock (for half-open transition)
             let (provider, config_model_id, model_id, allowed) = {
-                let providers = self.providers.read().await;
-                if tier_idx >= providers.len() {
+                let mut providers = self.providers.write().await;
+                if provider_index >= providers.len() {
                     break;
                 }
-                let entry = &providers[tier_idx];
+                let entry = &mut providers[provider_index];
+                entry.circuit_breaker.maybe_transition_to_half_open();
                 let allowed =
                     entry.circuit_breaker.is_allowed() && !entry.circuit_breaker.is_rate_limited();
                 (
@@ -347,47 +528,64 @@ impl ModelRouter {
                 continue;
             }
 
-            let tier_label = policy
-                .tiers
-                .get(tier_idx)
-                .map(|t| t.label.clone())
-                .unwrap_or_else(|| format!("tier-{tier_idx}"));
+            // Check hint filtering
+            if !Self::provider_matches_hint(provider.as_ref(), hint, estimated_tokens) {
+                continue;
+            }
+
+            let tier_label = attempt.tier_label.clone();
 
             let start = std::time::Instant::now();
-            let result = provider.complete(request.clone()).await;
+            let result = provider.complete(Self::provider_request(&request)).await;
             let latency_ms = start.elapsed().as_millis() as u64;
 
             match result {
                 Ok(response) => {
                     {
                         let mut providers = self.providers.write().await;
-                        if tier_idx < providers.len() {
-                            providers[tier_idx].circuit_breaker.record_success(latency_ms);
+                        if provider_index < providers.len() {
+                            providers[provider_index]
+                                .circuit_breaker
+                                .record_success(latency_ms);
                         }
                     }
 
                     let confidence = ConfidenceSignal::from_response(&response);
-                    let is_last_tier = tier_idx + 1 >= max_attempts;
+                    let is_last_tier = attempt_idx + 1 >= max_attempts;
 
                     let decision = RoutingDecision {
                         provider_id: config_model_id,
-                        model_id,
+                        model_id: model_id.clone(),
                         tier_label: Some(tier_label.clone()),
                         reason: if confidence.score >= policy.escalation_threshold || is_last_tier {
                             format!(
-                                "Cascade accepted at tier '{}' (confidence: {:.2})",
-                                tier_label, confidence.score
+                                "Cascade accepted at tier '{}' (order {}, confidence: {:.2})",
+                                tier_label, attempt.tier_order, confidence.score
                             )
                         } else {
                             format!(
-                                "Cascade escalating from tier '{}' (confidence: {:.2} < threshold: {:.2})",
-                                tier_label, confidence.score, policy.escalation_threshold
+                                "Cascade escalating from tier '{}' (order {}, confidence: {:.2} < threshold: {:.2})",
+                                tier_label, attempt.tier_order, confidence.score, policy.escalation_threshold
                             )
                         },
-                        estimated_cost_tokens: None,
+                        estimated_cost_tokens: Some(estimated_tokens),
                     };
 
-                    if confidence.score >= policy.escalation_threshold || is_last_tier {
+                    let accepted = confidence.score >= policy.escalation_threshold || is_last_tier;
+                    let event_reason = if accepted {
+                        format!(
+                            "accepted (confidence: {:.2}, threshold: {:.2}, last_tier: {})",
+                            confidence.score, policy.escalation_threshold, is_last_tier
+                        )
+                    } else {
+                        format!(
+                            "escalated (confidence: {:.2} < threshold: {:.2})",
+                            confidence.score, policy.escalation_threshold
+                        )
+                    };
+                    self.emit_routing_event(model_id, tier_label, event_reason);
+
+                    if accepted {
                         return Ok((response, decision));
                     }
                     // Below threshold — escalate to next tier
@@ -398,9 +596,15 @@ impl ModelRouter {
                         _ => None,
                     };
                     let mut providers = self.providers.write().await;
-                    if tier_idx < providers.len() {
-                        providers[tier_idx].circuit_breaker.record_failure(retry_after);
+                    if provider_index < providers.len() {
+                        providers[provider_index]
+                            .circuit_breaker
+                            .record_failure(retry_after);
                     }
+                    drop(providers);
+
+                    self.emit_routing_event(model_id, tier_label, format!("failed ({err})"));
+
                     // Continue to next tier on error
                 }
             }
@@ -457,7 +661,7 @@ impl ModelProvider for ModelRouter {
     }
 
     async fn embed(&self, input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
-        let idx = self.select_provider(None).await?;
+        let idx = self.select_provider(None, 0).await?;
         let providers = self.providers.read().await;
         providers[idx].provider.embed(input).await
     }

--- a/crates/mister-smith-llm/src/types.rs
+++ b/crates/mister-smith-llm/src/types.rs
@@ -2,6 +2,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::tool_schema::{ToolCall, ToolDefinition, ToolResult};
 
+/// Caller-provided routing preferences consumed and stripped at the routing boundary.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingHint {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preferred_tier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_capabilities: Vec<String>,
+}
+
 /// Provider-neutral completion request.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompletionRequest {
@@ -25,6 +36,9 @@ pub struct CompletionRequest {
     /// Extra provider-neutral request metadata.
     #[serde(default = "default_metadata")]
     pub metadata: serde_json::Value,
+    /// Optional routing hints consumed by ModelRouter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_hint: Option<RoutingHint>,
 }
 
 impl Default for CompletionRequest {
@@ -37,6 +51,7 @@ impl Default for CompletionRequest {
             max_tokens: None,
             stop_sequences: None,
             metadata: default_metadata(),
+            routing_hint: None,
         }
     }
 }

--- a/crates/mister-smith-llm/tests/budget_tests.rs
+++ b/crates/mister-smith-llm/tests/budget_tests.rs
@@ -1,5 +1,11 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use mister_smith_core::LlmError;
 use mister_smith_llm::budget::{
-    BudgetEnforcer, BudgetNode, BudgetPolicy, InMemoryBudgetStore,
+    BudgetEnforcer, BudgetNode, BudgetPolicy, BudgetReservation, BudgetStore,
+    InMemoryBudgetStore,
 };
 
 fn test_store() -> InMemoryBudgetStore {
@@ -235,4 +241,110 @@ fn budget_policy_serde_round_trip() {
         let deserialized: BudgetPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(*policy, deserialized);
     }
+}
+
+// --- CAS retry tests (#118) ---
+
+/// Budget store that simulates a configurable number of CAS conflicts.
+struct FlakyCasStore {
+    node: Mutex<BudgetNode>,
+    conflicts_remaining: AtomicUsize,
+}
+
+impl FlakyCasStore {
+    fn new(node: BudgetNode, conflicts: usize) -> Self {
+        Self {
+            node: Mutex::new(node),
+            conflicts_remaining: AtomicUsize::new(conflicts),
+        }
+    }
+}
+
+#[async_trait]
+impl BudgetStore for FlakyCasStore {
+    async fn get(&self, _key: &str) -> Result<Option<BudgetNode>, LlmError> {
+        Ok(Some(self.node.lock().unwrap().clone()))
+    }
+
+    async fn cas_update(
+        &self,
+        node: &BudgetNode,
+        expected_revision: u64,
+    ) -> Result<u64, LlmError> {
+        let remaining = self
+            .conflicts_remaining
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                if v > 0 { Some(v - 1) } else { None }
+            });
+
+        if remaining.is_ok() {
+            // Simulate conflict: bump revision but return error
+            let mut inner = self.node.lock().unwrap();
+            inner.revision += 1;
+            return Err(LlmError::InvalidRequest(format!(
+                "CAS conflict on budget key '{}': expected revision {}, actual {}",
+                node.key, expected_revision, inner.revision
+            )));
+        }
+
+        // Allow the update
+        let mut inner = self.node.lock().unwrap();
+        let new_revision = inner.revision + 1;
+        inner.used_tokens = node.used_tokens;
+        inner.revision = new_revision;
+        Ok(new_revision)
+    }
+}
+
+#[tokio::test]
+async fn reconcile_retries_on_cas_conflict_and_succeeds() {
+    let node = BudgetNode {
+        key: "budget/flaky".to_string(),
+        limit_tokens: 10000,
+        used_tokens: 500,
+        period: "test".to_string(),
+        policy: BudgetPolicy::HardCap,
+        revision: 1,
+    };
+    // 2 conflicts, then success
+    let store = FlakyCasStore::new(node, 2);
+    let enforcer = BudgetEnforcer::new(Box::new(store));
+
+    let reservation = BudgetReservation {
+        budget_key: "budget/flaky".to_string(),
+        estimated_tokens: 500,
+        revision: 2,
+    };
+
+    enforcer.reconcile(&reservation, 200).await.unwrap();
+
+    let result = enforcer.get_budget("budget/flaky").await.unwrap().unwrap();
+    assert_eq!(result.used_tokens, 200);
+}
+
+#[tokio::test]
+async fn reconcile_returns_error_after_retry_limit_exhausted() {
+    let node = BudgetNode {
+        key: "budget/flaky".to_string(),
+        limit_tokens: 10000,
+        used_tokens: 500,
+        period: "test".to_string(),
+        policy: BudgetPolicy::HardCap,
+        revision: 1,
+    };
+    // 10 conflicts — more than CAS_RETRY_LIMIT (3)
+    let store = FlakyCasStore::new(node, 10);
+    let enforcer = BudgetEnforcer::new(Box::new(store));
+
+    let reservation = BudgetReservation {
+        budget_key: "budget/flaky".to_string(),
+        estimated_tokens: 500,
+        revision: 2,
+    };
+
+    let err = enforcer.reconcile(&reservation, 200).await.unwrap_err();
+    assert!(
+        err.to_string().contains("CAS conflict"),
+        "expected CAS conflict error, got: {err}"
+    );
 }

--- a/crates/mister-smith-llm/tests/mock_tests.rs
+++ b/crates/mister-smith-llm/tests/mock_tests.rs
@@ -17,6 +17,7 @@ fn request_with_user(prompt: &str) -> CompletionRequest {
         max_tokens: None,
         stop_sequences: None,
         metadata: json!({}),
+        routing_hint: None,
     }
 }
 

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -1,9 +1,16 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use async_trait::async_trait;
+use futures::stream;
+use mister_smith_core::LlmError;
+use mister_smith_llm::budget::{BudgetEnforcer, BudgetNode, BudgetPolicy, BudgetStore, InMemoryBudgetStore};
+use mister_smith_llm::router::ModelEventSink;
 use mister_smith_llm::{
     CascadePolicy, CascadeTier, CircuitBreakerConfig, CircuitState, CompletionRequest,
-    ModelRouter, MockProvider, ModelProvider, ProviderConfig, ProviderKind, RoutingPolicy,
+    CompletionResponse, ContentBlock, EmbeddingResponse, ModelCapabilities, ModelEvent,
+    ModelProvider, ModelRouter, MockProvider, ProviderConfig, ProviderKind, RoutingHint,
+    RoutingPolicy, StopReason, Usage,
 };
 
 fn mock_request() -> CompletionRequest {
@@ -22,6 +29,155 @@ fn mock_config(model_id: &str) -> ProviderConfig {
         ..Default::default()
     }
 }
+
+// --- Shared test helpers ---
+
+/// Provider that always fails with a network error.
+#[derive(Debug)]
+struct FailingProvider {
+    model_id: String,
+}
+
+impl FailingProvider {
+    fn new(model_id: impl Into<String>) -> Self {
+        Self {
+            model_id: model_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProvider for FailingProvider {
+    async fn complete(&self, _request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        Err(LlmError::Network("simulated provider failure".to_string()))
+    }
+
+    fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+        Box::pin(stream::once(async {
+            Err(LlmError::Network("simulated provider failure".to_string()))
+        }))
+    }
+
+    async fn embed(&self, _input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
+        Ok(EmbeddingResponse {
+            embeddings: vec![],
+            model_id: self.model_id.clone(),
+            usage: Usage::default(),
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn capabilities(&self) -> ModelCapabilities {
+        ModelCapabilities {
+            completion: true,
+            streaming: false,
+            embeddings: false,
+            tool_calling: false,
+        }
+    }
+}
+
+/// Provider that records requests for inspection.
+#[derive(Debug)]
+struct RecordingProvider {
+    model_id: String,
+    capabilities: ModelCapabilities,
+    observed_requests: Arc<Mutex<Vec<CompletionRequest>>>,
+}
+
+impl RecordingProvider {
+    fn new(
+        model_id: &str,
+        capabilities: ModelCapabilities,
+        observed_requests: Arc<Mutex<Vec<CompletionRequest>>>,
+    ) -> Self {
+        Self {
+            model_id: model_id.to_string(),
+            capabilities,
+            observed_requests,
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProvider for RecordingProvider {
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        self.observed_requests
+            .lock()
+            .unwrap()
+            .push(request.clone());
+        Ok(CompletionResponse {
+            content: vec![ContentBlock::Text {
+                text: "recorded".to_string(),
+            }],
+            model_id: self.model_id.clone(),
+            usage: Usage::new(10, 5),
+            stop_reason: StopReason::Completed,
+            tool_calls: vec![],
+        })
+    }
+
+    fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+        Box::pin(stream::once(async {
+            Err(LlmError::UnsupportedCapability {
+                capability: "streaming".into(),
+                model: "recording".into(),
+            })
+        }))
+    }
+
+    async fn embed(&self, _input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
+        Err(LlmError::UnsupportedCapability {
+            capability: "embeddings".into(),
+            model: "recording".into(),
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    fn capabilities(&self) -> ModelCapabilities {
+        self.capabilities
+    }
+}
+
+/// Shared budget store wrapper for test assertions.
+#[derive(Clone)]
+struct SharedBudgetStore(Arc<InMemoryBudgetStore>);
+
+#[async_trait]
+impl BudgetStore for SharedBudgetStore {
+    async fn get(&self, key: &str) -> Result<Option<BudgetNode>, LlmError> {
+        self.0.get(key).await
+    }
+
+    async fn cas_update(
+        &self,
+        node: &BudgetNode,
+        expected_revision: u64,
+    ) -> Result<u64, LlmError> {
+        self.0.cas_update(node, expected_revision).await
+    }
+}
+
+fn budget_store_with_default() -> SharedBudgetStore {
+    let inner = InMemoryBudgetStore::new();
+    inner.insert(BudgetNode {
+        key: "budget/test".to_string(),
+        limit_tokens: 50_000,
+        used_tokens: 0,
+        period: "test".to_string(),
+        policy: BudgetPolicy::HardCap,
+        revision: 1,
+    });
+    SharedBudgetStore(Arc::new(inner))
+}
+
+// --- Basic routing tests ---
 
 #[tokio::test]
 async fn round_robin_distributes_across_providers() {
@@ -67,8 +223,6 @@ async fn sub_millisecond_routing_overhead() {
     let elapsed = start.elapsed();
     let per_request_us = elapsed.as_micros() / iterations;
 
-    // MockProvider is instant, so routing overhead should be very small.
-    // Allow generous threshold since we're measuring in test environment.
     assert!(
         per_request_us < 5000,
         "Routing overhead too high: {per_request_us}us per request"
@@ -139,7 +293,149 @@ async fn provider_count() {
     assert_eq!(router.provider_count().await, 1);
 }
 
-// Circuit breaker tests
+// --- Routing hint tests (#121) ---
+
+#[tokio::test]
+async fn required_capabilities_hint_filters_providers() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+
+    let no_tools = MockProvider::new("no-tools").with_capabilities(ModelCapabilities {
+        completion: true,
+        streaming: true,
+        embeddings: true,
+        tool_calling: false,
+    });
+    let with_tools = MockProvider::new("with-tools");
+
+    router
+        .add_provider(
+            mock_config("no-tools"),
+            Arc::new(no_tools),
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+    router
+        .add_provider(
+            mock_config("with-tools"),
+            Arc::new(with_tools),
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let request = CompletionRequest {
+        routing_hint: Some(RoutingHint {
+            required_capabilities: vec!["tool_calling".to_string()],
+            ..Default::default()
+        }),
+        ..mock_request()
+    };
+
+    let (_, decision) = router.route_completion(request).await.unwrap();
+    assert_eq!(decision.provider_id, "with-tools");
+}
+
+#[tokio::test]
+async fn max_cost_tokens_hint_blocks_over_budget_estimate() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    let provider: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("test"));
+
+    router
+        .add_provider(mock_config("test"), provider, CircuitBreakerConfig::default())
+        .await;
+
+    let request = CompletionRequest {
+        max_tokens: Some(200),
+        routing_hint: Some(RoutingHint {
+            max_cost_tokens: Some(1),
+            ..Default::default()
+        }),
+        ..mock_request()
+    };
+
+    let result = router.route_completion(request).await;
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), LlmError::NoHealthyProvider(_)));
+}
+
+#[tokio::test]
+async fn route_completion_strips_routing_hint_before_provider_dispatch() {
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let recorder: Arc<dyn ModelProvider> = Arc::new(RecordingProvider::new(
+        "recorder",
+        ModelCapabilities::all(),
+        observed.clone(),
+    ));
+
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    router
+        .add_provider(mock_config("recorder"), recorder, CircuitBreakerConfig::default())
+        .await;
+
+    let request = CompletionRequest {
+        routing_hint: Some(RoutingHint {
+            preferred_tier: Some("fast".into()),
+            max_cost_tokens: Some(5000),
+            required_capabilities: vec!["completion".into()],
+        }),
+        ..mock_request()
+    };
+
+    let _ = router.route_completion(request).await.unwrap();
+
+    let recorded = observed.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert!(
+        recorded[0].routing_hint.is_none(),
+        "routing_hint should be stripped before dispatch to provider"
+    );
+}
+
+// --- Budget error-path tests (#118) ---
+
+#[tokio::test]
+async fn provider_failure_after_reserve_reverts_budget_usage() {
+    let store = budget_store_with_default();
+    let enforcer = BudgetEnforcer::new(Box::new(store.clone()));
+
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin)
+        .with_budget(enforcer, "budget/test");
+
+    let provider: Arc<dyn ModelProvider> = Arc::new(FailingProvider::new("failing-model"));
+    router
+        .add_provider(mock_config("failing-model"), provider, CircuitBreakerConfig::default())
+        .await;
+
+    let result = router.route_completion(mock_request()).await;
+    assert!(result.is_err());
+
+    // Budget should be fully reverted
+    let node = store.get("budget/test").await.unwrap().unwrap();
+    assert_eq!(node.used_tokens, 0, "budget should revert to 0 after provider failure");
+}
+
+#[tokio::test]
+async fn failed_requests_have_no_net_token_leak() {
+    let store = budget_store_with_default();
+    let enforcer = BudgetEnforcer::new(Box::new(store.clone()));
+
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin)
+        .with_budget(enforcer, "budget/test");
+
+    let provider: Arc<dyn ModelProvider> = Arc::new(FailingProvider::new("failing-model"));
+    router
+        .add_provider(mock_config("failing-model"), provider, CircuitBreakerConfig::default())
+        .await;
+
+    for _ in 0..3 {
+        let _ = router.route_completion(mock_request()).await;
+    }
+
+    let node = store.get("budget/test").await.unwrap().unwrap();
+    assert_eq!(node.used_tokens, 0, "3 failed requests should leave 0 used tokens");
+}
+
+// --- Circuit breaker tests ---
+
 mod circuit_breaker {
     use mister_smith_llm::health::{CircuitBreaker, CircuitBreakerConfig, CircuitState};
     use std::time::Duration;
@@ -148,7 +444,7 @@ mod circuit_breaker {
     fn closed_to_open_on_threshold() {
         let mut cb = CircuitBreaker::new(CircuitBreakerConfig {
             failure_threshold: 3,
-            error_rate_threshold: 1.1, // Disable error-rate trigger for this test
+            error_rate_threshold: 1.1,
             ..Default::default()
         });
         assert_eq!(cb.state(), CircuitState::Closed);
@@ -219,7 +515,8 @@ mod circuit_breaker {
     }
 }
 
-// Cascade routing tests (T051-T053)
+// --- Cascade routing tests ---
+
 mod cascade {
     use super::*;
 
@@ -240,9 +537,26 @@ mod cascade {
         }
     }
 
+    /// Recording sink for model event assertions.
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Mutex<Vec<ModelEvent>>,
+    }
+
+    impl RecordingSink {
+        fn events(&self) -> Vec<ModelEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl ModelEventSink for RecordingSink {
+        fn publish(&self, event: ModelEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
     #[tokio::test]
     async fn cascade_accepts_first_tier_when_confidence_high() {
-        // Threshold is low (0.3) so the mock response should pass
         let policy = cascade_policy(0.3, 1);
         let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
 
@@ -258,15 +572,12 @@ mod cascade {
 
         let (_response, decision) = router.route_completion(mock_request()).await.unwrap();
 
-        // Should accept at tier 0 (SLM)
         assert_eq!(decision.tier_label.as_deref(), Some("slm-tier"));
         assert!(decision.reason.contains("accepted"));
     }
 
     #[tokio::test]
     async fn cascade_escalates_when_confidence_low() {
-        // Threshold is impossibly high (1.1) so every tier will be below threshold
-        // except the last tier which is always accepted
         let policy = cascade_policy(1.1, 1);
         let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
 
@@ -282,21 +593,17 @@ mod cascade {
 
         let (_response, decision) = router.route_completion(mock_request()).await.unwrap();
 
-        // Should escalate to tier 1 (LLM) and accept as last tier
         assert_eq!(decision.tier_label.as_deref(), Some("llm-tier"));
     }
 
     #[tokio::test]
     async fn cascade_honors_max_escalations() {
-        // max_escalations=0 means only first tier is tried
         let policy = CascadePolicy {
-            tiers: vec![
-                CascadeTier {
-                    provider_config: mock_config("tier-0"),
-                    label: "only-tier".to_string(),
-                },
-            ],
-            escalation_threshold: 1.1, // impossibly high
+            tiers: vec![CascadeTier {
+                provider_config: mock_config("tier-0"),
+                label: "only-tier".to_string(),
+            }],
+            escalation_threshold: 1.1,
             max_escalations: 0,
         };
         let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
@@ -308,7 +615,6 @@ mod cascade {
 
         let (_response, decision) = router.route_completion(mock_request()).await.unwrap();
 
-        // max_escalations=0 means 1 attempt total, so it returns the first tier's response
         assert_eq!(decision.tier_label.as_deref(), Some("only-tier"));
     }
 
@@ -316,7 +622,7 @@ mod cascade {
     async fn cascade_returns_error_when_all_tiers_unhealthy() {
         let policy = cascade_policy(0.5, 1);
         let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
-        // No providers registered
+        // No providers registered — will fail at build_cascade_attempt_plan
         let result = router.route_completion(mock_request()).await;
         assert!(result.is_err());
     }
@@ -324,7 +630,6 @@ mod cascade {
     #[tokio::test]
     async fn confidence_signal_penalizes_short_responses() {
         use mister_smith_llm::ConfidenceSignal;
-        use mister_smith_llm::{CompletionResponse, ContentBlock, StopReason, Usage};
 
         let short_response = CompletionResponse {
             content: vec![ContentBlock::Text {
@@ -337,7 +642,221 @@ mod cascade {
         };
 
         let signal = ConfidenceSignal::from_response(&short_response);
-        // Short text (< 10 chars) should reduce confidence
         assert!(signal.score < 1.0);
+    }
+
+    // --- Tier ordering tests (#124) ---
+
+    #[tokio::test]
+    async fn cascade_uses_declared_tier_order_over_registration_order() {
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
+
+        // Deliberately register in REVERSE order: llm first, then slm
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+
+        let (_response, decision) = router.route_completion(mock_request()).await.unwrap();
+
+        // Should still use slm-tier first (declared order), not llm (registration order)
+        assert_eq!(decision.tier_label.as_deref(), Some("slm-tier"));
+        assert_eq!(decision.provider_id, "slm");
+    }
+
+    // --- Preferred tier hint tests (#121) ---
+
+    #[tokio::test]
+    async fn cascade_preferred_tier_hint_is_prioritized() {
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy));
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let request = CompletionRequest {
+            routing_hint: Some(RoutingHint {
+                preferred_tier: Some("llm-tier".to_string()),
+                ..Default::default()
+            }),
+            ..mock_request()
+        };
+
+        let (_, decision) = router.route_completion(request).await.unwrap();
+
+        assert_eq!(decision.tier_label.as_deref(), Some("llm-tier"));
+    }
+
+    // --- Cascade budget tests (#119) ---
+
+    #[tokio::test]
+    async fn cascade_reserves_and_reconciles_budget_on_accept() {
+        let store = budget_store_with_default();
+        let enforcer = BudgetEnforcer::new(Box::new(store.clone()));
+
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_budget(enforcer, "budget/test");
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let (response, _decision) = router.route_completion(mock_request()).await.unwrap();
+
+        let node = store.get("budget/test").await.unwrap().unwrap();
+        assert_eq!(
+            node.used_tokens, response.usage.total_tokens,
+            "budget should be reconciled to actual usage"
+        );
+        assert!(response.usage.total_tokens < 1024);
+    }
+
+    #[tokio::test]
+    async fn cascade_reconciles_budget_when_escalating_to_second_tier() {
+        let store = budget_store_with_default();
+        let enforcer = BudgetEnforcer::new(Box::new(store.clone()));
+
+        // threshold 1.1 forces escalation
+        let policy = cascade_policy(1.1, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_budget(enforcer, "budget/test");
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let (response, decision) = router.route_completion(mock_request()).await.unwrap();
+
+        assert_eq!(decision.tier_label.as_deref(), Some("llm-tier"));
+        let node = store.get("budget/test").await.unwrap().unwrap();
+        assert_eq!(
+            node.used_tokens, response.usage.total_tokens,
+            "budget should be reconciled after escalation"
+        );
+        assert!(decision.estimated_cost_tokens.is_some());
+    }
+
+    // --- Routing event emission tests (#127) ---
+
+    #[tokio::test]
+    async fn cascade_emits_routing_events_for_escalation_and_acceptance() {
+        let sink = Arc::new(RecordingSink::default());
+
+        // threshold 1.1 forces escalation from tier 0 to tier 1
+        let policy = cascade_policy(1.1, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_model_event_sink(sink.clone());
+
+        let slm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("slm-model"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), slm, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let _ = router.route_completion(mock_request()).await.unwrap();
+
+        let events = sink.events();
+        assert_eq!(events.len(), 2, "should emit 2 routing events");
+
+        // First event: escalated from slm-tier
+        match &events[0] {
+            ModelEvent::RoutingDecision {
+                model_id, tier, reason,
+            } => {
+                assert_eq!(model_id, "slm-model");
+                assert_eq!(tier, "slm-tier");
+                assert!(reason.contains("escalated"), "reason: {reason}");
+            }
+            other => panic!("expected RoutingDecision, got: {other:?}"),
+        }
+
+        // Second event: accepted at llm-tier
+        match &events[1] {
+            ModelEvent::RoutingDecision {
+                model_id, tier, reason,
+            } => {
+                assert_eq!(model_id, "llm-model");
+                assert_eq!(tier, "llm-tier");
+                assert!(reason.contains("accepted"), "reason: {reason}");
+            }
+            other => panic!("expected RoutingDecision, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cascade_emits_routing_events_for_failure_then_acceptance() {
+        let sink = Arc::new(RecordingSink::default());
+
+        let policy = cascade_policy(0.3, 1);
+        let router = ModelRouter::new(RoutingPolicy::Cascade(policy))
+            .with_model_event_sink(sink.clone());
+
+        // First tier fails, second succeeds
+        let failing: Arc<dyn ModelProvider> = Arc::new(FailingProvider::new("slm-failure"));
+        let llm: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("llm-model"));
+
+        router
+            .add_provider(mock_config("slm"), failing, CircuitBreakerConfig::default())
+            .await;
+        router
+            .add_provider(mock_config("llm"), llm, CircuitBreakerConfig::default())
+            .await;
+
+        let _ = router.route_completion(mock_request()).await.unwrap();
+
+        let events = sink.events();
+        assert_eq!(events.len(), 2, "should emit 2 routing events");
+
+        match &events[0] {
+            ModelEvent::RoutingDecision {
+                model_id, tier, reason,
+            } => {
+                assert_eq!(model_id, "slm-failure");
+                assert_eq!(tier, "slm-tier");
+                assert!(reason.contains("failed"), "reason: {reason}");
+            }
+            other => panic!("expected RoutingDecision, got: {other:?}"),
+        }
+
+        match &events[1] {
+            ModelEvent::RoutingDecision {
+                model_id, tier, reason,
+            } => {
+                assert_eq!(model_id, "llm-model");
+                assert_eq!(tier, "llm-tier");
+                assert!(reason.contains("accepted"), "reason: {reason}");
+            }
+            other => panic!("expected RoutingDecision, got: {other:?}"),
+        }
     }
 }

--- a/crates/mister-smith-llm/tests/types_tests.rs
+++ b/crates/mister-smith-llm/tests/types_tests.rs
@@ -29,6 +29,7 @@ fn completion_request_roundtrip_preserves_tools_and_metadata() {
         max_tokens: Some(256),
         stop_sequences: Some(vec!["END".to_string()]),
         metadata: json!({ "trace_id": "abc123" }),
+        routing_hint: None,
     };
 
     let encoded = serde_json::to_string(&request).unwrap();


### PR DESCRIPTION
## Summary

Combines 5 router-area PRs that could not merge independently due to overlapping changes in `router.rs`:

- **#121**: `RoutingHint` on `CompletionRequest`, provider filtering by capabilities/cost, hint stripping
- **#118**: Budget reconciliation on all error paths, CAS retry in `BudgetEnforcer::reconcile`
- **#119**: Budget reservation before cascade branch, `reserve_budget()` helper
- **#124**: `build_cascade_attempt_plan()` for declared tier-to-provider binding
- **#127**: `ModelEventSink` trait, `emit_routing_event()` in cascade loop

### Key fixes over individual PRs
- #119's `BudgetReservationContext::reconcile()` now propagates errors (was `let _`)
- Unified `FailingProvider` and `SharedBudgetStore` test helpers (deduplicated)
- Used #118's `CAS_RETRY_LIMIT` approach (dropped #119's duplicate `RECONCILE_MAX_RETRIES`)

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — 0 failures across 82 test targets
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] 11 new tests covering hint filtering, budget error paths, tier ordering, event emission