### PR TITLE
fix(llm): finish routing hint handling and clear fmt gate

### DIFF
--- a/crates/mister-smith-llm/src/router.rs
+++ b/crates/mister-smith-llm/src/router.rs
@@ -224,6 +224,15 @@ impl ModelRouter {
             entry.circuit_breaker.maybe_transition_to_half_open();
         }
 
+        self.select_provider_from_entries(&providers, hint, estimated_tokens)
+    }
+
+    fn select_provider_from_entries(
+        &self,
+        providers: &[ProviderEntry],
+        hint: Option<&RoutingHint>,
+        estimated_tokens: u64,
+    ) -> Result<usize, LlmError> {
         let healthy_indices: Vec<usize> = providers
             .iter()
             .enumerate()
@@ -239,7 +248,6 @@ impl ModelRouter {
             ));
         }
 
-        // Filter by hint capabilities and cost
         let filtered_indices: Vec<usize> = if let Some(hint) = hint {
             healthy_indices
                 .into_iter()
@@ -261,16 +269,18 @@ impl ModelRouter {
             ));
         }
 
+        let candidate_indices = Self::prioritize_preferred_tier(providers, filtered_indices, hint);
+
         match &self.routing_policy {
             RoutingPolicy::RoundRobin => {
                 let idx = self
                     .round_robin_counter
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                Ok(filtered_indices[idx % filtered_indices.len()])
+                Ok(candidate_indices[idx % candidate_indices.len()])
             }
-            RoutingPolicy::CostOptimized => Ok(filtered_indices[0]),
-            RoutingPolicy::CapabilityMatched => Ok(filtered_indices[0]),
-            RoutingPolicy::Cascade(_) => Ok(filtered_indices[0]),
+            RoutingPolicy::CostOptimized => Ok(candidate_indices[0]),
+            RoutingPolicy::CapabilityMatched => Ok(candidate_indices[0]),
+            RoutingPolicy::Cascade(_) => Ok(candidate_indices[0]),
         }
     }
 
@@ -302,6 +312,43 @@ impl ModelRouter {
             }
         }
         true
+    }
+
+    fn prioritize_preferred_tier(
+        providers: &[ProviderEntry],
+        candidate_indices: Vec<usize>,
+        hint: Option<&RoutingHint>,
+    ) -> Vec<usize> {
+        let Some(preferred_tier) = hint.and_then(|hint| hint.preferred_tier.as_deref()) else {
+            return candidate_indices;
+        };
+
+        let (mut preferred, fallback): (Vec<usize>, Vec<usize>) =
+            candidate_indices.into_iter().partition(|&index| {
+                Self::provider_matches_preferred_tier(&providers[index].config, preferred_tier)
+            });
+
+        if preferred.is_empty() {
+            return fallback;
+        }
+
+        preferred.extend(fallback);
+        preferred
+    }
+
+    fn provider_matches_preferred_tier(config: &ProviderConfig, preferred_tier: &str) -> bool {
+        if config.model_id == preferred_tier {
+            return true;
+        }
+
+        ["tier", "tier_label"].into_iter().any(|field| {
+            config
+                .metadata
+                .get(field)
+                .and_then(serde_json::Value::as_str)
+                .map(|value| value == preferred_tier)
+                .unwrap_or(false)
+        })
     }
 
     /// Clone the request with routing_hint stripped before dispatch to a provider.
@@ -636,24 +683,22 @@ impl ModelProvider for ModelRouter {
     fn stream(&self, request: CompletionRequest) -> CompletionStream {
         // For streaming, select provider synchronously and delegate
         // This is a simplified version - full async selection would need a different approach
-        let providers = self.providers.try_read();
+        let estimated = Self::estimate_tokens(&request);
+        let hint = request.routing_hint.as_ref();
+        let providers = self.providers.try_write();
         match providers {
-            Ok(providers) => {
-                let healthy: Vec<usize> = providers
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, e)| e.circuit_breaker.is_allowed())
-                    .map(|(i, _)| i)
-                    .collect();
+            Ok(mut providers) => {
+                for entry in providers.iter_mut() {
+                    entry.circuit_breaker.maybe_transition_to_half_open();
+                }
 
-                if let Some(&idx) = healthy.first() {
-                    providers[idx].provider.stream(request)
-                } else {
-                    Box::pin(futures::stream::once(async {
-                        Err(LlmError::NoHealthyProvider(
-                            "No healthy providers for streaming".to_string(),
-                        ))
-                    }))
+                match self.select_provider_from_entries(&providers, hint, estimated) {
+                    Ok(idx) => {
+                        let provider = providers[idx].provider.clone();
+                        drop(providers);
+                        provider.stream(Self::provider_request(&request))
+                    }
+                    Err(err) => Box::pin(futures::stream::once(async { Err(err) })),
                 }
             }
             Err(_) => Box::pin(futures::stream::once(async {

--- a/crates/mister-smith-llm/tests/router_tests.rs
+++ b/crates/mister-smith-llm/tests/router_tests.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use futures::stream;
+use futures::StreamExt;
 use mister_smith_core::LlmError;
 use mister_smith_llm::budget::{
     BudgetEnforcer, BudgetNode, BudgetPolicy, BudgetStore, InMemoryBudgetStore,
@@ -29,6 +30,13 @@ fn mock_config(model_id: &str) -> ProviderConfig {
         provider_kind: ProviderKind::Mock,
         model_id: model_id.to_string(),
         ..Default::default()
+    }
+}
+
+fn mock_config_with_tier(model_id: &str, tier: &str) -> ProviderConfig {
+    ProviderConfig {
+        metadata: serde_json::json!({ "tier": tier }),
+        ..mock_config(model_id)
     }
 }
 
@@ -119,13 +127,20 @@ impl ModelProvider for RecordingProvider {
         })
     }
 
-    fn stream(&self, _request: CompletionRequest) -> mister_smith_llm::CompletionStream {
-        Box::pin(stream::once(async {
-            Err(LlmError::UnsupportedCapability {
-                capability: "streaming".into(),
-                model: "recording".into(),
-            })
-        }))
+    fn stream(&self, request: CompletionRequest) -> mister_smith_llm::CompletionStream {
+        self.observed_requests.lock().unwrap().push(request.clone());
+        Box::pin(stream::iter(vec![
+            Ok(mister_smith_llm::StreamChunk {
+                index: 0,
+                delta: mister_smith_llm::ChunkDelta::Text {
+                    text: "recorded-stream".to_string(),
+                },
+            }),
+            Ok(mister_smith_llm::StreamChunk::stop(
+                1,
+                StopReason::Completed,
+            )),
+        ]))
     }
 
     async fn embed(&self, _input: Vec<String>) -> Result<EmbeddingResponse, LlmError> {
@@ -406,6 +421,37 @@ async fn required_capabilities_hint_filters_providers() {
 }
 
 #[tokio::test]
+async fn preferred_tier_hint_prioritizes_matching_provider_for_non_cascade_routing() {
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+
+    router
+        .add_provider(
+            mock_config_with_tier("baseline", "slm"),
+            Arc::new(MockProvider::new("baseline-model")),
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+    router
+        .add_provider(
+            mock_config_with_tier("preferred", "llm"),
+            Arc::new(MockProvider::new("preferred-model")),
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let request = CompletionRequest {
+        routing_hint: Some(RoutingHint {
+            preferred_tier: Some("llm".to_string()),
+            ..Default::default()
+        }),
+        ..mock_request()
+    };
+
+    let (_, decision) = router.route_completion(request).await.unwrap();
+    assert_eq!(decision.provider_id, "preferred");
+}
+
+#[tokio::test]
 async fn max_cost_tokens_hint_blocks_over_budget_estimate() {
     let router = ModelRouter::new(RoutingPolicy::RoundRobin);
     let provider: Arc<dyn ModelProvider> = Arc::new(MockProvider::new("test"));
@@ -433,6 +479,68 @@ async fn max_cost_tokens_hint_blocks_over_budget_estimate() {
         result.unwrap_err(),
         LlmError::NoHealthyProvider(_)
     ));
+}
+
+#[tokio::test]
+async fn stream_consumes_hint_for_selection_and_strips_before_dispatch() {
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let recorder: Arc<dyn ModelProvider> = Arc::new(RecordingProvider::new(
+        "recorder",
+        ModelCapabilities::all(),
+        observed.clone(),
+    ));
+    let no_tools = Arc::new(
+        MockProvider::new("no-tools").with_capabilities(ModelCapabilities {
+            completion: true,
+            streaming: true,
+            embeddings: true,
+            tool_calling: false,
+        }),
+    );
+
+    let router = ModelRouter::new(RoutingPolicy::RoundRobin);
+    router
+        .add_provider(
+            mock_config_with_tier("baseline", "slm"),
+            no_tools,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+    router
+        .add_provider(
+            mock_config_with_tier("preferred", "llm"),
+            recorder,
+            CircuitBreakerConfig::default(),
+        )
+        .await;
+
+    let chunks = router
+        .stream(CompletionRequest {
+            tools: Some(vec![]),
+            routing_hint: Some(RoutingHint {
+                preferred_tier: Some("llm".to_string()),
+                required_capabilities: vec!["tool_calling".to_string()],
+                ..Default::default()
+            }),
+            ..mock_request()
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(
+        chunks[0].as_ref().unwrap().delta,
+        mister_smith_llm::ChunkDelta::Text {
+            text: "recorded-stream".to_string(),
+        }
+    );
+
+    let recorded = observed.lock().unwrap();
+    assert_eq!(recorded.len(), 1);
+    assert!(
+        recorded[0].routing_hint.is_none(),
+        "routing_hint should be stripped before dispatch to provider"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

MS-5 fixes the remaining RoutingHint gaps, but the branch was still blocked because GitHub Actions `Check` runs `cargo fmt --all -- --check` against a repo baseline that was already red outside the ticket diff.

## Solution

- finish the RoutingHint router handling on the completion and streaming paths
- gate the macOS-only Claude keychain constant so the Linux `-Dwarnings` build succeeds
- carry the existing rustfmt baseline cleanup in a separate commit so the shared formatter gate is green on this branch

## Validation

- cargo fmt --all -- --check
- cargo test -p mister-smith-llm --test router_tests
- cargo test -p mister-smith-llm
- cargo build --workspace
- RUSTFLAGS='-Dwarnings' cargo build --workspace
