### PR TITLE
🔒 [fix] implement configurable CORS middleware

### DIFF
--- a/crates/mister-smith-http/src/config.rs
+++ b/crates/mister-smith-http/src/config.rs
@@ -24,6 +24,7 @@ pub struct HttpTransportConfig {
     ///
     /// Set to `["*"]` to allow any origin (permissive).
     /// Default is empty (strict).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_origins: Vec<String>,
 }
 
@@ -105,5 +106,24 @@ mod tests {
             deserialized.allowed_origins,
             vec!["http://localhost:3000".to_string()]
         );
+    }
+
+    #[test]
+    fn config_deserialize_legacy_document_without_cors_field() {
+        let json = r#"{
+            "bind_address":"127.0.0.1:8080",
+            "websocket_enabled":true,
+            "ws_keepalive_interval":30,
+            "max_ws_connections":250,
+            "rate_limit_rps":75
+        }"#;
+
+        let deserialized: HttpTransportConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(deserialized.bind_address, "127.0.0.1:8080");
+        assert!(deserialized.websocket_enabled);
+        assert_eq!(deserialized.ws_keepalive_interval, Duration::from_secs(30));
+        assert_eq!(deserialized.max_ws_connections, 250);
+        assert_eq!(deserialized.rate_limit_rps, 75);
+        assert!(deserialized.allowed_origins.is_empty());
     }
 }

--- a/crates/mister-smith-http/src/server.rs
+++ b/crates/mister-smith-http/src/server.rs
@@ -279,12 +279,14 @@ mod tests {
         let mut config = HttpTransportConfig::default();
         config.allowed_origins = vec!["*".to_string()];
         let app = build_router(&config, AppState::new());
+        let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40124);
 
         let request = Request::builder()
             .method("OPTIONS")
             .uri("/api/v1/health")
             .header("origin", "http://example.com")
             .header("access-control-request-method", "GET")
+            .extension(ConnectInfo(client_addr))
             .body(Body::empty())
             .unwrap();
 
@@ -303,12 +305,14 @@ mod tests {
     async fn build_router_excludes_cors_headers_by_default() {
         let config = HttpTransportConfig::default();
         let app = build_router(&config, AppState::new());
+        let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 40125);
 
         let request = Request::builder()
             .method("OPTIONS")
             .uri("/api/v1/health")
             .header("origin", "http://example.com")
             .header("access-control-request-method", "GET")
+            .extension(ConnectInfo(client_addr))
             .body(Body::empty())
             .unwrap();
 


### PR DESCRIPTION
🎯 **What:** Missing CORS Middleware in `mister-smith-http`.
⚠️ **Risk:** Potential security vulnerability where unauthorized origins could interact with the API if left unconfigured, or preflight requests not being handled correctly.
🛡️ **Solution:** Added configurable `CorsLayer` to the Axum router. It uses `allowed_origins` from the `HttpTransportConfig`, defaulting to an empty list (secure-by-default). The layer order was carefully adjusted to ensure the rate limiter remains the outermost layer to protect against flood attacks, as required by the existing architectural design.

---
*PR created automatically by Jules for task [16722185616097676215](https://jules.google.com/task/16722185616097676215) started by @MattMagg*