### PR TITLE
test(config): harden config-loader env coverage

### DIFF
--- a/crates/mister-smith-config/tests/loader_tests.rs
+++ b/crates/mister-smith-config/tests/loader_tests.rs
@@ -146,7 +146,10 @@ fn env_overlay_log_level() {
 fn env_overlay_transport() {
     let mut config = FrameworkConfig::default();
     let _env = EnvGuard::new(&[
-        ("TEST_PREFIX4_TRANSPORT__NATS_URL", Some("nats://remote:4222")),
+        (
+            "TEST_PREFIX4_TRANSPORT__NATS_URL",
+            Some("nats://remote:4222"),
+        ),
         ("TEST_PREFIX4_TRANSPORT__HTTP_PORT", Some("8080")),
         ("TEST_PREFIX4_TRANSPORT__GRPC_PORT", Some("9090")),
     ]);
@@ -218,7 +221,10 @@ fn load_config_returns_defaults_when_no_file() {
         ("MISTER_SMITH_AGENT__RUNTIME__WORKER_THREADS", None),
         ("MISTER_SMITH_AGENT__RUNTIME__BLOCKING_THREADS", None),
         ("MISTER_SMITH_AGENT__RUNTIME__MAX_MEMORY", None),
-        ("MISTER_SMITH_AGENT__SUPERVISION__MAX_RESTART_ATTEMPTS", None),
+        (
+            "MISTER_SMITH_AGENT__SUPERVISION__MAX_RESTART_ATTEMPTS",
+            None,
+        ),
         ("MISTER_SMITH_AGENT__MONITORING__LOG_LEVEL", None),
         ("MISTER_SMITH_TRANSPORT__NATS_URL", None),
         ("MISTER_SMITH_TRANSPORT__HTTP_PORT", None),


### PR DESCRIPTION
## Problem
Config loader tests covered only part of `apply_env_overlay()` and only the local discovery path, leaving several env branches unverified.

## Solution
- add direct coverage for runtime, supervision, transport, and nested security env overlays
- add deterministic discovery tests for both missing and present `HOME` and `MS_ENVIRONMENT`
- isolate env-sensitive tests with a local guard that restores prior values and harden the default `load_config()` test against operator shell state

## Validation
- cargo test -p mister-smith-config --test loader_tests
- cargo test -p mister-smith-config
- cargo build --workspace
