### PR TITLE
fix(persistence): batch audit inserts in one statement

### DIFF
--- a/crates/mister-smith-persistence/src/postgres/queries.rs
+++ b/crates/mister-smith-persistence/src/postgres/queries.rs
@@ -942,6 +942,72 @@ pub struct AuditEntry {
     pub created_at: DateTime<Utc>,
 }
 
+struct AuditBatchInsert {
+    ids: Vec<Uuid>,
+    event_types: Vec<String>,
+    agent_ids: Vec<Option<Uuid>>,
+    resource_types: Vec<Option<String>>,
+    resource_ids: Vec<Option<Uuid>>,
+    actions: Vec<String>,
+    old_values: Vec<Option<serde_json::Value>>,
+    new_values: Vec<Option<serde_json::Value>>,
+    metadata: Vec<serde_json::Value>,
+    correlation_ids: Vec<Option<Uuid>>,
+    created_ats: Vec<DateTime<Utc>>,
+}
+
+impl AuditBatchInsert {
+    const SQL: &str = r#"
+        INSERT INTO audit_log (
+            id, event_type, agent_id, resource_type, resource_id,
+            action, old_values, new_values, metadata,
+            correlation_id, created_at
+        )
+        SELECT *
+        FROM UNNEST(
+            $1::uuid[],
+            $2::text[],
+            $3::uuid[],
+            $4::text[],
+            $5::uuid[],
+            $6::text[],
+            $7::jsonb[],
+            $8::jsonb[],
+            $9::jsonb[],
+            $10::uuid[],
+            $11::timestamptz[]
+        )
+    "#;
+
+    fn from_entries(entries: &[AuditEntry]) -> Self {
+        Self {
+            ids: entries.iter().map(|entry| entry.id).collect(),
+            event_types: entries
+                .iter()
+                .map(|entry| entry.event_type.clone())
+                .collect(),
+            agent_ids: entries.iter().map(|entry| entry.agent_id).collect(),
+            resource_types: entries
+                .iter()
+                .map(|entry| entry.resource_type.clone())
+                .collect(),
+            resource_ids: entries.iter().map(|entry| entry.resource_id).collect(),
+            actions: entries.iter().map(|entry| entry.action.clone()).collect(),
+            old_values: entries
+                .iter()
+                .map(|entry| entry.old_values.clone())
+                .collect(),
+            new_values: entries
+                .iter()
+                .map(|entry| entry.new_values.clone())
+                .collect(),
+            metadata: entries.iter().map(|entry| entry.metadata.clone()).collect(),
+            correlation_ids: entries.iter().map(|entry| entry.correlation_id).collect(),
+            created_ats: entries.iter().map(|entry| entry.created_at).collect(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Audit log CRUD
 // ---------------------------------------------------------------------------
@@ -988,35 +1054,24 @@ pub async fn insert_audit_batch(
     }
 
     let mut tx = pool.begin().await.map_err(from_sqlx_error)?;
-
-    for entry in entries {
-        sqlx::query(
-            r#"
-            INSERT INTO audit_log (
-                id, event_type, agent_id, resource_type, resource_id,
-                action, old_values, new_values, metadata,
-                correlation_id, created_at
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            "#,
-        )
-        .bind(entry.id)
-        .bind(&entry.event_type)
-        .bind(entry.agent_id)
-        .bind(&entry.resource_type)
-        .bind(entry.resource_id)
-        .bind(&entry.action)
-        .bind(&entry.old_values)
-        .bind(&entry.new_values)
-        .bind(&entry.metadata)
-        .bind(entry.correlation_id)
-        .bind(entry.created_at)
+    let batch = AuditBatchInsert::from_entries(entries);
+    let count = sqlx::query(AuditBatchInsert::SQL)
+        .bind(&batch.ids[..])
+        .bind(&batch.event_types[..])
+        .bind(&batch.agent_ids[..])
+        .bind(&batch.resource_types[..])
+        .bind(&batch.resource_ids[..])
+        .bind(&batch.actions[..])
+        .bind(&batch.old_values[..])
+        .bind(&batch.new_values[..])
+        .bind(&batch.metadata[..])
+        .bind(&batch.correlation_ids[..])
+        .bind(&batch.created_ats[..])
         .execute(&mut *tx)
         .await
-        .map_err(from_sqlx_error)?;
-    }
+        .map_err(from_sqlx_error)?
+        .rows_affected() as usize;
 
-    let count = entries.len();
     tx.commit().await.map_err(from_sqlx_error)?;
     Ok(count)
 }
@@ -1607,6 +1662,32 @@ mod tests {
         assert!(deserialized.resource_id.is_some());
         assert!(deserialized.old_values.is_some());
         assert!(deserialized.correlation_id.is_some());
+    }
+
+    #[test]
+    fn audit_batch_insert_uses_single_unnest_statement() {
+        let entries = vec![sample_audit_entry(), sample_audit_entry()];
+
+        let batch = AuditBatchInsert::from_entries(&entries);
+        let normalized_sql = AuditBatchInsert::SQL
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert!(normalized_sql.contains("FROM UNNEST("));
+        assert_eq!(batch.ids.len(), entries.len());
+        assert_eq!(batch.event_types.len(), entries.len());
+        assert_eq!(batch.agent_ids.len(), entries.len());
+        assert_eq!(batch.resource_types.len(), entries.len());
+        assert_eq!(batch.resource_ids.len(), entries.len());
+        assert_eq!(batch.actions.len(), entries.len());
+        assert_eq!(batch.old_values.len(), entries.len());
+        assert_eq!(batch.new_values.len(), entries.len());
+        assert_eq!(batch.metadata.len(), entries.len());
+        assert_eq!(batch.correlation_ids.len(), entries.len());
+        assert_eq!(batch.created_ats.len(), entries.len());
+        assert_eq!(batch.ids[0], entries[0].id);
+        assert_eq!(batch.event_types[1], entries[1].event_type);
     }
 
     // -------------------------------------------------------------------

--- a/crates/mister-smith-persistence/tests/repository_tests.rs
+++ b/crates/mister-smith-persistence/tests/repository_tests.rs
@@ -56,7 +56,7 @@ mod tests {
     #[ignore]
     async fn audit_append_batch() {
         let pool = test_pool().await;
-        let repo = AuditRepository::new(pool);
+        let repo = AuditRepository::new(pool.clone());
 
         let entries: Vec<AuditEntry> = (0..5)
             .map(|i| AuditEntry {
@@ -79,6 +79,68 @@ mod tests {
             .await
             .expect("batch append should succeed");
         assert_eq!(count, 5);
+
+        let entry_ids: Vec<Uuid> = entries.iter().map(|entry| entry.id).collect();
+        let persisted_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM audit_log WHERE id = ANY($1)")
+                .bind(&entry_ids[..])
+                .fetch_one(&pool)
+                .await
+                .expect("count query should succeed");
+
+        assert_eq!(persisted_count, entries.len() as i64);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn audit_append_batch_is_atomic_on_failure() {
+        let pool = test_pool().await;
+        let repo = AuditRepository::new(pool.clone());
+
+        let duplicate_id = Uuid::new_v4();
+        let duplicate_created_at = Utc::now();
+        let entries = vec![
+            AuditEntry {
+                id: duplicate_id,
+                event_type: "authorization".to_string(),
+                agent_id: None,
+                resource_type: Some("security".to_string()),
+                resource_id: None,
+                action: "duplicate_0".to_string(),
+                old_values: None,
+                new_values: None,
+                metadata: serde_json::json!({}),
+                correlation_id: None,
+                created_at: duplicate_created_at,
+            },
+            AuditEntry {
+                id: duplicate_id,
+                event_type: "authorization".to_string(),
+                agent_id: None,
+                resource_type: Some("security".to_string()),
+                resource_id: None,
+                action: "duplicate_1".to_string(),
+                old_values: None,
+                new_values: None,
+                metadata: serde_json::json!({}),
+                correlation_id: None,
+                created_at: duplicate_created_at,
+            },
+        ];
+
+        repo.append_batch(&entries)
+            .await
+            .expect_err("duplicate primary key should fail the batch");
+
+        let persisted_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM audit_log WHERE id = $1 AND created_at = $2")
+                .bind(duplicate_id)
+                .bind(duplicate_created_at)
+                .fetch_one(&pool)
+                .await
+                .expect("count query should succeed");
+
+        assert_eq!(persisted_count, 0);
     }
 
     #[tokio::test]

--- a/docs/plans/2026-03-10-ms-18-audit-batch-insert.md
+++ b/docs/plans/2026-03-10-ms-18-audit-batch-insert.md
@@ -1,0 +1,79 @@
+# MS-18 Audit Batch Insert Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the audit batch insert path with a real single-statement batched insert while preserving atomic failure semantics and adding explicit validation for the multi-row path.
+
+**Architecture:** Keep the `AuditRepository` API unchanged and constrain the behavior change to `mister-smith-persistence` by rewriting `insert_audit_batch()` to issue one PostgreSQL batch insert statement. Add targeted persistence tests that prove the batched path inserts multiple rows and rolls the whole batch back when one row conflicts.
+
+**Tech Stack:** Rust, `sqlx 0.8`, PostgreSQL, existing ignored integration tests in `crates/mister-smith-persistence/tests`
+
+---
+
+### Task 1: Red Phase For Audit Batch Coverage
+
+**Files:**
+- Modify: `crates/mister-smith-persistence/tests/repository_tests.rs`
+
+**Step 1: Write the failing test**
+
+- Add an ignored integration test that inserts a multi-entry audit batch, queries the rows back by id, and expects every entry to be present.
+- Add an ignored integration test that submits a batch containing a duplicate primary key and expects the whole batch to fail with zero persisted rows.
+
+**Step 2: Run the targeted tests to verify RED**
+
+Run:
+- `cargo test -p mister-smith-persistence audit_append_batch -- --ignored`
+- `cargo test -p mister-smith-persistence audit_append_batch_is_atomic_on_failure -- --ignored`
+
+Expected:
+- The multi-row coverage passes or remains neutral against current behavior.
+- The atomic failure test fails if the current batch path partially commits rows, otherwise it becomes the guard for the refactor.
+
+---
+
+### Task 2: Implement Single-Statement Audit Batch Insert
+
+**Files:**
+- Modify: `crates/mister-smith-persistence/src/postgres/queries.rs`
+
+**Step 1: Build the batch statement inputs**
+
+- Collect column-wise vectors for every audit entry field in `insert_audit_batch()`.
+- Keep empty-batch handling unchanged.
+
+**Step 2: Replace the per-row loop**
+
+- Execute one PostgreSQL `INSERT INTO audit_log ... SELECT * FROM UNNEST(...)` statement inside the existing transaction.
+- Keep bind types explicit where `sqlx` needs help with `Vec<Option<T>>` and JSON/UUID/timestamp arrays.
+
+**Step 3: Verify GREEN**
+
+Run:
+- `cargo test -p mister-smith-persistence`
+
+Expected:
+- Unit tests pass locally.
+- Ignored DB-backed tests are ready for an environment with `DATABASE_URL`.
+
+---
+
+### Task 3: Scope Validation
+
+**Files:**
+- No new files
+
+**Step 1: Run affected crate validation**
+
+Run:
+- `cargo test -p mister-smith-persistence`
+
+**Step 2: Run cross-workspace compile validation**
+
+Run:
+- `cargo build --workspace`
+
+**Step 3: Reconcile Linear workpad**
+
+- Check off completed plan and acceptance items.
+- Record exact commands run, plus whether ignored DB-backed tests were executable in-session.


### PR DESCRIPTION
## Problem
- `insert_audit_batch()` opened a transaction but still executed one `INSERT` per audit row.
- That meant the audit persister's batch flush path still paid one database round-trip per event.

## Solution
- Replace the per-row loop with one PostgreSQL `INSERT ... SELECT * FROM UNNEST(...)` statement.
- Keep the existing transaction boundary so batch failures remain atomic.
- Add explicit coverage for the multi-row statement shape and ignored repository tests for persisted rows and rollback behavior.

## Validation
- `cargo fmt --all`
- `cargo test -p mister-smith-persistence`
- `cargo build --workspace`
- Ignored DB-backed audit tests were not run because `DATABASE_URL` is unset in this session.
- `vet --agentic --agent-harness codex` did not complete in-session.

Linear: MS-18
