### PR TITLE
fix(http): evict expired rate limiter buckets

### DIFF
--- a/crates/mister-smith-http/src/middleware.rs
+++ b/crates/mister-smith-http/src/middleware.rs
@@ -78,9 +78,9 @@ impl RateLimiter {
     ///
     /// Returns `true` if the request is allowed, `false` if rate limited.
     pub async fn check(&self, ip: &str) -> bool {
-        let now = Instant::now();
         let window = std::time::Duration::from_secs(1);
         let mut state = self.state.lock().await;
+        let now = Instant::now();
 
         if now.duration_since(state.last_cleanup) >= window {
             state.entries.retain(|_, entry| {


### PR DESCRIPTION
## Problem
The shared HTTP `RateLimiter` kept per-IP buckets in memory even after every timestamp in the bucket had expired, so long-lived public servers could accumulate stale state from one-shot clients.

## Solution
- wrap the HTTP limiter map and cleanup timestamp in a single mutex-guarded state
- sweep expired buckets at most once per rate-limit window
- keep per-IP pruning for the current caller and add regressions for stale one-shot IP eviction plus active bucket preservation across a sweep

## Validation
- `cargo test -p mister-smith-http`
- `cargo build --workspace`
- `git diff --check`
