### PR TITLE
⚡ Bolt: Optimize checkpoint snapshot creation by avoiding cloning state values

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-11-23 - Avoiding clones in Rust iterators
+**Learning:** In Rust, iterating over references `for item in &collection` requires cloning the fields if they are needed by value. Consuming the collection by taking ownership `for item in collection` avoids `clone()` calls completely and improves memory and speed.
+**Action:** Always check if a collection is needed later in the function. If not, consume it instead of borrowing it to avoid unnecessary `.clone()` calls.

--- a/crates/mister-smith-persistence/src/repository/agent.rs
+++ b/crates/mister-smith-persistence/src/repository/agent.rs
@@ -223,11 +223,12 @@ impl AgentRepository {
 
         // Read all state from SQL
         let rows = queries::get_all_state(&self.pool, agent_id).await?;
+        let keys = rows.len();
 
         // Build snapshot as a JSON object
         let mut snapshot = serde_json::Map::new();
-        for row in &rows {
-            snapshot.insert(row.state_key.clone(), row.state_value.clone());
+        for row in rows {
+            snapshot.insert(row.state_key, row.state_value);
         }
 
         let snapshot_value = Value::Object(snapshot);
@@ -239,7 +240,7 @@ impl AgentRepository {
         debug!(
             agent_id = %agent_id,
             checkpoint_id = %checkpoint_id,
-            keys = rows.len(),
+            keys = keys,
             "Checkpoint created"
         );
 


### PR DESCRIPTION
💡 What: Changed the iterator from `&rows` to `rows` in the `checkpoint` method of `AgentRepository` to consume the vector rather than borrowing it. This allows the use of `row.state_key` and `row.state_value` directly without calling `.clone()`.
🎯 Why: Creating a checkpoint reads all state from SQL and builds a JSON object. Calling `.clone()` on potentially large `state_value` JSON objects for every row was an unnecessary performance bottleneck and memory allocation.
📊 Impact: Completely eliminates the `clone()` overhead for state keys and values during checkpoint creation, improving speed and reducing memory spikes for agents with large state.
🔬 Measurement: Run `cargo test -p mister-smith-persistence`. The tests pass, and performance during heavy checkpointing under load should improve.

---
*PR created automatically by Jules for task [1267753969823769371](https://jules.google.com/task/1267753969823769371) started by @MattMagg*