### PR TITLE
chore(deploy): scaffold autonomy observability assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           toolchain: "1.88.0"
           components: clippy, rustfmt
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
       - uses: Swatinem/rust-cache@v2
       - name: Install protoc
         uses: arduino/setup-protoc@v3
@@ -43,6 +46,8 @@ jobs:
 
           docker logs nats-server
           exit 1
+      - name: Validate deploy assets
+        run: python3 scripts/validate_deploy_assets.py
       - name: Build
         run: cargo build --workspace
       - name: Test

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,3 +34,77 @@ python3 scripts/audit_nats_permissions.py deploy
 The audit fails on wildcard `>` and `$JS.>` permissions. Documentation and spec
 Markdown are excluded on purpose so example snippets do not produce false
 positives.
+
+## Phase 10.5 autonomy observability scaffold
+
+This prep slice adds deploy-only operator assets for the blocked Phase 10.5
+autonomy view work:
+
+- `deploy/dashboards/mister-smith-autonomy.json`
+- `deploy/alerts/mister-smith-autonomy-rules.yml`
+
+These assets are intentionally standalone. They do not implement
+`AutonomyStatusView`, event aggregation, or app wiring. `MS-33` remains the
+implementation issue that must emit the runtime signals and finalize the
+placeholder queries below.
+
+### Placeholder metric mapping
+
+The new dashboard and alert rules assume typed autonomy state is exported as
+Prometheus metrics with the existing `mistersmith_` prefix. The mapping target
+is the Phase 10 `AutonomyStatusView` contract, not raw logs.
+
+| `AutonomyStatusView` field | Placeholder metric(s) | Expected labels | Used by |
+| --- | --- | --- | --- |
+| `graph` | `mistersmith_autonomy_workflows_active` | `workflow_id`, `status` | Active autonomy workflow stat |
+| `topology` | `mistersmith_autonomy_topology_info`, `mistersmith_autonomy_topology_selections_total` | `workflow_id`, `topology`, `rationale` | Topology table and selection trends |
+| `branches` | `mistersmith_autonomy_branches`, `mistersmith_autonomy_branch_checkpoint_age_seconds` | `workflow_id`, `branch_id`, `state`, `recovery_state` | Branch health panels and checkpoint staleness alert |
+| `memory_pressure` | `mistersmith_autonomy_context_pressure_ratio` | `workflow_id`, `branch_id`, `pressure_level` | Context pressure panels and critical alert |
+| `interventions` | `mistersmith_autonomy_interventions_total` | `workflow_id`, `branch_id`, `intervention`, `decision_source` | Intervention history panel and spike alert |
+| `delegation_alerts` | `mistersmith_autonomy_delegation_rejections_total` | `workflow_id`, `reason`, `scope`, `issuer`, `recipient` | Provenance rejection panel and visibility alert |
+
+### Placeholder finalization notes for `MS-33`
+
+The scaffold is intentionally opinionated but not final. `MS-33` must confirm
+or revise these assumptions when typed runtime state exists:
+
+- `mistersmith_autonomy_workflows_active` should represent operator-visible
+  active workflow count. If runtime state prefers a per-workflow info metric
+  instead, update the stat query but keep the panel.
+- `mistersmith_autonomy_topology_info` currently assumes topology rationale can
+  be emitted as a label. If the rationale text is too high-cardinality, replace
+  it with a stable rationale code and keep the human-readable text in the app
+  surface.
+- `mistersmith_autonomy_branches` assumes one gauge per branch/state. If the
+  runtime emits counters or separate health metrics instead, preserve the panel
+  intent and change only the PromQL.
+- `mistersmith_autonomy_branch_checkpoint_age_seconds` assumes "seconds since
+  last durable checkpoint" semantics. Use a freshness metric with the same
+  meaning if the implementation prefers a different name.
+- `mistersmith_autonomy_context_pressure_ratio` assumes normalized `0..1`
+  pressure semantics. The dashboard thresholds and critical alert depend on that
+  contract.
+- `mistersmith_autonomy_interventions_total` should count targeted Guard or
+  Advisor decisions only. Do not mix it with generic restart or failure metrics.
+- `mistersmith_autonomy_delegation_rejections_total` is reserved for
+  operator-visible provenance or delegation chain failures. Do not point it at
+  the existing `mistersmith_unauthorized_operations_total` counter, which is
+  broader than the Phase 10 autonomy surface.
+
+### Syntax validation commands
+
+Validate all repo-managed dashboard and alert assets with the checked-in script:
+
+```bash
+python3 scripts/validate_deploy_assets.py
+```
+
+This validator requires:
+
+- `python3` for dashboard JSON parsing
+- `ruby` with `Psych` available on `PATH` for alert rule YAML parsing
+
+The script validates:
+
+- every `deploy/dashboards/*.json` file via Python's `json` module
+- every `deploy/alerts/*.yml` or `*.yaml` file via Ruby `Psych`

--- a/deploy/alerts/mister-smith-autonomy-rules.yml
+++ b/deploy/alerts/mister-smith-autonomy-rules.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: mister-smith-autonomy-alerts
+    rules:
+      - alert: AutonomyCheckpointStale
+        expr: max by (workflow_id, branch_id) (mistersmith_autonomy_branch_checkpoint_age_seconds) > 900
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Autonomy checkpoint age exceeds 15 minutes"
+          description: "Workflow {{ $labels.workflow_id }} branch {{ $labels.branch_id }} has not published a fresh checkpoint. MS-33 must wire this metric from typed checkpoint lineage."
+
+      - alert: AutonomyInterventionSpike
+        expr: sum(increase(mistersmith_autonomy_interventions_total[10m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Autonomy interventions are spiking"
+          description: "{{ $value }} interventions were recorded in the last 10 minutes. MS-33 must finalize the intervention counter and label set from typed guard decisions."
+
+      - alert: AutonomyContextPressureCritical
+        expr: max by (workflow_id, branch_id) (mistersmith_autonomy_context_pressure_ratio) > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Autonomy context pressure is above 90%"
+          description: "Workflow {{ $labels.workflow_id }} branch {{ $labels.branch_id }} is above the assumed normalized pressure threshold. MS-33 must confirm the ratio semantics stay in the 0..1 range."
+
+      - alert: AutonomyProvenanceRejectionsDetected
+        expr: sum by (workflow_id, reason) (increase(mistersmith_autonomy_delegation_rejections_total[15m])) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Autonomy provenance rejection detected"
+          description: "Workflow {{ $labels.workflow_id }} reported delegation/provenance rejection reason {{ $labels.reason }}. This placeholder alert is reserved for operator-visible invalid-chain outcomes, not generic authorization failures."

--- a/deploy/dashboards/mister-smith-autonomy.json
+++ b/deploy/dashboards/mister-smith-autonomy.json
@@ -1,0 +1,191 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Mister Smith Framework — Phase 10 autonomy observability scaffold. All PromQL queries are placeholders that MS-33 must wire to typed AutonomyStatusView state.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "description": "Placeholder gauge for operator-visible workflow state derived from AutonomyStatusView.graph.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(mistersmith_autonomy_workflows_active)",
+          "legendFormat": "Active Workflows"
+        }
+      ],
+      "title": "Active Autonomy Workflows",
+      "type": "stat"
+    },
+    {
+      "description": "Placeholder branch-health summary from AutonomyStatusView.branches. Assumes one gauge per branch with a state label.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 3 }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(mistersmith_autonomy_branches{state=~\"degraded|failed|isolated\"})",
+          "legendFormat": "Degraded Branches"
+        }
+      ],
+      "title": "Degraded Branches",
+      "type": "stat"
+    },
+    {
+      "description": "Placeholder checkpoint freshness gauge from branch checkpoint lineage. MS-33 must emit seconds since the last durable checkpoint.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1800,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 900 }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "max(mistersmith_autonomy_branch_checkpoint_age_seconds)",
+          "legendFormat": "Checkpoint Age"
+        }
+      ],
+      "title": "Max Checkpoint Age",
+      "type": "gauge"
+    },
+    {
+      "description": "Placeholder memory-pressure ratio from AutonomyStatusView.memory_pressure. Assumes a normalized 0..1 pressure ratio.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 0.7 },
+              { "color": "red", "value": 0.9 }
+            ]
+          },
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "targets": [
+        {
+          "expr": "max(mistersmith_autonomy_context_pressure_ratio)",
+          "legendFormat": "Pressure Ratio"
+        }
+      ],
+      "title": "Max Context Pressure",
+      "type": "gauge"
+    },
+    {
+      "description": "Placeholder topology selection table from AutonomyStatusView.topology. Prefer stable rationale codes over free-form labels if label cardinality becomes unsafe.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (workflow_id, topology, rationale) (mistersmith_autonomy_topology_info)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{workflow_id}} {{topology}}"
+        }
+      ],
+      "title": "Current Topology Selection",
+      "type": "table"
+    },
+    {
+      "description": "Placeholder branch-state visibility for operator inspection. Assumes one active series per workflow and state.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (workflow_id, state) (mistersmith_autonomy_branches)",
+          "legendFormat": "{{workflow_id}} {{state}}"
+        }
+      ],
+      "title": "Branch State by Workflow",
+      "type": "timeseries"
+    },
+    {
+      "description": "Placeholder checkpoint lineage panel. MS-33 should back this with per-branch checkpoint age or freshness metrics derived from typed state.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "max by (workflow_id, branch_id) (mistersmith_autonomy_branch_checkpoint_age_seconds)",
+          "legendFormat": "{{workflow_id}} {{branch_id}}"
+        }
+      ],
+      "title": "Checkpoint Freshness by Branch",
+      "type": "timeseries"
+    },
+    {
+      "description": "Placeholder context-pressure panel. Assumes the runtime exports a normalized pressure ratio and a coarse pressure_level label.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "expr": "max by (workflow_id, branch_id, pressure_level) (mistersmith_autonomy_context_pressure_ratio)",
+          "legendFormat": "{{workflow_id}} {{branch_id}} {{pressure_level}}"
+        }
+      ],
+      "title": "Context Pressure by Branch",
+      "type": "timeseries"
+    },
+    {
+      "description": "Placeholder intervention history from AutonomyStatusView.interventions. Assumes a counter labeled by intervention type and decision source.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        {
+          "expr": "sum by (intervention) (increase(mistersmith_autonomy_interventions_total[15m]))",
+          "legendFormat": "{{intervention}}"
+        }
+      ],
+      "title": "Interventions by Type (15m)",
+      "type": "timeseries"
+    },
+    {
+      "description": "Placeholder delegation and provenance visibility from AutonomyStatusView.delegation_alerts. Intended for invalid, expired, revoked, or otherwise rejected chains only.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        {
+          "expr": "sum by (reason) (increase(mistersmith_autonomy_delegation_rejections_total[15m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "title": "Provenance Rejections by Reason (15m)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["mister-smith", "autonomy", "phase10"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Mister Smith Autonomy",
+  "uid": "mister-smith-autonomy",
+  "version": 1
+}

--- a/docs/plans/2026-03-10-ms-36-autonomy-observability-scaffold.md
+++ b/docs/plans/2026-03-10-ms-36-autonomy-observability-scaffold.md
@@ -1,0 +1,114 @@
+# MS-36 Autonomy Observability Scaffold Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add standalone Phase 10 autonomy dashboard and alert scaffolding plus deploy mapping notes without pulling blocked runtime work into scope.
+
+**Architecture:** Keep the existing overview dashboard and phase-8 alert file untouched. Add one new dashboard JSON and one new alert rules YAML that use `mistersmith_` placeholder metric names mapped directly to the `AutonomyStatusView` contract, then document the intended runtime wiring in `deploy/README.md`.
+
+**Tech Stack:** Grafana dashboard JSON, Prometheus alert rules YAML, Markdown documentation, narrow CLI syntax validation (`python3`, `ruby` with `Psych`, optional `promtool` when installed)
+
+---
+
+### Task 1: Stand up the autonomy dashboard scaffold
+
+**Files:**
+- Create: `deploy/dashboards/mister-smith-autonomy.json`
+- Reference: `deploy/dashboards/mister-smith-overview.json`
+- Reference: `specs/012-phase10-frontier-autonomy/contracts/autonomy-observability.md`
+
+**Step 1: Reuse the existing dashboard conventions**
+
+Read the current dashboard scaffold and copy its top-level structure:
+
+- `deploy/dashboards/mister-smith-overview.json`
+- Match `schemaVersion`, `tags`, `time`, `editable`, and `gridPos` style.
+
+**Step 2: Add only the Phase 10 operator surface**
+
+Create panels for:
+
+- topology choice and rationale
+- branch health
+- checkpoint freshness
+- context pressure
+- intervention history
+- delegation/provenance rejections
+
+Use placeholder `mistersmith_autonomy_*` PromQL queries and panel descriptions that explicitly say `MS-33` must wire the runtime emitters.
+
+**Step 3: Validate the dashboard syntax**
+
+Run:
+
+```bash
+python3 scripts/validate_deploy_assets.py deploy/dashboards
+```
+
+Expected: every dashboard JSON parses cleanly.
+
+### Task 2: Add autonomy alert scaffolding
+
+**Files:**
+- Create: `deploy/alerts/mister-smith-autonomy-rules.yml`
+- Reference: `deploy/alerts/mister-smith-rules.yml`
+- Reference: `specs/012-phase10-frontier-autonomy/tasks.md:221`
+
+**Step 1: Match the existing alert rule shape**
+
+Reuse the current `groups -> rules -> labels/annotations` YAML structure and severity conventions from `deploy/alerts/mister-smith-rules.yml`.
+
+**Step 2: Add the four requested autonomy alerts**
+
+Create rules for:
+
+- checkpoint staleness
+- intervention spikes
+- context pressure
+- provenance rejection visibility
+
+Use placeholder `mistersmith_autonomy_*` metrics and annotations that describe the intended operator meaning without claiming runtime support exists yet.
+
+**Step 3: Validate the YAML syntax**
+
+Run:
+
+```bash
+python3 scripts/validate_deploy_assets.py deploy/alerts
+```
+
+Expected: every alert file parses cleanly.
+
+### Task 3: Document placeholder metric mappings and validation
+
+**Files:**
+- Modify: `deploy/README.md`
+- Reference: `specs/012-phase10-frontier-autonomy/contracts/autonomy-observability.md`
+- Reference: `crates/mister-smith-monitoring/src/prometheus.rs`
+
+**Step 1: Add a Phase 10.5 scaffold section**
+
+Document:
+
+- the new dashboard and alert files
+- the mapping from `AutonomyStatusView` fields to placeholder metric names
+- the label expectations each placeholder query assumes
+
+**Step 2: Record the unresolved runtime wiring points**
+
+Call out the specific query assumptions `MS-33` must finalize, especially:
+
+- whether topology rationale is a safe Prometheus label
+- whether branch state emits one gauge per branch or aggregated counters
+- whether context pressure is normalized as a ratio
+- whether delegation rejection alerts should exclude general auth failures
+
+**Step 3: Run final narrow validation and review**
+
+Run:
+
+```bash
+python3 scripts/validate_deploy_assets.py
+```
+
+Then run `vet` against the final diff and update the Linear workpad with the validation evidence and remaining placeholders.

--- a/scripts/tests/test_validate_deploy_assets.py
+++ b/scripts/tests/test_validate_deploy_assets.py
@@ -1,0 +1,53 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_deploy_assets.py"
+
+
+class ValidateDeployAssetsScriptTests(unittest.TestCase):
+    def run_script(self, *paths: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(SCRIPT_PATH), *paths],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_valid_repository_assets_pass(self) -> None:
+        result = self.run_script(
+            "deploy/dashboards/mister-smith-autonomy.json",
+            "deploy/alerts/mister-smith-autonomy-rules.yml",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("json ok: deploy/dashboards/mister-smith-autonomy.json", result.stdout)
+        self.assertIn("yaml ok: deploy/alerts/mister-smith-autonomy-rules.yml", result.stdout)
+
+    def test_invalid_json_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            invalid_json = Path(temp_dir) / "broken.json"
+            invalid_json.write_text("{not valid json", encoding="utf-8")
+
+            result = self.run_script(str(invalid_json))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid json", result.stderr)
+
+    def test_invalid_yaml_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            invalid_yaml = Path(temp_dir) / "broken.yml"
+            invalid_yaml.write_text("groups: [broken", encoding="utf-8")
+
+            result = self.run_script(str(invalid_yaml))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid yaml", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_deploy_assets.py
+++ b/scripts/validate_deploy_assets.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Validate repo-managed Grafana dashboards and Prometheus alert rules.
+
+JSON dashboards are parsed with Python's stdlib `json` module. YAML alert rules
+are parsed with Ruby `Psych`, so this validator requires `ruby` to be available
+on `PATH`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+JSON_SUFFIXES = {".json"}
+YAML_SUFFIXES = {".yml", ".yaml"}
+DEFAULT_PATHS = ("deploy/dashboards", "deploy/alerts")
+
+
+def iter_candidates(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path] if is_candidate_file(path) else []
+
+    candidates: list[Path] = []
+    for candidate in path.rglob("*"):
+        if candidate.is_file() and is_candidate_file(candidate):
+            candidates.append(candidate)
+    return candidates
+
+
+def is_candidate_file(path: Path) -> bool:
+    return path.suffix.lower() in JSON_SUFFIXES | YAML_SUFFIXES
+
+
+def validate_json(path: Path) -> None:
+    with path.open(encoding="utf-8") as handle:
+        json.load(handle)
+
+
+def validate_yaml(path: Path) -> None:
+    ruby = shutil.which("ruby")
+    if ruby is None:
+        raise RuntimeError(
+            "ruby is required to validate YAML deploy assets; "
+            "install Ruby with Psych support or run the check in CI"
+        )
+
+    parser = (
+        "require 'psych'; "
+        "Psych.safe_load(File.read(ARGV[0]), aliases: true)"
+    )
+    subprocess.run(
+        [ruby, "-e", parser, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_PATHS),
+        help="Files or directories to validate (defaults to deploy dashboards and alerts).",
+    )
+    args = parser.parse_args()
+
+    candidates: list[Path] = []
+    for raw_path in args.paths:
+        path = Path(raw_path)
+        if not path.exists():
+            print(f"missing path: {path}", file=sys.stderr)
+            return 2
+        candidates.extend(iter_candidates(path))
+
+    unique_candidates = sorted(set(candidates))
+    if not unique_candidates:
+        print("No deploy asset files found.", file=sys.stderr)
+        return 2
+
+    validated = 0
+    for candidate in unique_candidates:
+        try:
+            if candidate.suffix.lower() in JSON_SUFFIXES:
+                validate_json(candidate)
+                print(f"json ok: {candidate}")
+            else:
+                validate_yaml(candidate)
+                print(f"yaml ok: {candidate}")
+            validated += 1
+        except json.JSONDecodeError as exc:
+            print(f"invalid json: {candidate}: {exc}", file=sys.stderr)
+            return 1
+        except subprocess.CalledProcessError as exc:
+            message = exc.stderr.strip() if exc.stderr else "ruby Psych parse failed"
+            print(f"invalid yaml: {candidate}: {message}", file=sys.stderr)
+            return 1
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+
+    print(f"deploy asset validation passed ({validated} file(s) checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Phase 10.5 needs an operator-facing autonomy dashboard and alert scaffold that is reviewable before `MS-33` wires the typed runtime state.

## Solution

- add a standalone autonomy dashboard for topology, branch health, checkpoint freshness, context pressure, interventions, and provenance rejection visibility
- add standalone autonomy alert scaffolding for checkpoint staleness, intervention spikes, context pressure, and provenance rejection visibility
- document the placeholder `AutonomyStatusView` metric mapping and finalization notes in `deploy/README.md`
- add a checked-in deploy asset validator, tests, and CI step so dashboard and alert syntax checks are automated

## Validation

- `python3 -m unittest scripts/tests/test_validate_deploy_assets.py -v`
- `python3 scripts/validate_deploy_assets.py`
- `ruby -e "require 'psych'; Psych.safe_load(File.read('.github/workflows/ci.yml'), aliases: true)"`
- `cargo build --workspace`
- `vet "Automate validation for the Phase 10 autonomy dashboard and alert scaffold by checking in a deploy asset validator and CI step, alongside the standalone scaffold assets and mapping notes" --model gpt-5.4`
