### PR TITLE
MS-27: stabilize Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,26 +31,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code Review (attempt 1)
-        id: claude-review-attempt-1
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
-      - name: Wait before retrying Claude review
-        if: steps.claude-review-attempt-1.outcome == 'failure'
-        shell: bash
-        run: sleep 15
-
-      - name: Run Claude Code Review (attempt 2)
-        id: claude-review-attempt-2
-        if: steps.claude-review-attempt-1.outcome == 'failure'
+      - name: Run Claude Code Review
+        id: claude-review
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -65,25 +47,19 @@ jobs:
         if: always()
         shell: bash
         env:
-          ATTEMPT_1_OUTCOME: ${{ steps.claude-review-attempt-1.outcome }}
-          ATTEMPT_2_OUTCOME: ${{ steps.claude-review-attempt-2.outcome }}
+          CLAUDE_REVIEW_OUTCOME: ${{ steps.claude-review.outcome }}
         run: |
           {
             echo "## Claude review status"
-            if [[ "$ATTEMPT_1_OUTCOME" == "success" ]]; then
-              echo "- Result: review completed on the first attempt."
-            elif [[ "$ATTEMPT_2_OUTCOME" == "success" ]]; then
-              echo "- Result: the first Claude review attempt exited before producing a usable review; the retry succeeded."
-              echo "- Classification: transient Claude action or SDK instability."
+            if [[ "$CLAUDE_REVIEW_OUTCOME" == "success" ]]; then
+              echo "- Result: review completed successfully."
             else
-              echo "- Result: both Claude review attempts exited before producing a usable review."
-              echo "- Classification: advisory Claude review infrastructure failure."
-              echo "- Merge posture: if \`Check\` and the other required repository validation checks pass, and there are no unresolved human review concerns, this advisory workflow should not block merge on its own."
+              echo "- Result: the Claude review step exited before producing a usable review."
+              echo "- Classification: inspect the action log before treating this as advisory infrastructure noise."
+              echo "- Merge posture: only treat this as advisory when the log shows the known SDK crash signature (\`SDK execution error: Error: Claude Code process exited with code 1\`), the PR does not change the Claude review workflow or plugin configuration, and required repository validation is green."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$ATTEMPT_1_OUTCOME" == "failure" && "$ATTEMPT_2_OUTCOME" == "success" ]]; then
-            echo "::warning title=Claude review retried successfully::The first Claude review attempt exited before producing a review; the second attempt completed successfully."
-          elif [[ "$ATTEMPT_1_OUTCOME" == "failure" && "$ATTEMPT_2_OUTCOME" == "failure" ]]; then
-            echo "::warning title=Claude review unavailable::Claude review failed twice before producing a usable review. Treat this as advisory review infrastructure noise unless the pull request changed the Claude review workflow or plugin configuration."
+          if [[ "$CLAUDE_REVIEW_OUTCOME" == "failure" ]]; then
+            echo "::warning title=Claude review requires log inspection::Check the workflow log for the known SDK crash signature before treating this failure as advisory infrastructure noise."
           fi

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -197,9 +197,12 @@ Instructions:
 
 - Treat `.github/workflows/ci.yml` (`Check`) and the other required repository validation checks as the substantive merge gate.
 - Treat `.github/workflows/claude-code-review.yml` as advisory automation.
-  If it exhausts its retry path or reports an action/SDK infrastructure failure before producing a usable review, do not block merge on that signal alone.
+  Only treat a `claude-review` failure as advisory when the log
+  shows the known SDK crash signature (`SDK execution error:
+  Error: Claude Code process exited with code 1`) and the PR does
+  not change that workflow or its plugin configuration.
 - Merge may proceed only when required repository validation is green and there are no unresolved human review findings.
-- If a pull request changes the Claude review workflow or its plugin configuration, treat a `claude-review` failure as potentially repo-local until the workflow change itself is reviewed.
+- Otherwise, treat a `claude-review` failure as potentially repo-local until the workflow change or failure mode is reviewed.
 
 ## Step 3: Human review and merge handling
 


### PR DESCRIPTION
## Problem

`Claude Code Review` has been intermittently crashing inside the Claude action or SDK before it produces a usable review. The failing runs all showed the same action SHA, Claude Code version, and plugin configuration succeeding elsewhere, which made the raw failure signal noisy for merge operators.

## Solution

- keep the review step non-blocking with explicit outcome classification in the GitHub step summary
- require log inspection for the known SDK crash signature before operators treat the failure as advisory infrastructure noise
- document the merge posture in `WORKFLOW.md` relative to the substantive `Check` workflow and other required repo validation

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/claude-code-review.yml'); puts 'validated .github/workflows/claude-code-review.yml'"`
- `npx markdownlint-cli2 WORKFLOW.md --config .markdownlint.json`
- `cargo build --workspace`
- focused diff review after the follow-up patch with no remaining findings
- `vet ...` could not produce a usable signal in this environment because API auth was missing and agentic Codex mode timed out
