### PR TITLE
⚡ Bolt: Replace Mutex<HashMap> with DashMap in HTTP RateLimiter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-17 - Serialize Request Body Outside Loop
 **Learning:** Avoid `serde_json::to_vec` and JSON serialization on each retry loop iteration, since the request payload is static. Even though `reqwest` exposes `.json()`, passing `.body()` directly with a cloned `Vec<u8>` is considerably faster and avoids excessive object creation in high-latency network retries.
 **Action:** Identify serialization inside retry loops and move it outside to save CPU cycles and reduce overall latency.
+
+## 2025-02-14 - Replace Mutex<HashMap> with DashMap in HTTP RateLimiter
+**Learning:** `tokio::sync::Mutex<HashMap>` for global state accessed by every request is a severe performance bottleneck. A mutex wraps the entire map, preventing parallel processing. `DashMap` provides fine-grained locking and allows concurrent updates across different keys (IPs). In addition, checking the cleanup timestamp via `AtomicU64` prevents blocking requests just for cleanup state tracking.
+**Action:** Default to `DashMap` or equivalent concurrent hash maps instead of `Mutex<HashMap>` for high-concurrency middleware state that receives updates frequently. For shared counters or timestamps, prefer `Atomic` types over locks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bytes",
+ "dashmap",
  "futures",
  "mister-smith-core",
  "mister-smith-monitoring",

--- a/crates/mister-smith-http/Cargo.toml
+++ b/crates/mister-smith-http/Cargo.toml
@@ -27,6 +27,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
+dashmap.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/mister-smith-http/src/middleware.rs
+++ b/crates/mister-smith-http/src/middleware.rs
@@ -10,11 +10,11 @@ use axum::extract::ConnectInfo;
 use axum::http::{HeaderValue, Request};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use std::collections::HashMap;
+use dashmap::DashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
 /// Header name for request ID tracking.
@@ -46,20 +46,16 @@ struct RateLimitEntry {
     request_times: Vec<Instant>,
 }
 
-/// Shared state guarded by the rate limiter mutex.
-struct RateLimiterState {
-    /// Per-IP request tracking.
-    entries: HashMap<String, RateLimitEntry>,
-    /// Last time the limiter swept expired buckets across all IPs.
-    last_cleanup: Instant,
-}
-
 /// Shared rate limiter state.
 pub struct RateLimiter {
     /// Maximum requests per second per IP.
     max_rps: u32,
     /// Rate limiter state.
-    state: Mutex<RateLimiterState>,
+    entries: DashMap<String, RateLimitEntry>,
+    /// Global start time used for cleanup offset calculation.
+    start: Instant,
+    /// Offset from start in seconds, identifying the last cleanup time.
+    last_cleanup_sec: AtomicU64,
 }
 
 impl RateLimiter {
@@ -67,10 +63,9 @@ impl RateLimiter {
     pub fn new(max_rps: u32) -> Self {
         Self {
             max_rps,
-            state: Mutex::new(RateLimiterState {
-                entries: HashMap::new(),
-                last_cleanup: Instant::now(),
-            }),
+            entries: DashMap::new(),
+            start: Instant::now(),
+            last_cleanup_sec: AtomicU64::new(0),
         }
     }
 
@@ -79,23 +74,34 @@ impl RateLimiter {
     /// Returns `true` if the request is allowed, `false` if rate limited.
     pub async fn check(&self, ip: &str) -> bool {
         let window = std::time::Duration::from_secs(1);
-        let mut state = self.state.lock().await;
         let now = Instant::now();
 
-        if now.duration_since(state.last_cleanup) >= window {
-            state.entries.retain(|_, entry| {
+        let elapsed_sec = now.duration_since(self.start).as_secs();
+        let last_cleanup = self.last_cleanup_sec.load(Ordering::Relaxed);
+
+        if elapsed_sec > last_cleanup
+            && self
+                .last_cleanup_sec
+                .compare_exchange(
+                    last_cleanup,
+                    elapsed_sec,
+                    Ordering::Acquire,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+        {
+            self.entries.retain(|_, entry| {
                 entry
                     .request_times
                     .last()
                     .is_some_and(|last_request| now.duration_since(*last_request) < window)
             });
-            state.last_cleanup = now;
         }
 
         let ip = ip.to_string();
         let mut remove_current_entry = false;
         let allowed = {
-            let entry = state.entries.entry(ip.clone()).or_insert(RateLimitEntry {
+            let mut entry = self.entries.entry(ip.clone()).or_insert(RateLimitEntry {
                 request_times: Vec::new(),
             });
 
@@ -114,7 +120,7 @@ impl RateLimiter {
         };
 
         if remove_current_entry {
-            state.entries.remove(&ip);
+            self.entries.remove(&ip);
         }
 
         allowed
@@ -226,12 +232,12 @@ mod tests {
             assert!(limiter.check(&ip).await);
         }
 
-        assert_eq!(limiter.state.lock().await.entries.len(), 128);
+        assert_eq!(limiter.entries.len(), 128);
 
         tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
         assert!(limiter.check("192.168.0.1").await);
-        assert_eq!(limiter.state.lock().await.entries.len(), 1);
+        assert_eq!(limiter.entries.len(), 1);
     }
 
     #[tokio::test]
@@ -244,7 +250,7 @@ mod tests {
 
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
         assert!(limiter.check("10.0.0.2").await);
-        assert_eq!(limiter.state.lock().await.entries.len(), 2);
+        assert_eq!(limiter.entries.len(), 2);
 
         assert!(limiter.check("10.0.0.1").await);
         assert!(!limiter.check("10.0.0.1").await);


### PR DESCRIPTION
💡 **What:** Replaces a `tokio::sync::Mutex` protecting a standard `HashMap` in the HTTP `RateLimiter` middleware with a `dashmap::DashMap`, and uses an `AtomicU64` for tracking cleanup intervals.

🎯 **Why:** The `Mutex<HashMap>` caused all incoming requests across all client IPs to lock the same mutex to check and update its rate limit, creating a single bottleneck that restricted parallel processing and overall throughput.

📊 **Impact:** Eliminates global lock contention. Significantly improves concurrency and server throughput, particularly when handling a high volume of requests from many different clients simultaneously.

🔬 **Measurement:** `cargo test -p mister-smith-http` passes locally (including `rate_limiter_per_ip_isolation` and `rate_limiter_preserves_active_buckets_across_cleanup_sweep`). The improvement can be verified under load using a tool like `wrk` or `hey` to measure maximum RPS and 95th/99th percentile latencies before and after the change.

---
*PR created automatically by Jules for task [10403523922911030894](https://jules.google.com/task/10403523922911030894) started by @MattMagg*