### PR TITLE
MS-42: add delegation prep harness

### DIFF
--- a/crates/mister-smith-security/tests/delegation_tests.rs
+++ b/crates/mister-smith-security/tests/delegation_tests.rs
@@ -1,0 +1,142 @@
+//! Prep-only delegation test harness for Phase 10 bounded delegation scenarios.
+
+use std::time::Duration;
+
+use mister_smith_core::SecurityError;
+use mister_smith_security::config::{JwtConfig, KeySource};
+use mister_smith_security::jwt::{AgentClaims, JwtManager, DEFAULT_MAX_DELEGATION_CHAIN_DEPTH};
+
+struct DelegationHarness {
+    jwt_manager: JwtManager,
+    secret: Vec<u8>,
+}
+
+impl DelegationHarness {
+    fn new(access_token_ttl: Duration) -> Self {
+        let secret = b"delegation-test-secret-key-for-hmac-256-min-32-bytes!!".to_vec();
+        let config = JwtConfig {
+            algorithm: "HS256".to_string(),
+            access_token_ttl,
+            refresh_token_ttl: Duration::from_secs(3_600),
+            issuer: Some("mister-smith-delegation-tests".to_string()),
+            audience: vec!["delegation-tests".to_string()],
+            delegation_chain_max_depth: DEFAULT_MAX_DELEGATION_CHAIN_DEPTH,
+            key_source: KeySource::Hmac {
+                secret: secret.clone(),
+            },
+        };
+
+        Self {
+            jwt_manager: JwtManager::new(&config).expect("delegation harness should initialize"),
+            secret,
+        }
+    }
+
+    fn delegated_claims(&self, child_agent_id: &str) -> AgentClaims {
+        parent_claims().delegated_to(child_agent_id.to_string(), "worker".to_string())
+    }
+
+    fn issue_access_token(&self, claims: &AgentClaims) -> String {
+        self.jwt_manager
+            .generate_token_pair(claims)
+            .expect("delegated token generation should succeed")
+            .access_token
+    }
+
+    fn encode_raw(&self, claims: &AgentClaims) -> String {
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            claims,
+            &jsonwebtoken::EncodingKey::from_secret(&self.secret),
+        )
+        .expect("raw delegated claims should encode")
+    }
+}
+
+fn parent_claims() -> AgentClaims {
+    AgentClaims {
+        sub: "coordinator-1".to_string(),
+        agent_id: "coordinator-1".to_string(),
+        agent_type: "coordinator".to_string(),
+        capabilities: vec!["delegate".to_string()],
+        permissions: vec!["execute:privileged:workflow".to_string()],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn delegation_valid_chain_roundtrip_survives_issue_and_validation() {
+    let harness = DelegationHarness::new(Duration::from_secs(300));
+    let delegated_claims = harness.delegated_claims("executor-1");
+
+    let access_token = harness.issue_access_token(&delegated_claims);
+    let validated = harness
+        .jwt_manager
+        .validate_token(&access_token)
+        .expect("delegated access token should validate");
+
+    assert_eq!(validated.agent_id, "executor-1");
+    assert_eq!(validated.agent_type, "worker");
+    assert_eq!(validated.delegation_chain, vec!["coordinator-1"]);
+}
+
+#[test]
+fn delegation_expired_token_is_rejected_for_delegated_claims() {
+    let harness = DelegationHarness::new(Duration::from_secs(0));
+    let delegated_claims = harness.delegated_claims("executor-expiring");
+
+    let access_token = harness.issue_access_token(&delegated_claims);
+
+    std::thread::sleep(Duration::from_secs(6));
+
+    assert!(matches!(
+        harness.jwt_manager.validate_token(&access_token),
+        Err(SecurityError::TokenExpired)
+    ));
+}
+
+#[test]
+fn delegation_revoked_token_is_rejected_for_delegated_claims() {
+    let harness = DelegationHarness::new(Duration::from_secs(300));
+    let delegated_claims = harness.delegated_claims("executor-revoked");
+
+    let access_token = harness.issue_access_token(&delegated_claims);
+    let validated = harness
+        .jwt_manager
+        .validate_token(&access_token)
+        .expect("delegated token should validate before revocation");
+
+    harness.jwt_manager.revoke_token(&validated.jti);
+
+    assert!(matches!(
+        harness.jwt_manager.validate_token(&access_token),
+        Err(SecurityError::TokenRevoked)
+    ));
+}
+
+#[test]
+fn delegation_cyclic_chain_is_rejected_during_validation() {
+    let harness = DelegationHarness::new(Duration::from_secs(300));
+    let now = chrono::Utc::now().timestamp() as u64;
+    let cyclic_claims = AgentClaims {
+        iss: Some("mister-smith-delegation-tests".to_string()),
+        sub: "executor-cycle".to_string(),
+        aud: vec!["delegation-tests".to_string()],
+        exp: now + 300,
+        iat: now,
+        jti: uuid::Uuid::new_v4().to_string(),
+        agent_id: "executor-cycle".to_string(),
+        agent_type: "worker".to_string(),
+        delegation_chain: vec!["root-agent".to_string(), "executor-cycle".to_string()],
+        token_use: "access".to_string(),
+        ..Default::default()
+    };
+
+    let forged_token = harness.encode_raw(&cyclic_claims);
+
+    assert!(matches!(
+        harness.jwt_manager.validate_token(&forged_token),
+        Err(SecurityError::InvalidToken(message))
+            if message.contains("delegation_chain contains a circular reference")
+    ));
+}

--- a/crates/mister-smith-security/tests/jwt_tests.rs
+++ b/crates/mister-smith-security/tests/jwt_tests.rs
@@ -264,6 +264,45 @@ fn delegation_propagation_roundtrip() {
 }
 
 #[test]
+fn delegation_expired_child_token_is_rejected() {
+    let config = JwtConfig {
+        access_token_ttl: Duration::from_secs(0),
+        ..hmac_config()
+    };
+    let mgr = JwtManager::new(&config).unwrap();
+    let mut parent = test_claims();
+    parent.agent_type = "coordinator".to_string();
+    let child = parent.delegated_to("agent-expiring", "worker");
+
+    let pair = mgr.generate_token_pair(&child).unwrap();
+
+    std::thread::sleep(Duration::from_secs(6));
+
+    assert!(matches!(
+        mgr.validate_token(&pair.access_token),
+        Err(mister_smith_core::SecurityError::TokenExpired)
+    ));
+}
+
+#[test]
+fn delegation_revoked_child_token_is_rejected() {
+    let mgr = JwtManager::new(&hmac_config()).unwrap();
+    let mut parent = test_claims();
+    parent.agent_type = "coordinator".to_string();
+    let child = parent.delegated_to("agent-revoked", "worker");
+
+    let pair = mgr.generate_token_pair(&child).unwrap();
+    let validated = mgr.validate_token(&pair.access_token).unwrap();
+
+    mgr.revoke_token(&validated.jti);
+
+    assert!(matches!(
+        mgr.validate_token(&pair.access_token),
+        Err(mister_smith_core::SecurityError::TokenRevoked)
+    ));
+}
+
+#[test]
 fn delegation_empty_entry_rejected_on_issue() {
     let mgr = JwtManager::new(&hmac_config()).unwrap();
     let mut claims = test_claims();


### PR DESCRIPTION
## Problem
MS-42 is the prep-only T036 slice for Phase 10.6 bounded delegation and provenance. The main 10.6 implementation remains blocked, but the security test surface needed explicit prep coverage for delegated validity, expiry, revocation, and cyclic-chain rejection.

## Solution
- add `crates/mister-smith-security/tests/delegation_tests.rs` as a prep-only delegation harness on top of the existing JWT delegation-chain substrate
- extend `crates/mister-smith-security/tests/jwt_tests.rs` with delegated-child expiry and revocation coverage
- keep scope strictly inside the existing Phase 9.1 JWT/delegation-chain substrate without introducing the blocked Phase 10 delegation runtime API

## Validation
- `cargo test -p mister-smith-security --test delegation_tests --test jwt_tests delegation`
- `cargo test -p mister-smith-security`
- `cargo build --workspace`
- `vet "MS-42 T036 prep-only delegation test harness in mister-smith-security"` (blocked: `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` unset; `--agentic --agent-harness codex` produced no usable result)
