### PR TITLE
⚡ Bolt: Avoid cloning heavy TaskAssignment structs during scheduler evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-02-17 - Serialize Request Body Outside Loop
 **Learning:** Avoid `serde_json::to_vec` and JSON serialization on each retry loop iteration, since the request payload is static. Even though `reqwest` exposes `.json()`, passing `.body()` directly with a cloned `Vec<u8>` is considerably faster and avoids excessive object creation in high-latency network retries.
 **Action:** Identify serialization inside retry loops and move it outside to save CPU cycles and reduce overall latency.
+
+## 2025-03-05 - [Optimize DashMap Iteration]
+**Learning:** Extracting full structs containing heavy `serde_json::Value` fields using `.map(|e| e.clone()).collect()` from a `DashMap` is extremely expensive when done repeatedly in hot paths like `DeadlineMonitor` ticks or `all_subtasks_completed` checks.
+**Action:** Use `.filter_map` to map directly to lightweight types (like `TaskId`) or evaluate states against references using `.iter().all()` to avoid deep clones and large vector allocations entirely.

--- a/crates/mister-smith-agents/src/orchestrator.rs
+++ b/crates/mister-smith-agents/src/orchestrator.rs
@@ -445,8 +445,7 @@ impl Orchestrator {
 
     /// Check if all subtasks of a parent task are completed.
     pub fn all_subtasks_completed(&self, parent_task_id: &TaskId) -> bool {
-        let subtasks = self.scheduler.subtasks(parent_task_id);
-        !subtasks.is_empty() && subtasks.iter().all(|t| t.state == TaskState::Completed)
+        self.scheduler.all_subtasks_completed(parent_task_id)
     }
 
     /// Get subtasks that are pending and have all dependencies satisfied.

--- a/crates/mister-smith-agents/src/scheduler.rs
+++ b/crates/mister-smith-agents/src/scheduler.rs
@@ -279,6 +279,21 @@ impl TaskScheduler {
             .collect()
     }
 
+    /// Check if all subtasks of a parent task are completed without cloning.
+    pub fn all_subtasks_completed(&self, parent_id: &TaskId) -> bool {
+        let mut has_subtasks = false;
+        let all_completed = self.tasks.iter().all(|e| {
+            let task = e.value();
+            if task.parent_task_id.as_ref() == Some(parent_id) {
+                has_subtasks = true;
+                task.state == TaskState::Completed
+            } else {
+                true // Ignore tasks that aren't subtasks of this parent
+            }
+        });
+        has_subtasks && all_completed
+    }
+
     /// Get count of tracked tasks.
     pub fn count(&self) -> usize {
         self.tasks.len()
@@ -338,22 +353,24 @@ impl DeadlineMonitor {
                     _ = ticker.tick() => {
                         let now = Utc::now();
                         // Check running and assigned tasks for deadline expiry
-                        let active: Vec<TaskAssignment> = scheduler
+                        let expired_tasks: Vec<TaskId> = scheduler
                             .tasks
                             .iter()
-                            .filter(|e| {
-                                matches!(e.value().state, TaskState::Running | TaskState::Assigned)
-                                    && e.value().deadline.is_some()
+                            .filter_map(|e| {
+                                let task = e.value();
+                                if matches!(task.state, TaskState::Running | TaskState::Assigned) {
+                                    if let Some(deadline) = task.deadline {
+                                        if now > deadline {
+                                            return Some(task.task_id);
+                                        }
+                                    }
+                                }
+                                None
                             })
-                            .map(|e| e.value().clone())
                             .collect();
 
-                        for task in active {
-                            if let Some(deadline) = task.deadline {
-                                if now > deadline {
-                                    let _ = scheduler.timeout(&task.task_id);
-                                }
-                            }
+                        for task_id in expired_tasks {
+                            let _ = scheduler.timeout(&task_id);
                         }
                     }
                     _ = stop_rx.changed() => {


### PR DESCRIPTION
💡 **What:** Refactored `DeadlineMonitor::start` and `all_subtasks_completed` in `mister-smith-agents` to prevent expensive deep clones of `TaskAssignment` structs.
🎯 **Why:** `TaskAssignment` contains potentially large `serde_json::Value` payloads in its `input` and `output` fields. The deadline monitor ticks repeatedly and `all_subtasks_completed` is called frequently by the orchestrator. Iterating over the `DashMap` and mapping to a new `Vec` of cloned structs (`.map(|e| e.value().clone()).collect()`) caused massive heap allocation overhead on every check.
📊 **Impact:** Massively reduces CPU overhead and garbage collection/heap fragmentation by entirely eliminating unnecessary clones. Replaces O(N) memory allocation with O(1) in `all_subtasks_completed` and O(E) in `DeadlineMonitor`, where E is strictly the number of expired tasks.
🔬 **Measurement:** Verify by running `cargo test -p mister-smith-agents` and monitoring memory profiles. The `test_deadline_timeout` and `test_orchestrator_decompose_and_aggregate` tests confirm correctness is maintained while avoiding intermediate vector allocations.

---
*PR created automatically by Jules for task [14011138208525247368](https://jules.google.com/task/14011138208525247368) started by @MattMagg*