### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix rate limiting IP spoofing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-15 - [CRITICAL] Fix rate limiting IP spoofing vulnerability
+**Vulnerability:** The HTTP authentication middleware (`axum_mw.rs`) used the `X-Forwarded-For` header to determine the client's IP address for rate limiting. This header is easily spoofed by an attacker, allowing them to bypass rate limiting completely by injecting arbitrary IPs in every request.
+**Learning:** Security middleware should never trust client-provided headers for critical security controls like rate limiting unless the application is deployed behind a trusted reverse proxy that explicitly sanitizes and guarantees the header's integrity. Here, the raw fallback logic was inherently vulnerable.
+**Prevention:** Use the actual transport layer peer IP. In Axum, this is reliably extracted via the `axum::extract::ConnectInfo<std::net::SocketAddr>` extension, which provides the true TCP connection origin.

--- a/crates/mister-smith-security/src/middleware/axum_mw.rs
+++ b/crates/mister-smith-security/src/middleware/axum_mw.rs
@@ -34,13 +34,12 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // Rate limiting — use peer address or fallback
+    // Rate limiting — use peer address to prevent X-Forwarded-For spoofing
     let source = request
-        .headers()
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("unknown")
-        .to_string();
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|axum::extract::ConnectInfo(addr)| addr.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
 
     if let Err(retry_after) = security.rate_limiter.check(&source) {
         #[cfg(feature = "audit")]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The HTTP authentication middleware (`axum_mw.rs`) used the `X-Forwarded-For` header to determine the client's IP address for rate limiting. This allowed an attacker to completely bypass rate limiting by injecting arbitrary IPs in every request.
🎯 Impact: Attackers could perform DoS attacks or brute-force endpoints without triggering rate limits, potentially leading to service degradation or unauthorized access.
🔧 Fix: Updated the middleware to use Axum's `axum::extract::ConnectInfo<std::net::SocketAddr>` extension to extract the true transport layer peer IP instead of trusting client-provided headers.
✅ Verification: Ran `cargo test -p mister-smith-security` and `cargo test -p mister-smith-http` to ensure changes didn't break existing behavior. Added a journal entry to `.jules/sentinel.md` capturing the learning.

---
*PR created automatically by Jules for task [14675593301435380692](https://jules.google.com/task/14675593301435380692) started by @MattMagg*