### PR TITLE
docs(phase10): close gate and refresh SpecKit

### DIFF
--- a/.codex/prompts/speckit.analyze.md
+++ b/.codex/prompts/speckit.analyze.md
@@ -1,8 +1,5 @@
 ---
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
 ---
 
 ## User Input
@@ -21,13 +18,13 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 **STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
 
-**Constitution Authority**: The project constitution (`/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
 
 ## Execution Steps
 
 ### 1. Initialize Analysis Context
 
-Run `{SCRIPT}` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
 
 - SPEC = FEATURE_DIR/spec.md
 - PLAN = FEATURE_DIR/plan.md
@@ -65,7 +62,7 @@ Load only the minimal necessary context from each artifact:
 
 **From constitution:**
 
-- Load `/memory/constitution.md` for principle validation
+- Load `.specify/memory/constitution.md` for principle validation
 
 ### 3. Build Semantic Models
 
@@ -184,4 +181,4 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 
 ## Context
 
-{ARGS}
+$ARGUMENTS

--- a/.codex/prompts/speckit.checklist.md
+++ b/.codex/prompts/speckit.checklist.md
@@ -1,8 +1,5 @@
 ---
 description: Generate a custom checklist for the current feature based on user requirements.
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json
-  ps: scripts/powershell/check-prerequisites.ps1 -Json
 ---
 
 ## Checklist Purpose: "Unit Tests for English"
@@ -36,7 +33,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Execution Steps
 
-1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
    - All file paths must be absolute.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
@@ -207,7 +204,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - ✅ "Are [edge cases/scenarios] addressed in requirements?"
    - ✅ "Does the spec define [missing aspect]?"
 
-6. **Structure Reference**: Generate the checklist following the canonical template in `templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
 
 7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
    - Focus areas selected

--- a/.codex/prompts/speckit.clarify.md
+++ b/.codex/prompts/speckit.clarify.md
@@ -4,9 +4,6 @@ handoffs:
   - label: Build Technical Plan
     agent: speckit.plan
     prompt: Create a plan for the spec. I am building with...
-scripts:
-   sh: scripts/bash/check-prerequisites.sh --json --paths-only
-   ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
 ---
 
 ## User Input
@@ -25,7 +22,7 @@ Note: This clarification workflow is expected to run (and be completed) BEFORE i
 
 Execution steps:
 
-1. Run `{SCRIPT}` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
    - `FEATURE_DIR`
    - `FEATURE_SPEC`
    - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
@@ -181,4 +178,4 @@ Behavior rules:
 - If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
-Context for prioritization: {ARGS}
+Context for prioritization: $ARGUMENTS

--- a/.codex/prompts/speckit.implement.md
+++ b/.codex/prompts/speckit.implement.md
@@ -1,8 +1,5 @@
 ---
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
 ---
 
 ## User Input
@@ -49,7 +46,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
    - Scan all checklist files in the checklists/ directory

--- a/.codex/prompts/speckit.plan.md
+++ b/.codex/prompts/speckit.plan.md
@@ -8,12 +8,6 @@ handoffs:
   - label: Create Checklist
     agent: speckit.checklist
     prompt: Create a checklist for the following domain...
-scripts:
-  sh: scripts/bash/setup-plan.sh --json
-  ps: scripts/powershell/setup-plan.ps1 -Json
-agent_scripts:
-  sh: scripts/bash/update-agent-context.sh __AGENT__
-  ps: scripts/powershell/update-agent-context.ps1 -AgentType __AGENT__
 ---
 
 ## User Input
@@ -26,9 +20,9 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
@@ -82,7 +76,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
 3. **Agent context update**:
-   - Run `{AGENT_SCRIPT}`
+   - Run `.specify/scripts/bash/update-agent-context.sh codex`
    - These scripts detect which AI agent is in use
    - Update the appropriate agent-specific context file
    - Add only new technology from current plan

--- a/.codex/prompts/speckit.specify.md
+++ b/.codex/prompts/speckit.specify.md
@@ -8,9 +8,6 @@ handoffs:
     agent: speckit.clarify
     prompt: Clarify specification requirements
     send: true
-scripts:
-  sh: scripts/bash/create-new-feature.sh --json "{ARGS}"
-  ps: scripts/powershell/create-new-feature.ps1 -Json "{ARGS}"
 ---
 
 ## User Input
@@ -23,7 +20,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `{ARGS}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
 
 Given that feature description, do this:
 
@@ -39,39 +36,20 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create the feature branch** by running the script with `--short-name` (and `--json`), and do NOT pass `--number` (the script auto-detects the next globally available number across all branches and spec directories):
 
-   a. First, fetch all remote branches to ensure we have the latest information:
-
-      ```bash
-      git fetch --all --prune
-      ```
-
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `{SCRIPT}` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `{SCRIPT} --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `{SCRIPT} -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   - Bash example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" --json --short-name "user-auth" "Add user authentication"`
+   - PowerShell example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Do NOT pass `--number` — the script determines the correct next number automatically
+   - Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
 
-3. Load `templates/spec-template.md` to understand required sections.
+3. Load `.specify/templates/spec-template.md` to understand required sections.
 
 4. Follow this execution flow:
 
@@ -148,7 +126,7 @@ Given that feature description, do this:
 
    c. **Handle Validation Results**:
 
-      - **If all items pass**: Mark checklist complete and proceed to step 6
+      - **If all items pass**: Mark checklist complete and proceed to step 7
 
       - **If items fail (excluding [NEEDS CLARIFICATION])**:
         1. List the failing items and specific issues
@@ -196,8 +174,6 @@ Given that feature description, do this:
 7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
-
-## General Guidelines
 
 ## Quick Guidelines
 

--- a/.codex/prompts/speckit.tasks.md
+++ b/.codex/prompts/speckit.tasks.md
@@ -9,9 +9,6 @@ handoffs:
     agent: speckit.implement
     prompt: Start the implementation in phases
     send: true
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json
-  ps: scripts/powershell/check-prerequisites.ps1 -Json
 ---
 
 ## User Input
@@ -58,7 +55,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. **Setup**: Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
@@ -76,7 +73,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Create parallel execution examples per user story
    - Validate task completeness (each user story has all needed tasks, independently testable)
 
-4. **Generate tasks.md**: Use `templates/tasks-template.md` as structure, fill with:
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
    - Correct feature name from plan.md
    - Phase 1: Setup tasks (project initialization)
    - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
@@ -126,7 +123,7 @@ You **MUST** consider the user input before proceeding (if not empty).
        ```
    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
-Context for task generation: {ARGS}
+Context for task generation: $ARGUMENTS
 
 The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
 

--- a/.codex/prompts/speckit.taskstoissues.md
+++ b/.codex/prompts/speckit.taskstoissues.md
@@ -1,9 +1,6 @@
 ---
 description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
 tools: ['github/github-mcp-server/issue_write']
-scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
 ---
 
 ## User Input
@@ -16,7 +13,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 1. From the executed script, extract the path to **tasks**.
 1. Get the Git remote by running:
 

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,9 @@
+{
+  "ai": "codex",
+  "ai_commands_dir": null,
+  "ai_skills": false,
+  "here": true,
+  "preset": null,
+  "script": "sh",
+  "speckit_version": "0.3.0"
+}

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -79,15 +79,28 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
-        printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
-            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
+        if has_jq; then
+            jq -cn \
+                --arg repo_root "$REPO_ROOT" \
+                --arg branch "$CURRENT_BRANCH" \
+                --arg feature_dir "$FEATURE_DIR" \
+                --arg feature_spec "$FEATURE_SPEC" \
+                --arg impl_plan "$IMPL_PLAN" \
+                --arg tasks "$TASKS" \
+                '{REPO_ROOT:$repo_root,BRANCH:$branch,FEATURE_DIR:$feature_dir,FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,TASKS:$tasks}'
+        else
+            printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
+                "$(json_escape "$REPO_ROOT")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$TASKS")"
+        fi
     else
         echo "REPO_ROOT: $REPO_ROOT"
         echo "BRANCH: $CURRENT_BRANCH"
@@ -141,14 +154,25 @@ fi
 # Output results
 if $JSON_MODE; then
     # Build JSON array of documents
-    if [[ ${#docs[@]} -eq 0 ]]; then
-        json_docs="[]"
+    if has_jq; then
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '%s\n' "${docs[@]}" | jq -R . | jq -s .)
+        fi
+        jq -cn \
+            --arg feature_dir "$FEATURE_DIR" \
+            --argjson docs "$json_docs" \
+            '{FEATURE_DIR:$feature_dir,AVAILABLE_DOCS:$docs}'
     else
-        json_docs=$(printf '"%s",' "${docs[@]}")
-        json_docs="[${json_docs%,}]"
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '"%s",' "${docs[@]}")
+            json_docs="[${json_docs%,}]"
+        fi
+        printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$(json_escape "$FEATURE_DIR")" "$json_docs"
     fi
-    
-    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$FEATURE_DIR" "$json_docs"
 else
     # Text output
     echo "FEATURE_DIR:$FEATURE_DIR"

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -120,7 +120,7 @@ find_feature_dir_by_prefix() {
         # Multiple matches - this shouldn't happen with proper naming convention
         echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
         echo "Please ensure only one spec directory exists per numeric prefix." >&2
-        echo "$specs_dir/$branch_name"  # Return something to avoid breaking the script
+        return 1
     fi
 }
 
@@ -134,23 +134,120 @@ get_feature_paths() {
     fi
 
     # Use prefix-based lookup to support multiple branches per spec
-    local feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
+    local feature_dir
+    if ! feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch"); then
+        echo "ERROR: Failed to resolve feature directory" >&2
+        return 1
+    fi
 
-    cat <<EOF
-REPO_ROOT='$repo_root'
-CURRENT_BRANCH='$current_branch'
-HAS_GIT='$has_git_repo'
-FEATURE_DIR='$feature_dir'
-FEATURE_SPEC='$feature_dir/spec.md'
-IMPL_PLAN='$feature_dir/plan.md'
-TASKS='$feature_dir/tasks.md'
-RESEARCH='$feature_dir/research.md'
-DATA_MODEL='$feature_dir/data-model.md'
-QUICKSTART='$feature_dir/quickstart.md'
-CONTRACTS_DIR='$feature_dir/contracts'
-EOF
+    # Use printf '%q' to safely quote values, preventing shell injection
+    # via crafted branch names or paths containing special characters
+    printf 'REPO_ROOT=%q\n' "$repo_root"
+    printf 'CURRENT_BRANCH=%q\n' "$current_branch"
+    printf 'HAS_GIT=%q\n' "$has_git_repo"
+    printf 'FEATURE_DIR=%q\n' "$feature_dir"
+    printf 'FEATURE_SPEC=%q\n' "$feature_dir/spec.md"
+    printf 'IMPL_PLAN=%q\n' "$feature_dir/plan.md"
+    printf 'TASKS=%q\n' "$feature_dir/tasks.md"
+    printf 'RESEARCH=%q\n' "$feature_dir/research.md"
+    printf 'DATA_MODEL=%q\n' "$feature_dir/data-model.md"
+    printf 'QUICKSTART=%q\n' "$feature_dir/quickstart.md"
+    printf 'CONTRACTS_DIR=%q\n' "$feature_dir/contracts"
+}
+
+# Check if jq is available for safe JSON construction
+has_jq() {
+    command -v jq >/dev/null 2>&1
+}
+
+# Escape a string for safe embedding in a JSON value (fallback when jq is unavailable).
+# Handles backslash, double-quote, and control characters (newline, tab, carriage return).
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    printf '%s' "$s"
 }
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+
+# Resolve a template name to a file path using the priority stack:
+#   1. .specify/templates/overrides/
+#   2. .specify/presets/<preset-id>/templates/ (sorted by priority from .registry)
+#   3. .specify/extensions/<ext-id>/templates/
+#   4. .specify/templates/ (core)
+resolve_template() {
+    local template_name="$1"
+    local repo_root="$2"
+    local base="$repo_root/.specify/templates"
+
+    # Priority 1: Project overrides
+    local override="$base/overrides/${template_name}.md"
+    [ -f "$override" ] && echo "$override" && return 0
+
+    # Priority 2: Installed presets (sorted by priority from .registry)
+    local presets_dir="$repo_root/.specify/presets"
+    if [ -d "$presets_dir" ]; then
+        local registry_file="$presets_dir/.registry"
+        if [ -f "$registry_file" ] && command -v python3 >/dev/null 2>&1; then
+            # Read preset IDs sorted by priority (lower number = higher precedence)
+            local sorted_presets
+            sorted_presets=$(SPECKIT_REGISTRY="$registry_file" python3 -c "
+import json, sys, os
+try:
+    with open(os.environ['SPECKIT_REGISTRY']) as f:
+        data = json.load(f)
+    presets = data.get('presets', {})
+    for pid, meta in sorted(presets.items(), key=lambda x: x[1].get('priority', 10)):
+        print(pid)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null)
+            if [ $? -eq 0 ] && [ -n "$sorted_presets" ]; then
+                while IFS= read -r preset_id; do
+                    local candidate="$presets_dir/$preset_id/templates/${template_name}.md"
+                    [ -f "$candidate" ] && echo "$candidate" && return 0
+                done <<< "$sorted_presets"
+            else
+                # python3 returned empty list — fall through to directory scan
+                for preset in "$presets_dir"/*/; do
+                    [ -d "$preset" ] || continue
+                    local candidate="$preset/templates/${template_name}.md"
+                    [ -f "$candidate" ] && echo "$candidate" && return 0
+                done
+            fi
+        else
+            # Fallback: alphabetical directory order (no python3 available)
+            for preset in "$presets_dir"/*/; do
+                [ -d "$preset" ] || continue
+                local candidate="$preset/templates/${template_name}.md"
+                [ -f "$candidate" ] && echo "$candidate" && return 0
+            done
+        fi
+    fi
+
+    # Priority 3: Extension-provided templates
+    local ext_dir="$repo_root/.specify/extensions"
+    if [ -d "$ext_dir" ]; then
+        for ext in "$ext_dir"/*/; do
+            [ -d "$ext" ] || continue
+            # Skip hidden directories (e.g. .backup, .cache)
+            case "$(basename "$ext")" in .*) continue;; esac
+            local candidate="$ext/templates/${template_name}.md"
+            [ -f "$candidate" ] && echo "$candidate" && return 0
+        done
+    fi
+
+    # Priority 4: Core templates
+    local core="$base/${template_name}.md"
+    [ -f "$core" ] && echo "$core" && return 0
+
+    # Return success with empty output so callers using set -e don't abort;
+    # callers check [ -n "$TEMPLATE" ] to detect "not found".
+    return 0
+}
 

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -162,10 +162,22 @@ clean_branch_name() {
     echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
 }
 
+# Escape a string for safe embedding in a JSON value (fallback when jq is unavailable).
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    printf '%s' "$s"
+}
+
 # Resolve repository root. Prefer git information when available, but fall back
 # to searching for repository markers so the workflow still functions in repositories that
 # were initialised with --no-git.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
     REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -296,18 +308,26 @@ fi
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
+TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT")
 SPEC_FILE="$FEATURE_DIR/spec.md"
-if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
+if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
 
-# Set the SPECIFY_FEATURE environment variable for the current session
-export SPECIFY_FEATURE="$BRANCH_NAME"
+# Inform the user how to persist the feature variable in their own shell
+printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg branch_name "$BRANCH_NAME" \
+            --arg spec_file "$SPEC_FILE" \
+            --arg feature_num "$FEATURE_NUM" \
+            '{BRANCH_NAME:$branch_name,SPEC_FILE:$spec_file,FEATURE_NUM:$feature_num}'
+    else
+        printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")"
+    fi
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"
     echo "FEATURE_NUM: $FEATURE_NUM"
-    echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
+    printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
 fi

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -28,7 +28,9 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
 # Check if we're on a proper feature branch (only for git repos)
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
@@ -37,20 +39,30 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 mkdir -p "$FEATURE_DIR"
 
 # Copy plan template if it exists
-TEMPLATE="$REPO_ROOT/.specify/templates/plan-template.md"
-if [[ -f "$TEMPLATE" ]]; then
+TEMPLATE=$(resolve_template "plan-template" "$REPO_ROOT")
+if [[ -n "$TEMPLATE" ]] && [[ -f "$TEMPLATE" ]]; then
     cp "$TEMPLATE" "$IMPL_PLAN"
     echo "Copied plan template to $IMPL_PLAN"
 else
-    echo "Warning: Plan template not found at $TEMPLATE"
+    echo "Warning: Plan template not found"
     # Create a basic plan file if template doesn't exist
     touch "$IMPL_PLAN"
 fi
 
 # Output results
 if $JSON_MODE; then
-    printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
-        "$FEATURE_SPEC" "$IMPL_PLAN" "$FEATURE_DIR" "$CURRENT_BRANCH" "$HAS_GIT"
+    if has_jq; then
+        jq -cn \
+            --arg feature_spec "$FEATURE_SPEC" \
+            --arg impl_plan "$IMPL_PLAN" \
+            --arg specs_dir "$FEATURE_DIR" \
+            --arg branch "$CURRENT_BRANCH" \
+            --arg has_git "$HAS_GIT" \
+            '{FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,SPECS_DIR:$specs_dir,BRANCH:$branch,HAS_GIT:$has_git}'
+    else
+        printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
+            "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$HAS_GIT")"
+    fi
 else
     echo "FEATURE_SPEC: $FEATURE_SPEC"
     echo "IMPL_PLAN: $IMPL_PLAN" 

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -30,12 +30,12 @@
 #
 # 5. Multi-Agent Support
 #    - Handles agent-specific file paths and naming conventions
-#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, Kiro CLI, or Antigravity
+#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, Tabnine CLI, Kiro CLI, Mistral Vibe, Kimi Code, Antigravity or Generic
 #    - Can update single agents or all existing agent files
 #    - Creates default Claude file if no agent files exist
 #
 # Usage: ./update-agent-context.sh [agent_type]
-# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|kiro-cli|agy|bob|qodercli
+# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic
 # Leave empty to update all existing agent files
 
 set -e
@@ -53,7 +53,9 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
 NEW_PLAN="$IMPL_PLAN"  # Alias for compatibility with existing code
 AGENT_TYPE="${1:-}"
@@ -71,11 +73,16 @@ AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 CODEBUDDY_FILE="$REPO_ROOT/CODEBUDDY.md"
 QODER_FILE="$REPO_ROOT/QODER.md"
-AMP_FILE="$REPO_ROOT/AGENTS.md"
+# AMP, Kiro CLI, and IBM Bob all share AGENTS.md — use AGENTS_FILE to avoid
+# updating the same file multiple times.
+AMP_FILE="$AGENTS_FILE"
 SHAI_FILE="$REPO_ROOT/SHAI.md"
-KIRO_FILE="$REPO_ROOT/AGENTS.md"
+TABNINE_FILE="$REPO_ROOT/TABNINE.md"
+KIRO_FILE="$AGENTS_FILE"
 AGY_FILE="$REPO_ROOT/.agent/rules/specify-rules.md"
-BOB_FILE="$REPO_ROOT/AGENTS.md"
+BOB_FILE="$AGENTS_FILE"
+VIBE_FILE="$REPO_ROOT/.vibe/agents/specify-agents.md"
+KIMI_FILE="$REPO_ROOT/KIMI.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -109,6 +116,8 @@ log_warning() {
 # Cleanup function for temporary files
 cleanup() {
     local exit_code=$?
+    # Disarm traps to prevent re-entrant loop
+    trap - EXIT INT TERM
     rm -f /tmp/agent_update_*_$$
     rm -f /tmp/manual_additions_$$
     exit $exit_code
@@ -473,7 +482,7 @@ update_existing_agent_file() {
         fi
         
         # Update timestamp
-        if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
+        if [[ "$line" =~ (\*\*)?Last\ updated(\*\*)?:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
             echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
         else
             echo "$line" >> "$temp_file"
@@ -604,65 +613,74 @@ update_specific_agent() {
     
     case "$agent_type" in
         claude)
-            update_agent_file "$CLAUDE_FILE" "Claude Code"
+            update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
             ;;
         gemini)
-            update_agent_file "$GEMINI_FILE" "Gemini CLI"
+            update_agent_file "$GEMINI_FILE" "Gemini CLI" || return 1
             ;;
         copilot)
-            update_agent_file "$COPILOT_FILE" "GitHub Copilot"
+            update_agent_file "$COPILOT_FILE" "GitHub Copilot" || return 1
             ;;
         cursor-agent)
-            update_agent_file "$CURSOR_FILE" "Cursor IDE"
+            update_agent_file "$CURSOR_FILE" "Cursor IDE" || return 1
             ;;
         qwen)
-            update_agent_file "$QWEN_FILE" "Qwen Code"
+            update_agent_file "$QWEN_FILE" "Qwen Code" || return 1
             ;;
         opencode)
-            update_agent_file "$AGENTS_FILE" "opencode"
+            update_agent_file "$AGENTS_FILE" "opencode" || return 1
             ;;
         codex)
-            update_agent_file "$AGENTS_FILE" "Codex CLI"
+            update_agent_file "$AGENTS_FILE" "Codex CLI" || return 1
             ;;
         windsurf)
-            update_agent_file "$WINDSURF_FILE" "Windsurf"
+            update_agent_file "$WINDSURF_FILE" "Windsurf" || return 1
             ;;
         kilocode)
-            update_agent_file "$KILOCODE_FILE" "Kilo Code"
+            update_agent_file "$KILOCODE_FILE" "Kilo Code" || return 1
             ;;
         auggie)
-            update_agent_file "$AUGGIE_FILE" "Auggie CLI"
+            update_agent_file "$AUGGIE_FILE" "Auggie CLI" || return 1
             ;;
         roo)
-            update_agent_file "$ROO_FILE" "Roo Code"
+            update_agent_file "$ROO_FILE" "Roo Code" || return 1
             ;;
         codebuddy)
-            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
+            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI" || return 1
             ;;
         qodercli)
-            update_agent_file "$QODER_FILE" "Qoder CLI"
+            update_agent_file "$QODER_FILE" "Qoder CLI" || return 1
             ;;
         amp)
-            update_agent_file "$AMP_FILE" "Amp"
+            update_agent_file "$AMP_FILE" "Amp" || return 1
             ;;
         shai)
-            update_agent_file "$SHAI_FILE" "SHAI"
+            update_agent_file "$SHAI_FILE" "SHAI" || return 1
+            ;;
+        tabnine)
+            update_agent_file "$TABNINE_FILE" "Tabnine CLI" || return 1
             ;;
         kiro-cli)
-            update_agent_file "$KIRO_FILE" "Kiro CLI"
+            update_agent_file "$KIRO_FILE" "Kiro CLI" || return 1
             ;;
         agy)
-            update_agent_file "$AGY_FILE" "Antigravity"
+            update_agent_file "$AGY_FILE" "Antigravity" || return 1
             ;;
         bob)
-            update_agent_file "$BOB_FILE" "IBM Bob"
+            update_agent_file "$BOB_FILE" "IBM Bob" || return 1
+            ;;
+        vibe)
+            update_agent_file "$VIBE_FILE" "Mistral Vibe" || return 1
+            ;;
+        kimi)
+            update_agent_file "$KIMI_FILE" "Kimi Code" || return 1
             ;;
         generic)
             log_info "Generic agent: no predefined context file. Use the agent-specific update script for your agent."
             ;;
         *)
             log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|kiro-cli|agy|bob|qodercli|generic"
+            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic"
             exit 1
             ;;
     esac
@@ -670,91 +688,53 @@ update_specific_agent() {
 
 update_all_existing_agents() {
     local found_agent=false
-    
-    # Check each possible agent file and update if it exists
-    if [[ -f "$CLAUDE_FILE" ]]; then
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$GEMINI_FILE" ]]; then
-        update_agent_file "$GEMINI_FILE" "Gemini CLI"
-        found_agent=true
-    fi
-    
-    if [[ -f "$COPILOT_FILE" ]]; then
-        update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-        found_agent=true
-    fi
-    
-    if [[ -f "$CURSOR_FILE" ]]; then
-        update_agent_file "$CURSOR_FILE" "Cursor IDE"
-        found_agent=true
-    fi
-    
-    if [[ -f "$QWEN_FILE" ]]; then
-        update_agent_file "$QWEN_FILE" "Qwen Code"
-        found_agent=true
-    fi
-    
-    if [[ -f "$AGENTS_FILE" ]]; then
-        update_agent_file "$AGENTS_FILE" "Codex/opencode"
-        found_agent=true
-    fi
-    
-    if [[ -f "$WINDSURF_FILE" ]]; then
-        update_agent_file "$WINDSURF_FILE" "Windsurf"
-        found_agent=true
-    fi
-    
-    if [[ -f "$KILOCODE_FILE" ]]; then
-        update_agent_file "$KILOCODE_FILE" "Kilo Code"
-        found_agent=true
-    fi
+    local _updated_paths=()
 
-    if [[ -f "$AUGGIE_FILE" ]]; then
-        update_agent_file "$AUGGIE_FILE" "Auggie CLI"
+    # Helper: skip non-existent files and files already updated (dedup by
+    # realpath so that variables pointing to the same file — e.g. AMP_FILE,
+    # KIRO_FILE, BOB_FILE all resolving to AGENTS_FILE — are only written once).
+    # Uses a linear array instead of associative array for bash 3.2 compatibility.
+    update_if_new() {
+        local file="$1" name="$2"
+        [[ -f "$file" ]] || return 0
+        local real_path
+        real_path=$(realpath "$file" 2>/dev/null || echo "$file")
+        local p
+        if [[ ${#_updated_paths[@]} -gt 0 ]]; then
+            for p in "${_updated_paths[@]}"; do
+                [[ "$p" == "$real_path" ]] && return 0
+            done
+        fi
+        update_agent_file "$file" "$name" || return 1
+        _updated_paths+=("$real_path")
         found_agent=true
-    fi
-    
-    if [[ -f "$ROO_FILE" ]]; then
-        update_agent_file "$ROO_FILE" "Roo Code"
-        found_agent=true
-    fi
+    }
 
-    if [[ -f "$CODEBUDDY_FILE" ]]; then
-        update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-        found_agent=true
-    fi
+    update_if_new "$CLAUDE_FILE" "Claude Code"
+    update_if_new "$GEMINI_FILE" "Gemini CLI"
+    update_if_new "$COPILOT_FILE" "GitHub Copilot"
+    update_if_new "$CURSOR_FILE" "Cursor IDE"
+    update_if_new "$QWEN_FILE" "Qwen Code"
+    update_if_new "$AGENTS_FILE" "Codex/opencode"
+    update_if_new "$AMP_FILE" "Amp"
+    update_if_new "$KIRO_FILE" "Kiro CLI"
+    update_if_new "$BOB_FILE" "IBM Bob"
+    update_if_new "$WINDSURF_FILE" "Windsurf"
+    update_if_new "$KILOCODE_FILE" "Kilo Code"
+    update_if_new "$AUGGIE_FILE" "Auggie CLI"
+    update_if_new "$ROO_FILE" "Roo Code"
+    update_if_new "$CODEBUDDY_FILE" "CodeBuddy CLI"
+    update_if_new "$SHAI_FILE" "SHAI"
+    update_if_new "$TABNINE_FILE" "Tabnine CLI"
+    update_if_new "$QODER_FILE" "Qoder CLI"
+    update_if_new "$AGY_FILE" "Antigravity"
+    update_if_new "$VIBE_FILE" "Mistral Vibe"
+    update_if_new "$KIMI_FILE" "Kimi Code"
 
-    if [[ -f "$SHAI_FILE" ]]; then
-        update_agent_file "$SHAI_FILE" "SHAI"
-        found_agent=true
-    fi
-
-    if [[ -f "$QODER_FILE" ]]; then
-        update_agent_file "$QODER_FILE" "Qoder CLI"
-        found_agent=true
-    fi
-
-    if [[ -f "$KIRO_FILE" ]]; then
-        update_agent_file "$KIRO_FILE" "Kiro CLI"
-        found_agent=true
-    fi
-
-    if [[ -f "$AGY_FILE" ]]; then
-        update_agent_file "$AGY_FILE" "Antigravity"
-        found_agent=true
-    fi
-    if [[ -f "$BOB_FILE" ]]; then
-        update_agent_file "$BOB_FILE" "IBM Bob"
-        found_agent=true
-    fi
-    
     # If no agent files exist, create a default Claude file
     if [[ "$found_agent" == false ]]; then
         log_info "No existing agent files found, creating default Claude file..."
-        update_agent_file "$CLAUDE_FILE" "Claude Code"
+        update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
     fi
 }
 print_summary() {
@@ -774,8 +754,7 @@ print_summary() {
     fi
     
     echo
-
-    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|kiro-cli|agy|bob|qodercli]"
+    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic]"
 }
 
 #==============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,18 @@ cargo clippy --workspace -- -D warnings    # Lint (must pass clean)
 | 8. Operations | Complete | `mister-smith-app` (binary entry point, bootstrap, shutdown, health probes, observability, cross-phase bridges) |
 | 9. LLM Providers | Complete | `mister-smith-llm` (ModelProvider trait, MockProvider, OpenAI/Anthropic/Claude providers, ModelRouter, circuit breaker, budget enforcement, dual-stream, ModelEvent, cascade routing); `mister-smith-agents` extended with `llm` feature (Planner/Critic/Executor LLM integration, ToolBus bridge) |
 | 9.1 Security Hardening | Complete | `mister-smith-transport`, `mister-smith-security`, `mister-smith-persistence`, `mister-smith-agents` |
-| 10. Frontier Autonomy & Control Plane | In Progress | `WORKFLOW.md`, `docs/linear/LINEAR.md`, smith MCP compatibility/recovery docs, queue governance work |
+| 10. Frontier Autonomy & Control Plane | Complete | `mister-smith-agents`, `mister-smith-persistence`, `mister-smith-security`, `mister-smith-app`, `mister-smith-events`, `mister-smith-llm`, deploy assets |
 
 ## Current Control Plane Sources
 
 - Runtime contract: `WORKFLOW.md`
 - Linear operating model: `docs/linear/LINEAR.md`
-- Active Phase 10 recovery and control-plane plans: `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`, `docs/plans/2026-03-14-smith-mcp-rebuild.md`, `docs/plans/2026-03-15-smith-mcp-workflow-forensics.md`, `docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md`
+- Phase 10 artifact set and gate evidence: `specs/012-phase10-frontier-autonomy/`,
+  `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`
+- Active control-plane recovery and queue-governance plans:
+  `docs/plans/2026-03-14-smith-mcp-rebuild.md`,
+  `docs/plans/2026-03-15-smith-mcp-workflow-forensics.md`,
+  `docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md`
 
 ## Workspace Crate Dependencies
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,35 @@ A multi-agent orchestration framework built in Rust with NATS messaging and Erla
 | 7. Agent System | Complete | `mister-smith-agents` | 951 |
 | 8. Operations | Complete | `mister-smith-app` | 983 |
 | 9. LLM Providers | Complete | `mister-smith-llm`, `mister-smith-agents` (llm feature) | 1115 |
-| 10. Frontier Autonomy & Control Plane | In Progress | repo workflow contract, Linear/Symphony control plane, smith MCP compatibility | live state tracked in `docs/plans/` and `WORKFLOW.md` |
+| 10. Frontier Autonomy & Control Plane | Complete | `mister-smith-agents`, `mister-smith-persistence`, `mister-smith-security`, `mister-smith-app`, `mister-smith-events`, `mister-smith-llm`, deploy assets | Phase 10 gate validated on 2026-03-15 |
 
-**20 crates** in the workspace (18 library + 1 binary + 1 integration test). The table above reflects completed build phases through 9.1 plus the active Phase 10 control-plane lane; treat exact test totals and warning counts as CI-validated state, not a static README guarantee.
+**20 crates** in the workspace (18 library + 1 binary + 1 integration test). The table above now
+reflects completed build phases through Phase 10. Treat exact test totals and warning counts as
+CI-validated state, not a static README guarantee.
 
 ## Current Control Plane
 
-- Live queue contract: [`WORKFLOW.md`](WORKFLOW.md) and [`docs/linear/LINEAR.md`](docs/linear/LINEAR.md)
-- Active Phase 10 control-plane work: [`docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`](docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md)
-- smith MCP rebuild and workflow recovery plans: [`docs/plans/2026-03-14-smith-mcp-rebuild.md`](docs/plans/2026-03-14-smith-mcp-rebuild.md), [`docs/plans/2026-03-15-smith-mcp-workflow-forensics.md`](docs/plans/2026-03-15-smith-mcp-workflow-forensics.md), [`docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md`](docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md)
+- Live queue contract:
+  [`WORKFLOW.md`](WORKFLOW.md) and
+  [`docs/linear/LINEAR.md`](docs/linear/LINEAR.md)
+- Phase 10 design and gate artifacts:
+  [`specs/012-phase10-frontier-autonomy/`](specs/012-phase10-frontier-autonomy/spec.md),
+  [`docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`](docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md)
+- smith MCP rebuild and workflow recovery plans:
+  [`docs/plans/2026-03-14-smith-mcp-rebuild.md`](docs/plans/2026-03-14-smith-mcp-rebuild.md),
+  [`docs/plans/2026-03-15-smith-mcp-workflow-forensics.md`](docs/plans/2026-03-15-smith-mcp-workflow-forensics.md),
+  [`docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md`](docs/plans/2026-03-15-smith-mcp-comprehensive-workflows.md)
+
+Phase 10 gate evidence on 2026-03-15:
+
+- `cargo test -p mister-smith-agents`
+- `cargo test -p mister-smith-persistence`
+- `cargo test -p mister-smith-security`
+- `cargo test -p mister-smith-llm`
+- `cargo test -p mister-smith-core`
+- `cargo test -p mister-smith-app`
+- `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
+- `cargo build --workspace`
 
 ## Architecture
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,16 @@
 
 Linear build order for the framework, end to end. Each phase depends on the phases above it. Within a phase, subphases are ordered but items at the same level can often be built in parallel.
 
-This is not an implementation plan — it does not prescribe tasks, timelines, or code. It is a dependency-aware map of what to build and in what order, with references to the specifications that define each component.
+This is not an implementation plan. It does not prescribe tasks, timelines, or code. It is a
+dependency-aware map of what to build and in what order, with references to the specifications that
+define each component.
 
-Current scope note: this roadmap remains the architectural build map through the completed framework phases. The active Phase 10 control-plane and workflow-recovery work now lives in [`WORKFLOW.md`](WORKFLOW.md), [`docs/linear/LINEAR.md`](docs/linear/LINEAR.md), and the dated plans under [`docs/plans/`](docs/plans/).
+Current scope note: this roadmap remains the architectural build map through the completed
+framework phases. Phase 10 is now implemented and validated in the repo, and the active
+frontier-autonomy artifact set spans
+[`specs/012-phase10-frontier-autonomy/`](specs/012-phase10-frontier-autonomy/spec.md),
+[`WORKFLOW.md`](WORKFLOW.md), [`docs/linear/LINEAR.md`](docs/linear/LINEAR.md), and the dated
+plans under [`docs/plans/`](docs/plans/).
 
 ## How to Read This
 

--- a/docs/plans/2026-03-15-ms-35-phase10-gate-and-speckit-refresh.md
+++ b/docs/plans/2026-03-15-ms-35-phase10-gate-and-speckit-refresh.md
@@ -1,0 +1,145 @@
+# MS-35 Phase 10 Gate And SpecKit Refresh
+
+## Objective
+
+- Close the `MS-35` Phase 10 verification/docs gate on top of current `origin/main`.
+- Re-apply only the still-valid parts of the stashed SpecKit/doc work after `e97d54a`
+  landed bounded delegation provenance.
+
+## Scope
+
+- Phase 10 gate artifacts under `specs/012-phase10-frontier-autonomy/`
+- High-level status docs: `ROADMAP.md`, `README.md`, `CLAUDE.md`
+- SpecKit scaffolding under `.specify/` and `.codex/prompts/`
+- Validation commands named by `MS-35` and the Phase 10 quickstart
+
+## Assumptions
+
+- `e97d54a feat(autonomy): enforce bounded delegation provenance (#190)` is now the
+  authoritative repo baseline for Phase 10.6.
+- The stash `phase10-readiness-cleanup-20260315-103853` is reference material, not a
+  patch to replay wholesale.
+- `crates/mister-smith-mcp/src/compatibility.rs` and the queue-governance notes are
+  separate control-plane work unless this gate proves they are required.
+
+## Constraints
+
+- Do not mix unrelated smith MCP queue-governance work into the Phase 10 gate branch.
+- Preserve reversibility with adjacent timestamp backups before overwriting tracked
+  files.
+- Keep the gate scoped to validation and documentation; do not reopen settled design
+  decisions without proof from current validation.
+- If Ralph is used later, rewrite `PROMPT.md` from the active issue context then; do
+  not treat the checked-in prompt as current execution truth.
+
+## Non-Goals
+
+- Do not land the stashed `compatibility.rs` patch in this branch unless it becomes a
+  verified gate blocker.
+- Do not redesign the Phase 10 roadmap or create new queue slices here.
+- Do not modify the live Linear workflow beyond what is required for the gate.
+
+## Milestones
+
+### 1. Refresh baseline context
+
+- Confirm current Phase 10 code/doc state after PR #190.
+- Separate stash contents into gate-relevant versus unrelated work.
+
+**Validation**
+
+- `git log --oneline HEAD..origin/main`
+- `linear.get_issue(MS-35)`
+- direct file inspection of current Phase 10 docs and stash references
+
+### 2. Reconcile SpecKit and Phase 10 docs
+
+- Refresh SpecKit scaffolding on the current baseline.
+- Update Phase 10 spec/task/analyze/research/plan artifacts plus high-level docs to
+  reflect completed Phase 10 implementation and the gate evidence.
+
+**Validation**
+
+- targeted diff review
+- `markdownlint` on touched docs
+
+### 3. Run the Phase 10 gate
+
+- Execute the validation matrix named in `MS-35`.
+- Record which quickstart scenarios are directly validated by automated tests and any
+  remaining manual evidence.
+
+**Validation**
+
+- `cargo test -p mister-smith-agents`
+- `cargo test -p mister-smith-persistence`
+- `cargo test -p mister-smith-security`
+- `cargo test -p mister-smith-llm`
+- `cargo test -p mister-smith-core`
+- `cargo test -p mister-smith-app`
+- `cargo build --workspace`
+- deploy artifact syntax validation
+
+### 4. Land if clean
+
+- Commit only the gate/spec refresh work.
+- Push, open/update the PR, and merge if validation is clean.
+
+**Validation**
+
+- clean `git status`
+- PR/merge success
+- local `main` fast-forwards cleanly after merge
+
+## Status
+
+- **Current milestone**: Complete
+- **Completed work**:
+  - Confirmed local `main` had been behind `origin/main` and fast-forwarded the repo
+    baseline to `e97d54a feat(autonomy): enforce bounded delegation provenance (#190)`.
+  - Confirmed `MS-35` remains the active Phase 10 gate and that its scope is
+    validation plus docs readiness, not additional runtime implementation.
+  - Refreshed SpecKit in place with
+    `uvx --from git+https://github.com/github/spec-kit.git specify init --here --force --ai codex --no-git`
+    and recorded `speckit_version: 0.3.0` in `.specify/init-options.json`.
+  - Reconciled `ROADMAP.md`, `README.md`, `CLAUDE.md`, and the Phase 10 artifact set
+    so the roadmap, research, architecture references, quickstart, tasks, and analyze
+    report all reflect the post-`e97d54a` repo baseline.
+  - Ran the `MS-35` validation bundle:
+    `cargo test -p mister-smith-agents`,
+    `cargo test -p mister-smith-persistence`,
+    `cargo test -p mister-smith-security`,
+    `cargo test -p mister-smith-llm`,
+    `cargo test -p mister-smith-core`,
+    `cargo test -p mister-smith-app`,
+    `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`,
+    and `cargo build --workspace`.
+  - Confirmed the stash `phase10-readiness-cleanup-20260315-103853` contains two
+    separate streams:
+    the Phase 10 gate/SpecKit work now reapplied on this branch, and a separate smith
+    MCP queue-governance follow-up (`crates/mister-smith-mcp/src/compatibility.rs`
+    plus throughput notes) that remains out of scope for `MS-35`.
+- **Decisions**:
+  - Land the SpecKit refresh together with the `MS-35` docs gate because both change
+    the same Phase 10 artifact set and share the same validation evidence.
+  - Do not replay or merge the stashed smith MCP queue-governance patch in this
+    branch; treat it as separate validated-backlog follow-up work unless a later gate
+    proves it is required.
+  - Reuse this note as the durable closeout record instead of restoring the older
+    pre-`e97d54a` audit note from the stash.
+- **Open verification gap**:
+  - `vet` remains unavailable in this environment because history-backed runs hit
+    missing `ANTHROPIC_API_KEY`, `--no-history` required `OPENAI_API_KEY`, and the
+    agentic Codex harness path did not complete.
+  - `ROADMAP.md`, `README.md`, and `CLAUDE.md` still have substantial pre-existing
+    markdownlint debt outside this scoped pass.
+- **Next step**:
+  - Stage only the `MS-35`/SpecKit refresh files, remove the temporary adjacent backup
+    files, and land the gate branch.
+
+## Stop Conditions
+
+- Stop before merge if current validation contradicts the “Phase 10 complete” claim.
+- Stop before merge if the gate depends on unrelated smith MCP queue-governance work.
+- Stop after merge once `main` is clean, up to date, and the stash is either
+  superseded or intentionally retained only for unrelated follow-up work.

--- a/specs/012-phase10-frontier-autonomy/analyze.md
+++ b/specs/012-phase10-frontier-autonomy/analyze.md
@@ -1,47 +1,71 @@
 # Analyze Report: Phase 10 — Frontier Autonomy & Advanced Agent Patterns
 
-**Date**: 2026-03-10
-**Mode**: Initial cross-artifact consistency analysis
-**Status**: READY FOR IMPLEMENTATION
+**Date**: 2026-03-15
+**Mode**: Gate validation after complete Phase 10 implementation
+**Status**: VALIDATED — ready to close the Phase 10 gate
 
 ## Execution Evidence
 
 - Reviewed `spec.md`, `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/`,
-  `tasks.md`, and `checklists/` for internal consistency.
+  `tasks.md`, and `checklists/` for internal consistency and repo-state drift.
+- Cross-referenced `ROADMAP.md`, `README.md`, `CLAUDE.md`, `WORKFLOW.md`, and
+  `docs/linear/LINEAR.md` to verify that the roadmap note, live control-plane docs, and Phase 10
+  artifact set all point at the same frontier-autonomy lane.
 - Cross-referenced `.specify/memory/constitution.md` to verify Phase 10 remains spec-first,
-  provider-neutral, evidence-based, and phase-gated.
-- Verified all mandatory requirement clusters in `spec.md` map to implementation tasks with exact
-  repository paths.
-- Verified deferred items from the March 9 design note and consolidated research corpus do not
-  leak into the Phase 10 task plan.
+  provider-neutral, evidence-based, and phase-gated after the final gate pass.
+- Verified the full Phase 10 validation bundle with:
+  - `cargo test -p mister-smith-agents`
+  - `cargo test -p mister-smith-persistence`
+  - `cargo test -p mister-smith-security`
+  - `cargo test -p mister-smith-llm`
+  - `cargo test -p mister-smith-core`
+  - `cargo test -p mister-smith-app`
+  - `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
+  - `cargo build --workspace`
+- Verified the quickstart scenarios map directly to the passing gate suites and deploy assets
+  rather than relying on narrative-only claims.
 
 ## Findings
 
-| ID | Category | Severity | Location(s) | Summary |
-| -- | -------- | -------- | ----------- | ------- |
-| A1 | Coverage | INFO | `spec.md`, `tasks.md` | Four user stories and six requirement clusters map to 43 implementation and verification tasks across foundational work plus subphases 10.1-10.6. |
-| A2 | Dependency | INFO | `plan.md`, `tasks.md` | Phase 9 stream/routing and Phase 9.1 security remain explicit prerequisites; Phase 10 does not redefine those public contracts. |
-| A3 | Consistency | INFO | `data-model.md`, `contracts/`, `tasks.md` | Core autonomy entities stay aligned across the data model, contracts, and task plan. |
-| A4 | Scope | INFO | `spec.md`, `research.md`, `tasks.md` | Deferred learned routing, speculative decoding, local inference, consensus, and ML monitoring remain out of scope and absent from tasks. |
-| A5 | Constitution | INFO | `spec.md`, `plan.md`, `analyze.md` | The artifact set remains canonical-source-aware, spec-first, phase-gated, model-agnostic, OTP-aligned, and evidence-based. |
-| A6 | Workflow | INFO | `spec.md`, `checklists/`, `tasks.md`, `analyze.md` | Clarifications, plan/research/data model, contracts, quickstart, tasks, analyze, and an optional checklist are present. |
+- **A1 Coverage / INFO**: `spec.md`, `tasks.md`, `crates/`, `deploy/`
+  Phase 10.0 through 10.6 are implemented in-tree and validated by the gate bundle above.
+- **A2 Dependency / INFO**: `ROADMAP.md`, `spec.md`, `plan.md`, `tasks.md`
+  The roadmap note, live control-plane docs, and Phase 10 artifacts point at the same
+  frontier-autonomy lane instead of mixing a Phase 9-only roadmap with a separate Phase 10 spec.
+- **A3 Consistency / INFO**: `data-model.md`, `contracts/`, `tasks.md`
+  Core autonomy entities stay aligned across the data model, contracts, and reconciled task plan.
+- **A4 Scope / INFO**: `spec.md`, `research.md`, `tasks.md`
+  Deferred learned routing, speculative decoding, local inference, consensus, and ML monitoring
+  remain out of scope and absent from implemented surfaces.
+- **A5 Constitution / INFO**: `spec.md`, `plan.md`, `analyze.md`
+  The artifact set remains canonical-source-aware, spec-first, phase-gated, model-agnostic,
+  OTP-aligned, and evidence-based after the gate pass.
 
 ## Coverage Summary
 
-| Requirement Key | Has Task? | Task IDs | Notes |
-| --------------- | --------- | -------- | ----- |
-| execution-graph-topology (`FR-201`..`FR-204`) | Yes | `T005`-`T015` | Covers graph compilation, topology selection, invalid-graph rejection, checkpointing, and resume/reassignment. |
-| managed-memory-context (`FR-205`..`FR-207`) | Yes | `T016`-`T021` | Covers context budgets, fragment metadata, paging, summaries, and checkpoint-ready snapshots. |
-| guard-supervision (`FR-208`..`FR-210`) | Yes | `T022`-`T026`, `T025A` | Covers failure taxonomy, degradation signals, profile snapshots, and intervention logic. |
-| operator-visibility (`FR-211`..`FR-212`) | Yes | `T025`, `T027`-`T031` | Covers typed autonomy status, rationale inspection, memory pressure, and intervention history. |
-| delegation-provenance (`FR-213`..`FR-214`) | Yes | `T032`-`T037` | Covers bounded delegation, expiry/revocation, operator-visible provenance, and workflow audits. |
-| substrate-fallback (`FR-215`..`FR-216`) | Yes | `T001`-`T004`, `T011`-`T012`, `T025A`, `T031`, `T033`-`T035` | Preserves substrate boundaries and explicit conservative fallback behavior. |
+- `execution-graph-topology` (`FR-201`..`FR-204`): Yes, `T005`-`T015`
+  Implemented and validated by `cargo test -p mister-smith-agents`.
+- `managed-memory-context` (`FR-205`..`FR-207`): Yes, `T016`-`T021`
+  Implemented and validated by `cargo test -p mister-smith-persistence` and
+  `cargo test -p mister-smith-agents`.
+- `guard-supervision` (`FR-208`..`FR-210`): Yes, `T022`-`T026`, `T025A`
+  Implemented and validated by `cargo test -p mister-smith-agents` and
+  `cargo test -p mister-smith-llm`.
+- `operator-visibility` (`FR-211`..`FR-212`): Yes, `T025`, `T027`-`T031`
+  Implemented and validated by `cargo test -p mister-smith-app`,
+  `cargo test -p mister-smith-agents`, and deploy-asset validation.
+- `delegation-provenance` (`FR-213`..`FR-214`): Yes, `T032`-`T037`
+  Implemented and validated by `cargo test -p mister-smith-security`,
+  `cargo test -p mister-smith-agents`, and `cargo test -p mister-smith-app`.
+- `substrate-fallback` (`FR-215`..`FR-216`): Yes,
+  `T001`-`T004`, `T011`-`T012`, `T025A`, `T031`, `T033`-`T035`
+  Implemented and validated by the agents, security, and app gate suites.
 
 ## Constitution Alignment
 
 No constitution conflicts detected. Phase 10 extends existing canonical types, phase boundaries,
-and supervisory architecture instead of redefining them. The task plan keeps implementation
-sequencing evidence-based and ties every public surface back to the Phase 10 specification.
+and supervisory architecture instead of redefining them. The reconciled task plan keeps completed
+work evidence-based and ties every public surface back to the Phase 10 specification.
 
 ## Unmapped Tasks
 
@@ -51,32 +75,29 @@ None.
 
 - Requirement clusters analyzed: 6
 - Total tasks: 43
-- Requirement-cluster coverage: 6/6 clusters have task coverage
+- Requirement-cluster coverage: 6/6 implemented and validated
 - Ambiguity findings: 0
 - Duplication findings: 0
 - Critical issues: 0
 - High-severity blockers: 0
-- Analyze gate result: READY FOR IMPLEMENTATION
+- Analyze gate result: VALIDATED — Phase 10 ready to close
 
 ## Verification Checklist
 
 1. Phase 10 remains positioned as the roadmap extension after Phase 9.1 rather than a rewrite of
    Phase 9 or 9.1.
-2. Every requirement cluster in `spec.md` maps to concrete files and validation tasks in
-   `tasks.md`.
-3. All five contracts align with the Phase 10 data model and planned source-code boundaries.
-4. Deferred scope items remain explicitly excluded from the implementation task plan.
+2. The roadmap note, live control-plane docs, and `specs/012-phase10-frontier-autonomy/` now
+   point at the same active frontier-autonomy lane.
+3. All five contracts align with the Phase 10 data model and current source-code boundaries.
+4. Deferred scope items remain explicitly excluded from the implementation task plan and from
+   landed code.
 5. Operator-visible, conservative degradation behavior remains explicit when profile, memory, or
    control-plane signals are stale or unavailable.
-6. Optional SpecKit workflow artifacts are present rather than skipped.
+6. The quickstart scenarios map directly to passing validation artifacts rather than aspirational
+   future commands.
 
 ## Next Actions
 
-1. Begin implementation with 10.0 and 10.1 to lock shared autonomy types, events, and graph
-   semantics first.
-2. Treat 10.2 and 10.3 as the next highest-leverage layers because branch-local recovery and
-   managed memory are prerequisites for reliable long-running autonomy.
-3. Add 10.4 and 10.5 before full delegation rollout so supervisory and operator visibility is in
-   place before privileged autonomy broadens.
-4. Keep deferred learned-routing and speculative-serving work out of this phase unless the spec is
-   explicitly amended first.
+1. Land the Phase 10 gate/docs branch and close `MS-35`.
+2. Keep smith MCP queue-governance and throughput work as separate operational follow-up rather
+   than reopening the completed framework phase.

--- a/specs/012-phase10-frontier-autonomy/checklists/architecture-alignment.md
+++ b/specs/012-phase10-frontier-autonomy/checklists/architecture-alignment.md
@@ -1,7 +1,7 @@
 # Architecture Alignment Checklist: Phase 10 — Frontier Autonomy & Advanced Agent Patterns
 
-**Purpose**: Verify the generated Phase 10 artifact set stays aligned with roadmap evidence,
-canonical framework docs, and zero-trust autonomy guardrails before implementation starts.
+**Purpose**: Verify the Phase 10 artifact set stays aligned with roadmap evidence, canonical
+framework docs, and zero-trust autonomy guardrails as implementation closes out.
 **Created**: 2026-03-10
 **Feature**: [spec.md](../spec.md)
 
@@ -36,12 +36,12 @@ It validates the planning artifacts themselves rather than future implementation
 - [x] CHK009 `tasks.md` maps every requirement cluster to concrete files in `mister-smith-core`,
   `mister-smith-events`, `mister-smith-agents`, `mister-smith-persistence`,
   `mister-smith-llm`, `mister-smith-security`, `mister-smith-app`, and `deploy/`.
-- [x] CHK010 `analyze.md` confirms zero constitution conflicts, zero uncovered requirement
-  clusters, and zero leaked deferred scope items.
+- [x] CHK010 `analyze.md` records complete implementation coverage, gate validation evidence, and
+  zero leaked deferred scope items.
 - [x] CHK011 `quickstart.md` and the verification tasks preserve a conservative, operator-visible
   degradation posture when profile data, memory metadata, or fresh control-plane state is missing.
 
 ## Notes
 
-- Use this checklist as the pre-implementation gate for any future Phase 10 coding session.
+- Use this checklist as the reconciliation gate before closing the Phase 10 implementation record.
 - Re-run the checklist if `spec.md`, `plan.md`, or `tasks.md` changes materially.

--- a/specs/012-phase10-frontier-autonomy/checklists/requirements.md
+++ b/specs/012-phase10-frontier-autonomy/checklists/requirements.md
@@ -31,7 +31,9 @@
 
 ## Notes
 
-- Validated after initial draft against the repo's current post-audit conventions:
-  governing-source traceability, explicit deferred scope, and recorded clarification outcomes.
-- Phase 10 is treated as a roadmap extension after Phase 9.1 because `ROADMAP.md` currently stops
-  at Phase 9 while the repo already contains completed Phase 9.1 artifacts.
+- Re-validated on 2026-03-15 against the repo's current post-gate conventions:
+  governing-source traceability, explicit deferred scope, recorded clarification outcomes, and
+  completed implementation evidence.
+- Phase 10 remains the structured frontier-autonomy artifact set layered after Phase 9.1, while
+  `ROADMAP.md` now points readers at `specs/012-phase10-frontier-autonomy/`, `WORKFLOW.md`,
+  `docs/linear/LINEAR.md`, and `docs/plans/` for the active control-plane lane.

--- a/specs/012-phase10-frontier-autonomy/plan.md
+++ b/specs/012-phase10-frontier-autonomy/plan.md
@@ -20,6 +20,25 @@ LLM, persistence, security, and operations foundations:
   operators
 - Phase 9.1 delegation-chain work is completed into enforceable provenance and bounded delegation
 
+## Implementation Status Snapshot (2026-03-15)
+
+- **Implemented and validated in repo**: foundational autonomy contracts/events (10.0),
+  execution-graph/topology compilation (10.1), branch checkpointing and resilience-aware routing
+  (10.2), managed memory/context assembly (10.3), Guard/Advisor supervision plus stream monitors
+  (10.4), operator autonomy views plus deploy scaffolding (10.5), and bounded
+  delegation/provenance enforcement (10.6).
+- **Validation evidence captured in this gate pass**:
+  - `cargo test -p mister-smith-agents`
+  - `cargo test -p mister-smith-persistence`
+  - `cargo test -p mister-smith-security`
+  - `cargo test -p mister-smith-llm`
+  - `cargo test -p mister-smith-core`
+  - `cargo test -p mister-smith-app`
+  - `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
+  - `cargo build --workspace`
+- **Operational follow-up stays separate**: current Symphony, Linear, and smith MCP queue
+  governance work remains active operational work, not incomplete Phase 10 framework scope.
+
 ## Technical Context
 
 - **Language/Version**: Rust, MSRV 1.88.0
@@ -32,7 +51,8 @@ LLM, persistence, security, and operations foundations:
   delegation-chain substrate
 - **Testing**: targeted crate tests for topology compilation, memory/context management, guard
   decisions, operator views, and delegation enforcement; `cargo build --workspace` as cross-crate
-  compatibility baseline
+  compatibility baseline. The 2026-03-15 gate pass validated all Phase 10 subphases with the
+  targeted crate suites plus deploy-asset checks.
 - **Target Platform**: Linux runtime, macOS development parity
 - **Performance Goals**: branch-local recovery without re-running completed work, at least 30%
   reduction in delivered role context versus full-history broadcast, operator-visible autonomy
@@ -125,8 +145,8 @@ crates/mister-smith-app/
 |   +-- main.rs                             # CLI or app wiring for autonomy views
 
 deploy/
-+-- dashboards/                            # Dashboards for topology, checkpoints, and interventions
-+-- alerts/                                # Alerts for autonomy degradation / checkpoint failures
++-- dashboards/mister-smith-autonomy.json  # Operator-facing topology/checkpoint/intervention dashboard
++-- alerts/mister-smith-autonomy-rules.yml # Autonomy-specific alert scaffolding
 ```
 
 ## Design Decisions

--- a/specs/012-phase10-frontier-autonomy/quickstart.md
+++ b/specs/012-phase10-frontier-autonomy/quickstart.md
@@ -9,35 +9,22 @@
 - NATS + JetStream available for env-gated checkpoint, routing, and operator-state integration
 - PostgreSQL available for env-gated managed-memory integration tests
 
-## Planned Build Flow After Implementation
+## Gate Validation Flow (2026-03-15)
 
 ```bash
 # 1. Cross-crate compile safety
 cargo build --workspace
 
-# 2. Topology compiler and execution-graph tests
-cargo test -p mister-smith-agents -- topology
-cargo test -p mister-smith-agents -- execution_graph
+# 2. Targeted Phase 10 gate suites
+cargo test -p mister-smith-agents
+cargo test -p mister-smith-persistence
+cargo test -p mister-smith-security
+cargo test -p mister-smith-llm
+cargo test -p mister-smith-core
+cargo test -p mister-smith-app
 
-# 3. Branch checkpoint and resume tests (env-gated where needed)
-NATS_URL=nats://localhost:4222 cargo test -p mister-smith-agents -- checkpoint --ignored
-
-# 4. Managed memory / context manager tests
-cargo test -p mister-smith-persistence -- memory
-DATABASE_URL=postgres://localhost/mister_smith cargo test -p mister-smith-persistence -- snapshot --ignored
-
-# 5. Guard / Advisor and stream-monitor tests
-cargo test -p mister-smith-agents -- guard
-cargo test -p mister-smith-llm -- stream_monitor
-
-# 6. Delegation and provenance tests
-cargo test -p mister-smith-security -- delegation
-
-# 7. Operator autonomy view tests
-cargo test -p mister-smith-app -- autonomy
-
-# 8. Lint baseline
-cargo clippy --workspace -- -D warnings
+# 3. Deploy artifact syntax
+python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts
 ```
 
 ## Usage Sketch
@@ -110,3 +97,18 @@ audit.record_provenance(&capability, &action).await?;
 1. Issue a bounded delegation chain for a privileged action.
 2. Revoke or expire the chain before the downstream execution.
 3. Verify the action is blocked and the operator-visible provenance record explains why.
+
+## Scenario Mapping To Gate Evidence
+
+- **Scenario 1** maps to `cargo test -p mister-smith-agents`, especially the
+  `execution_graph_tests`, `topology_tests`, and `gate10_tests` suites.
+- **Scenario 2** maps to `cargo test -p mister-smith-agents`, especially the
+  `checkpoint_tests` and `gate10_tests` suites.
+- **Scenario 3** maps to `cargo test -p mister-smith-persistence` plus
+  `cargo test -p mister-smith-agents`, especially the memory manager, performance, and
+  context-manager suites.
+- **Scenario 4** maps to `cargo test -p mister-smith-app` and `cargo test -p mister-smith-agents`,
+  plus deploy asset validation for the autonomy dashboard and alert rules.
+- **Scenario 5** maps to `cargo test -p mister-smith-security`,
+  `cargo test -p mister-smith-agents`, and `cargo test -p mister-smith-app`, where revoked,
+  expired, or invalid delegation chains are rejected and surfaced to operators.

--- a/specs/012-phase10-frontier-autonomy/research.md
+++ b/specs/012-phase10-frontier-autonomy/research.md
@@ -19,6 +19,18 @@ that intentionally combines:
 - operator-visible autonomy state
 - bounded delegation/provenance
 
+## Implementation Alignment Note (2026-03-15)
+
+The current repository state still matches the research ordering captured here:
+
+- the repo now has real topology, checkpoint, managed-memory, Guard, operator-view, and bounded
+  delegation surfaces, which is consistent with the research priority ordering behind R1-R5
+- the repo still keeps learned routing, speculative decoding, local inference, consensus, and ML
+  anomaly detection outside Phase 10, which preserves the design note's anti-drift boundary
+
+No new evidence in this review pass justified pulling deferred serving or model-selection work back
+into Phase 10 scope.
+
 ## Key Research Findings
 
 ### R1: Topology Dominates Static Team Structure
@@ -143,6 +155,7 @@ Token-format replacement or federation-specific capability systems can remain la
 | `docs/research-output/consolidated/04-security-and-trust.md` | Grounds bounded delegation/provenance as enabling substrate |
 | `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md` | Provides the phase's strategic framing and anti-drift guardrail |
 | `docs/2026-03-05-implementation-deviation-report.md` | Identifies "Phase 10: Advanced Agent Patterns" as the next roadmap extension |
+| `spec/core-architecture/supervision-and-events.md` | Grounds typed autonomy event propagation and operator-visible event assembly |
 | `spec/data-management/agent-orchestration.md` | Provides the existing planner/router/memory boundaries and context-management hook |
 | `spec/data-management/message-schemas.md` | Defines workflow coordination and hook-event boundaries that Phase 10 can extend |
 

--- a/specs/012-phase10-frontier-autonomy/spec.md
+++ b/specs/012-phase10-frontier-autonomy/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `012-phase10-frontier-autonomy`
 **Created**: 2026-03-10
-**Status**: Draft
+**Status**: Validated (repo state reconciled 2026-03-15)
 **Input**: Linear issue `MS-26`, `ROADMAP.md`, `docs/2026-03-05-architectural-grounding-audit.md`,
 `docs/2026-03-05-implementation-deviation-report.md`,
 `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`, the consolidated research corpus in
@@ -12,10 +12,12 @@
 
 ### Phase Position
 
-`ROADMAP.md` currently defines phases through Phase 9 only, while the repository already contains
-completed implementation artifacts for Phase 9 and Phase 9.1. This specification defines **Phase 10
-as the next roadmap extension after Phase 9.1**, using the strongest repo-local evidence for what
-should come next:
+`ROADMAP.md` still carries the numbered architectural build map through the completed framework
+phases and now explicitly points Phase 10 readers at
+`specs/012-phase10-frontier-autonomy/`, `WORKFLOW.md`, `docs/linear/LINEAR.md`, and the dated
+control-plane plans under `docs/plans/`. This specification is the structured Phase 10 artifact
+set for that active frontier-autonomy lane, extending the roadmap after Phase 9.1 using the
+strongest repo-local evidence for what should come next:
 
 - `docs/2026-03-05-implementation-deviation-report.md` proposes **Phase 10: Advanced Agent
   Patterns**
@@ -28,23 +30,27 @@ should come next:
 
 This Phase 10 specification is constrained by the following precedence order:
 
-1. `ROADMAP.md` through completed Phase 9 and the repo's active Phase 9.1 follow-on work
-2. `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`
-3. `docs/2026-03-05-implementation-deviation-report.md`
-4. `docs/2026-03-05-architectural-grounding-audit.md`
-5. Consolidated research findings in `docs/research-output/consolidated/`
-6. Canonical architecture sources in `spec/`
-7. Supporting repo context in `README.md`, `CLAUDE.md`, and `.specify/memory/constitution.md`
+1. `ROADMAP.md` current scope note plus completed roadmap phases through Phase 9
+2. `WORKFLOW.md` and `docs/linear/LINEAR.md` for the live Phase 10 control-plane contract
+3. `docs/plans/2026-03-09-frontier-autonomy-zero-trust-design.md`
+4. `docs/2026-03-05-implementation-deviation-report.md`
+5. `docs/2026-03-05-architectural-grounding-audit.md`
+6. Consolidated research findings in `docs/research-output/consolidated/`
+7. Canonical architecture sources in `spec/`
+8. Supporting repo context in `README.md`, `CLAUDE.md`, and `.specify/memory/constitution.md`
 
 ### Canonical Architecture Citations
 
 Phase 10 artifacts MUST trace back to these framework sources:
 
 - `spec/core-architecture/system-architecture.md` for async-first, fault-tolerant system design
+- `spec/core-architecture/component-architecture.md` for cross-crate boundaries and subsystem seams
 - `spec/core-architecture/async-patterns.md` for stream processing, ToolBus, and bounded async
   execution patterns
 - `spec/core-architecture/supervision-trees.md` for restart policies, failure isolation, and
   supervisory boundaries
+- `spec/core-architecture/supervision-and-events.md` for typed event propagation, supervisory
+  signals, and operator-visible state assembly
 - `spec/data-management/agent-orchestration.md` for planner/executor/critic/router/memory roles,
   context-management patterns, and parallel coordination hooks
 - `spec/data-management/message-schemas.md` for workflow coordination, hook-event schemas, and
@@ -110,6 +116,32 @@ The following items are intentionally **not** Phase 10 acceptance scope:
   management layer, not a replacement storage system
 - Phase 8 operations remains the system entry point and observability substrate; Phase 10 extends
   it with topology- and autonomy-specific visibility
+
+### Current Implementation Alignment (2026-03-15)
+
+Repo reality now includes landed and validated Phase 10 surfaces across subphases 10.0 through
+10.6:
+
+- shared autonomy value objects and typed autonomy events
+- execution graph compilation, topology selection, branch checkpoints, and resilience-aware routing
+- managed memory, context budgeting, consolidation, and checkpoint-ready snapshots
+- Guard/Advisor supervision plus stream-monitor degradation signals
+- operator-facing autonomy status views, metrics wiring, and deploy scaffolding
+- bounded delegation, provenance enforcement, operator-visible rejection reasons, and auditability
+
+Evidence for that alignment in this gate pass:
+
+- `cargo test -p mister-smith-agents`
+- `cargo test -p mister-smith-persistence`
+- `cargo test -p mister-smith-security`
+- `cargo test -p mister-smith-llm`
+- `cargo test -p mister-smith-core`
+- `cargo test -p mister-smith-app`
+- `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
+- `cargo build --workspace`
+
+The remaining active repo work around Symphony, Linear, and smith MCP queue governance is
+operational follow-up, not missing Phase 10 framework implementation.
 
 ## Clarifications
 

--- a/specs/012-phase10-frontier-autonomy/tasks.md
+++ b/specs/012-phase10-frontier-autonomy/tasks.md
@@ -39,6 +39,7 @@ verification.
 | Source | Task ranges | Why it matters |
 | ------ | ----------- | -------------- |
 | `spec/data-management/agent-orchestration.md` | `T005`-`T021`, `T024`, `T034`, `T037` | Keeps planner, router, role, and context-management behavior inside existing agent seams. |
+| `spec/core-architecture/supervision-and-events.md` | `T003`, `T012`, `T025`, `T027`-`T031`, `T035` | Keeps autonomy events and operator status inside the repo's event-driven supervision model. |
 | `spec/core-architecture/supervision-trees.md` | `T009`-`T015`, `T022`-`T031` | Preserves OTP-style failure isolation and targeted intervention boundaries. |
 | `spec/operations/observability-monitoring-framework.md` | `T003`, `T012`, `T025`, `T027`-`T031` | Grounds typed autonomy state, operator views, and deployment alerts. |
 | `docs/research-output/consolidated/03-supervision-and-resilience.md` | `T009`-`T015`, `T022`-`T031` | Grounds branch-local recovery, Guard/Advisor behavior, and checkpoint-aware remediation. |
@@ -54,27 +55,44 @@ verification.
 - **Deferred work**: learned routing, guided/speculative decoding, local inference, consensus/CRDT
   suites, auction-based orchestration, and ML/eBPF anomaly detection stay out of Phase 10 tasks.
 
+## Status Reconciliation (2026-03-15)
+
+- This checklist was reconciled against current repository reality to eliminate stale "not
+  started" signals and to close the Phase 10 gate on the post-PR-190 baseline.
+- Verified the full gate validation bundle with:
+  - `cargo test -p mister-smith-agents`
+  - `cargo test -p mister-smith-persistence`
+  - `cargo test -p mister-smith-security`
+  - `cargo test -p mister-smith-llm`
+  - `cargo test -p mister-smith-core`
+  - `cargo test -p mister-smith-app`
+  - `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
+  - `cargo build --workspace`
+- Subphases 10.0 through 10.6 are implemented and validated in-tree.
+- Verification/readiness tasks `T038` through `T042` are complete, including the quickstart
+  scenario coverage captured in `quickstart.md`.
+
 ---
 
-## Subphase 10.0 — Foundational Autonomy Types (Blocking Prerequisites)
+## Subphase 10.0 — Foundational Autonomy Types (Blocking Prerequisites) — DONE
 
 **Goal**: Introduce shared autonomy identifiers, typed events, and dependency tooling before user
 story work begins.
 
-- [ ] T001 Add `petgraph` workspace dependency plumbing in `Cargo.toml` and `crates/mister-smith-agents/Cargo.toml`.
-- [ ] T002 [P] Create shared autonomy IDs, enums, and errors in
+- [x] T001 Add `petgraph` workspace dependency plumbing in `Cargo.toml` and `crates/mister-smith-agents/Cargo.toml`.
+- [x] T002 [P] Create shared autonomy IDs, enums, and errors in
   `crates/mister-smith-core/src/autonomy.rs`, extend
   `crates/mister-smith-core/src/ids.rs`, `crates/mister-smith-core/src/enums.rs`,
   `crates/mister-smith-core/src/error.rs`, and re-export from
   `crates/mister-smith-core/src/lib.rs`.
-- [ ] T003 [P] Create typed autonomy events and summaries in `crates/mister-smith-events/src/autonomy.rs`, update `crates/mister-smith-events/src/types.rs`, and re-export from `crates/mister-smith-events/src/lib.rs`.
-- [ ] T004 Add foundational compile and serialization coverage in `crates/mister-smith-core/tests/trait_compilation_tests.rs` and create `crates/mister-smith-events/tests/autonomy_event_tests.rs`.
+- [x] T003 [P] Create typed autonomy events and summaries in `crates/mister-smith-events/src/autonomy.rs`, update `crates/mister-smith-events/src/types.rs`, and re-export from `crates/mister-smith-events/src/lib.rs`.
+- [x] T004 Add foundational compile and serialization coverage in `crates/mister-smith-core/tests/trait_compilation_tests.rs` and create `crates/mister-smith-events/tests/autonomy_event_tests.rs`.
 
 **Checkpoint**: Shared autonomy types and event envelopes are stable enough for all user stories.
 
 ---
 
-## Subphase 10.1 — Execution Graph + Topology Compiler (User Story 1, Priority: P1)
+## Subphase 10.1 — Execution Graph + Topology Compiler (User Story 1, Priority: P1) — DONE
 
 **Goal**: Normalize planner output into an explicit `ExecutionGraph`, reject invalid graphs, and
 select topology deterministically before dispatch.
@@ -84,22 +102,22 @@ the compiler selects a compatible topology, rejects cycles, and preserves depend
 
 ### US1 Graph Compilation Tasks
 
-- [ ] T005 [US1] Create `crates/mister-smith-agents/src/execution_graph.rs` with
+- [x] T005 [US1] Create `crates/mister-smith-agents/src/execution_graph.rs` with
   `ExecutionGraph`, `ExecutionNode`, `ExecutionEdge`, graph-state validation, and
   re-export from `crates/mister-smith-agents/src/lib.rs`.
-- [ ] T006 [P] [US1] Create `crates/mister-smith-agents/src/topology.rs` with `TopologyCompiler`, `TopologySignals`, deterministic topology-selection policy, and rationale recording.
-- [ ] T007 [P] [US1] Extend `crates/mister-smith-agents/src/roles/planner.rs`,
+- [x] T006 [P] [US1] Create `crates/mister-smith-agents/src/topology.rs` with `TopologyCompiler`, `TopologySignals`, deterministic topology-selection policy, and rationale recording.
+- [x] T007 [P] [US1] Extend `crates/mister-smith-agents/src/roles/planner.rs`,
   `crates/mister-smith-agents/src/roles/coordinator.rs`, and
   `crates/mister-smith-agents/src/orchestrator.rs` so planner output is normalized into a
   validated `ExecutionGraph` before dispatch.
-- [ ] T008 [US1] Add graph validation and topology selection coverage in `crates/mister-smith-agents/tests/execution_graph_tests.rs` and `crates/mister-smith-agents/tests/topology_tests.rs`.
+- [x] T008 [US1] Add graph validation and topology selection coverage in `crates/mister-smith-agents/tests/execution_graph_tests.rs` and `crates/mister-smith-agents/tests/topology_tests.rs`.
 
 **Checkpoint**: Planner output is compiled into a valid `ExecutionGraph` with explicit topology
 selection and rationale.
 
 ---
 
-## Subphase 10.2 — Branch Checkpointing + Resilience-Aware Routing (User Story 1, Priority: P1)
+## Subphase 10.2 — Branch Checkpointing + Resilience-Aware Routing (User Story 1, Priority: P1) — DONE
 
 **Goal**: Persist branch progress, attach health/budget/profile signals to dispatch decisions, and
 resume or reassign failed work without replaying completed branches.
@@ -109,29 +127,29 @@ Verify only the affected branch resumes or reassigns while completed branches re
 
 ### US1 Recovery & Routing Tasks
 
-- [ ] T009 [US1] Create `crates/mister-smith-agents/src/branch_checkpoint.rs` with
+- [x] T009 [US1] Create `crates/mister-smith-agents/src/branch_checkpoint.rs` with
   branch-local checkpoint capture, resume, and reassignment helpers, then export it from
   `crates/mister-smith-agents/src/lib.rs`.
-- [ ] T010 [P] [US1] Extend `crates/mister-smith-persistence/src/kv/state.rs`,
+- [x] T010 [P] [US1] Extend `crates/mister-smith-persistence/src/kv/state.rs`,
   `crates/mister-smith-persistence/src/repository/task.rs`, and
   `crates/mister-smith-persistence/src/hybrid/manager.rs` to persist
   `BranchCheckpoint` state and resume metadata.
-- [ ] T011 [P] [US1] Create `crates/mister-smith-agents/src/profile.rs` and update
+- [x] T011 [P] [US1] Create `crates/mister-smith-agents/src/profile.rs` and update
   `crates/mister-smith-agents/src/scheduler.rs`,
   `crates/mister-smith-agents/src/roles/router.rs`, and
   `crates/mister-smith-agents/src/orchestrator.rs` to use health, budget,
   dependency-depth, and profile signals for branch dispatch decisions.
-- [ ] T012 [US1] Emit checkpoint and routing-rationale events in `crates/mister-smith-events/src/autonomy.rs` and integrate publishers in `crates/mister-smith-agents/src/orchestrator.rs`.
-- [ ] T013 [US1] Add branch checkpoint and reassignment coverage in `crates/mister-smith-agents/tests/checkpoint_tests.rs` and `crates/mister-smith-persistence/tests/repository_tests.rs`.
-- [ ] T014 [US1] Add resilience-aware routing coverage in `crates/mister-smith-agents/tests/topology_tests.rs` and `crates/mister-smith-agents/tests/team_tests.rs`.
-- [ ] T015 [US1] Add Gate 10 workflow coverage in `crates/mister-smith-agents/tests/gate10_tests.rs` exercising mixed-dependency execution, checkpoint resume, and invalid-graph rejection.
+- [x] T012 [US1] Emit checkpoint and routing-rationale events in `crates/mister-smith-events/src/autonomy.rs` and integrate publishers in `crates/mister-smith-agents/src/orchestrator.rs`.
+- [x] T013 [US1] Add branch checkpoint and reassignment coverage in `crates/mister-smith-agents/tests/checkpoint_tests.rs` and `crates/mister-smith-persistence/tests/repository_tests.rs`.
+- [x] T014 [US1] Add resilience-aware routing coverage in `crates/mister-smith-agents/tests/topology_tests.rs` and `crates/mister-smith-agents/tests/team_tests.rs`.
+- [x] T015 [US1] Add Gate 10 workflow coverage in `crates/mister-smith-agents/tests/gate10_tests.rs` exercising mixed-dependency execution, checkpoint resume, and invalid-graph rejection.
 
 **Checkpoint**: Branch-local recovery and resilience-aware dispatch work without re-running
 completed branches.
 
 ---
 
-## Subphase 10.3 — Managed Memory / Context Manager (User Story 2, Priority: P1)
+## Subphase 10.3 — Managed Memory / Context Manager (User Story 2, Priority: P1) — DONE
 
 **Goal**: Add managed memory fragments, role-aware context assembly, async consolidation, and
 checkpoint-ready snapshots over the existing Phase 6 storage substrate.
@@ -141,33 +159,33 @@ metadata-preserving consolidation, and snapshot-based resume without replaying f
 
 ### US2 Memory Management Tasks
 
-- [ ] T016 [US2] Create `crates/mister-smith-persistence/src/memory/mod.rs`,
+- [x] T016 [US2] Create `crates/mister-smith-persistence/src/memory/mod.rs`,
   `crates/mister-smith-persistence/src/memory/fragment.rs`,
   `crates/mister-smith-persistence/src/memory/manager.rs`,
   `crates/mister-smith-persistence/src/memory/snapshot.rs`, and export the new module from
   `crates/mister-smith-persistence/src/lib.rs`.
-- [ ] T017 [P] [US2] Create `crates/mister-smith-persistence/src/memory/consolidation.rs`
+- [x] T017 [P] [US2] Create `crates/mister-smith-persistence/src/memory/consolidation.rs`
   and extend `crates/mister-smith-persistence/src/repository/agent.rs` and
   `crates/mister-smith-persistence/src/repository/task.rs` with fragment metadata,
   paging, and snapshot persistence APIs.
-- [ ] T018 [P] [US2] Create `crates/mister-smith-agents/src/context_manager.rs` and
+- [x] T018 [P] [US2] Create `crates/mister-smith-agents/src/context_manager.rs` and
   integrate role-aware context assembly into
   `crates/mister-smith-agents/src/roles/planner.rs`,
   `crates/mister-smith-agents/src/roles/executor.rs`,
   `crates/mister-smith-agents/src/roles/critic.rs`, and
   `crates/mister-smith-agents/src/roles/memory.rs`.
-- [ ] T019 [US2] Update `crates/mister-smith-agents/src/branch_checkpoint.rs` and
+- [x] T019 [US2] Update `crates/mister-smith-agents/src/branch_checkpoint.rs` and
   `crates/mister-smith-persistence/src/memory/snapshot.rs` so branch resume reconstructs
   checkpoint-ready context snapshots instead of replaying full history.
-- [ ] T020 [US2] Add managed-memory and context-budget tests in `crates/mister-smith-persistence/tests/memory_manager_tests.rs` and `crates/mister-smith-agents/tests/context_manager_tests.rs`.
-- [ ] T021 [US2] Extend `crates/mister-smith-persistence/tests/performance_tests.rs`
+- [x] T020 [US2] Add managed-memory and context-budget tests in `crates/mister-smith-persistence/tests/memory_manager_tests.rs` and `crates/mister-smith-agents/tests/context_manager_tests.rs`.
+- [x] T021 [US2] Extend `crates/mister-smith-persistence/tests/performance_tests.rs`
   with context-reduction and async-consolidation assertions that prove `SC-202`.
 
 **Checkpoint**: Context delivery is bounded, role-aware, metadata-rich, and checkpoint-ready.
 
 ---
 
-## Subphase 10.4 — Guard / Advisor Supervision (User Story 3, Priority: P1)
+## Subphase 10.4 — Guard / Advisor Supervision (User Story 3, Priority: P1) — DONE
 
 **Goal**: Add predictive supervision that classifies failures, consumes step-level degradation
 signals, and applies targeted interventions before graph-wide restart.
@@ -177,31 +195,31 @@ the Guard layer chooses targeted interventions and emits operator-visible record
 
 ### US3 Guard Tasks
 
-- [ ] T022 [US3] Create `crates/mister-smith-agents/src/guard.rs` and
+- [x] T022 [US3] Create `crates/mister-smith-agents/src/guard.rs` and
   `crates/mister-smith-agents/src/intervention.rs` with failure taxonomy, decision
   policies, intervention application, and re-export them from
   `crates/mister-smith-agents/src/lib.rs`.
-- [ ] T023 [P] [US3] Extend `crates/mister-smith-llm/src/model_event.rs` and create `crates/mister-smith-llm/src/stream_monitor.rs` to emit step-boundary and degradation signals usable by the Guard layer.
-- [ ] T024 [P] [US3] Integrate Guard decisions into
+- [x] T023 [P] [US3] Extend `crates/mister-smith-llm/src/model_event.rs` and create `crates/mister-smith-llm/src/stream_monitor.rs` to emit step-boundary and degradation signals usable by the Guard layer.
+- [x] T024 [P] [US3] Integrate Guard decisions into
   `crates/mister-smith-agents/src/orchestrator.rs`,
   `crates/mister-smith-agents/src/roles/monitor.rs`,
   `crates/mister-smith-agents/src/roles/supervisor.rs`, and
   `crates/mister-smith-agents/src/scheduler.rs`.
-- [ ] T025 [US3] Extend `crates/mister-smith-agents/src/profile.rs` and `crates/mister-smith-events/src/autonomy.rs` with supervisory profile snapshots, failure evidence, and intervention summaries.
-- [ ] T025A [US3] Implement conservative fallback behavior in
+- [x] T025 [US3] Extend `crates/mister-smith-agents/src/profile.rs` and `crates/mister-smith-events/src/autonomy.rs` with supervisory profile snapshots, failure evidence, and intervention summaries.
+- [x] T025A [US3] Implement conservative fallback behavior in
   `crates/mister-smith-agents/src/orchestrator.rs`,
   `crates/mister-smith-agents/src/profile.rs`,
   `crates/mister-smith-agents/src/context_manager.rs`, and
   `crates/mister-smith-events/src/autonomy.rs` so missing profile data, memory metadata,
   or fresh control-plane state narrows autonomy and emits operator-visible reasons.
-- [ ] T026 [US3] Add Guard and stream-monitor tests in `crates/mister-smith-agents/tests/guard_tests.rs` and `crates/mister-smith-llm/tests/stream_monitor_tests.rs`.
+- [x] T026 [US3] Add Guard and stream-monitor tests in `crates/mister-smith-agents/tests/guard_tests.rs` and `crates/mister-smith-llm/tests/stream_monitor_tests.rs`.
 
 **Checkpoint**: Predictive supervision exists as a typed, branch-local layer above OTP restart
 semantics.
 
 ---
 
-## Subphase 10.5 — Operator Autonomy View (User Story 3, Priority: P1)
+## Subphase 10.5 — Operator Autonomy View (User Story 3, Priority: P1) — DONE
 
 **Goal**: Surface topology state, checkpoint lineage, context pressure, routing rationale, and
 intervention history through typed operator-facing autonomy views.
@@ -211,20 +229,20 @@ checkpoint lineage, memory pressure, and intervention history are visible withou
 
 ### US3 Operator View Tasks
 
-- [ ] T027 [US3] Create `crates/mister-smith-app/src/autonomy.rs` and wire
+- [x] T027 [US3] Create `crates/mister-smith-app/src/autonomy.rs` and wire
   autonomy-status inspection commands in `crates/mister-smith-app/src/main.rs` and
   `crates/mister-smith-app/src/bootstrap.rs`.
-- [ ] T028 [P] [US3] Extend `crates/mister-smith-app/src/observability.rs`,
+- [x] T028 [P] [US3] Extend `crates/mister-smith-app/src/observability.rs`,
   `crates/mister-smith-events/src/bus.rs`, and
   `crates/mister-smith-events/src/types.rs` to assemble `AutonomyStatusView` from typed
   topology, checkpoint, memory-pressure, and intervention events.
-- [ ] T029 [P] [US3] Add autonomy dashboards and alerts in `deploy/dashboards/` and
+- [x] T029 [P] [US3] Add autonomy dashboards and alerts in `deploy/dashboards/` and
   `deploy/alerts/` for topology choice, branch health, checkpoint staleness, context
   pressure, and intervention spikes.
-- [ ] T030 [US3] Create `crates/mister-smith-app/tests/autonomy_status_tests.rs` and
+- [x] T030 [US3] Create `crates/mister-smith-app/tests/autonomy_status_tests.rs` and
   extend `crates/mister-smith-events/tests/autonomy_event_tests.rs` to verify
   operator-visible rationale and intervention history.
-- [ ] T031 [US3] Extend `crates/mister-smith-agents/tests/gate10_tests.rs` with
+- [x] T031 [US3] Extend `crates/mister-smith-agents/tests/gate10_tests.rs` with
   transient, streaming, semantic-degradation, and missing-input fallback scenarios that
   remain operator-visible without raw log inspection and prove `SC-203`.
 
@@ -232,7 +250,7 @@ checkpoint lineage, memory pressure, and intervention history are visible withou
 
 ---
 
-## Subphase 10.6 — Bounded Delegation + Provenance (User Story 4, Priority: P2)
+## Subphase 10.6 — Bounded Delegation + Provenance (User Story 4, Priority: P2) — DONE
 
 **Goal**: Enforce bounded delegation, expiry, revocation, and provenance tracing for privileged
 autonomous actions without replacing the Phase 9.1 security substrate.
@@ -242,27 +260,27 @@ allow execution while expired, revoked, or broken chains are blocked and surface
 
 ### US4 Delegation Tasks
 
-- [ ] T032 [US4] Create `crates/mister-smith-security/src/delegation.rs` and re-export
+- [x] T032 [US4] Create `crates/mister-smith-security/src/delegation.rs` and re-export
   it from `crates/mister-smith-security/src/lib.rs` with issue, validate, and revoke
   capability services.
-- [ ] T033 [P] [US4] Extend `crates/mister-smith-security/src/jwt/claims.rs`,
+- [x] T033 [P] [US4] Extend `crates/mister-smith-security/src/jwt/claims.rs`,
   `crates/mister-smith-security/src/auth_callout.rs`, and
   `crates/mister-smith-security/src/audit/events.rs` with bounded delegation scope,
   expiry, revocation, and invalid-chain rejection.
-- [ ] T034 [P] [US4] Integrate capability checks into
+- [x] T034 [P] [US4] Integrate capability checks into
   `crates/mister-smith-agents/src/agent.rs`,
   `crates/mister-smith-agents/src/tool_bus.rs`,
   `crates/mister-smith-agents/src/orchestrator.rs`, and
   `crates/mister-smith-agents/src/branch_checkpoint.rs` so privileged actions carry
   provenance lineage.
-- [ ] T035 [P] [US4] Extend `crates/mister-smith-app/src/autonomy.rs`,
+- [x] T035 [P] [US4] Extend `crates/mister-smith-app/src/autonomy.rs`,
   `crates/mister-smith-app/src/observability.rs`, and
   `crates/mister-smith-events/src/autonomy.rs` to surface delegation chains and
   operator-visible rejection reasons.
-- [ ] T036 [US4] Create `crates/mister-smith-security/tests/delegation_tests.rs` and
+- [x] T036 [US4] Create `crates/mister-smith-security/tests/delegation_tests.rs` and
   extend `crates/mister-smith-security/tests/jwt_tests.rs` with valid, expired, revoked,
   and cyclic-chain coverage.
-- [ ] T037 [US4] Extend `crates/mister-smith-agents/tests/gate10_tests.rs` and
+- [x] T037 [US4] Extend `crates/mister-smith-agents/tests/gate10_tests.rs` and
   `crates/mister-smith-app/tests/autonomy_status_tests.rs` with privileged workflow
   audit scenarios proving full provenance reconstruction.
 
@@ -272,12 +290,15 @@ allow execution while expired, revoked, or broken chains are blocked and surface
 
 ## Verification & Readiness
 
-- [ ] T038 [P] Run `cargo test -p mister-smith-agents` after `T005`-`T015`, `T022`-`T031`, and `T034`-`T037`.
-- [ ] T039 [P] Run `cargo test -p mister-smith-persistence` and `cargo test -p mister-smith-security` after `T010`, `T016`-`T021`, and `T032`-`T036`.
-- [ ] T040 [P] Run `cargo test -p mister-smith-llm` and `cargo test -p mister-smith-core` after `T002`-`T004` and `T023`.
-- [ ] T041 [P] Run `cargo test -p mister-smith-app` after `T027`-`T035` and verify
+- [x] T038 [P] Run `cargo test -p mister-smith-agents` after `T005`-`T015`, `T022`-`T031`, and `T034`-`T037`.
+- [x] T039 [P] Run `cargo test -p mister-smith-persistence` and `cargo test -p mister-smith-security` after `T010`, `T016`-`T021`, and `T032`-`T036`.
+- [x] T040 [P] Run `cargo test -p mister-smith-llm` and `cargo test -p mister-smith-core` after `T002`-`T004` and `T023`.
+- [x] T041 [P] Run `cargo test -p mister-smith-app` after `T027`-`T035` and verify
   deploy artifact syntax for `deploy/dashboards/` and `deploy/alerts/`.
-- [ ] T042 Update `ROADMAP.md`, `CLAUDE.md`, and `README.md` with Phase 10 implementation status, then run `cargo build --workspace` and the scenarios in `specs/012-phase10-frontier-autonomy/quickstart.md`.
+- [x] T042 Update `ROADMAP.md`, `CLAUDE.md`, and `README.md` with Phase 10 implementation status, then run `cargo build --workspace` and the scenarios in `specs/012-phase10-frontier-autonomy/quickstart.md`.
+
+**Verification Note**: The 2026-03-15 gate pass completed the targeted crate suites, deploy asset
+syntax validation, workspace build, and the quickstart scenario mapping recorded in `quickstart.md`.
 
 ---
 
@@ -285,16 +306,16 @@ allow execution while expired, revoked, or broken chains are blocked and surface
 
 ### Subphase Dependencies
 
-- **10.0 Foundational**: No implementation dependencies; blocks all downstream work.
-- **10.1 Execution Graph + Topology Compiler**: Depends on 10.0.
-- **10.2 Branch Checkpointing + Resilience-Aware Routing**: Depends on 10.1.
-- **10.3 Managed Memory / Context Manager**: Depends on 10.0 and the branch identity introduced in 10.1.
-- **10.4 Guard / Advisor Supervision**: Depends on 10.1 and stable Phase 9 stream surfaces.
-- **10.5 Operator Autonomy View**: Depends on 10.2, 10.3, and 10.4 because it aggregates their typed state.
+- **10.0 Foundational**: No implementation dependencies; blocks all downstream work. Done.
+- **10.1 Execution Graph + Topology Compiler**: Depends on 10.0. Done.
+- **10.2 Branch Checkpointing + Resilience-Aware Routing**: Depends on 10.1. Done.
+- **10.3 Managed Memory / Context Manager**: Depends on 10.0 and the branch identity introduced in 10.1. Done.
+- **10.4 Guard / Advisor Supervision**: Depends on 10.1 and stable Phase 9 stream surfaces. Done.
+- **10.5 Operator Autonomy View**: Depends on 10.2, 10.3, and 10.4 because it aggregates their typed state. Done.
 - **10.6 Bounded Delegation + Provenance**: Depends on 10.5 and the Phase 9.1
   delegation-chain substrate because operator-visible provenance is part of the phase
-  acceptance boundary.
-- **Verification**: Depends on all implemented subphases and documentation updates.
+  acceptance boundary. Done.
+- **Verification**: Depends on all implemented subphases and documentation updates. Done.
 
 ### User Story Dependencies
 


### PR DESCRIPTION
## Problem

`MS-35` was still open after Phase 10 landed. The repo needed a gate pass that reconciled the SpecKit artifacts, roadmap, research, and architecture references against the post-PR-190 baseline, while also separating unrelated local stash work from the gate branch.

## Solution

- refresh SpecKit scaffolding in place to upstream `0.3.0`
- reconcile the Phase 10 spec, plan, tasks, research, quickstart, and analyze docs with the current repo implementation
- update `ROADMAP.md`, `README.md`, and `CLAUDE.md` to reflect the closed Phase 10 gate state
- add a durable `MS-35` closeout note that records validation evidence and the stash split decision

## Validation

- `cargo test -p mister-smith-agents`
- `cargo test -p mister-smith-persistence`
- `cargo test -p mister-smith-security`
- `cargo test -p mister-smith-llm`
- `cargo test -p mister-smith-core`
- `cargo test -p mister-smith-app`
- `python3 scripts/validate_deploy_assets.py deploy/dashboards deploy/alerts`
- `cargo build --workspace`
- `npx markdownlint-cli2 "specs/012-phase10-frontier-autonomy/**/*.md" "docs/plans/2026-03-15-ms-35-phase10-gate-and-speckit-refresh.md" --config .markdownlint.json`
- `git diff --check`
