### PR TITLE
fix(workflow): streamline delegated review and PR checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,14 +8,18 @@ jobs.
 
 ### Core automation
 
-- `ci.yml`: Required Rust CI for pushes and pull requests targeting `main`.
+- `ci.yml`: Required Rust CI for code-changing pushes and pull requests
+  targeting `main`. It is intentionally scoped away from docs-only and
+  release-note-only changes, and it cancels superseded runs for the same PR.
 - `vet.yml`: Pull-request review workflow that runs `imbue-ai/vet` with the
   repository's `.vet/configs.toml` CI profile and posts findings back to the
-  PR.
+  PR. It is scoped to code-changing PRs, skips Dependabot, and skips cleanly
+  when `OPENAI_API_KEY` is unavailable.
 - `claude.yml`: On-demand Claude assistant for `@claude` issue and pull request
   interactions using `anthropics/claude-code-action@v1`.
-- `claude-code-review.yml`: Automatic Claude review on pull request updates using
-  the same OAuth-backed action.
+- `claude-code-review.yml`: Automatic Claude review on code-changing pull
+  request updates using the same OAuth-backed action. It skips Dependabot and
+  cancels superseded runs for the same PR.
 - `pr-labeler.yml`: Automatic pull request labeling based on changed files and
   branch patterns.
 - `release-drafter.yml`: Maintains a draft release on `main` so release notes
@@ -56,6 +60,9 @@ the old `CLAUDE_ACCESS_TOKEN`, `CLAUDE_REFRESH_TOKEN`, `CLAUDE_EXPIRES_AT`, and
 - The Rust CI is the repository's primary enforcement workflow.
 - Vet adds LLM-based PR review on top of CI instead of replacing compile/test
   validation.
+- `Human Review` remains the native Symphony state name, but delegated-agent
+  review may satisfy that checkpoint when the operator has already granted
+  review-and-merge authority in the active session.
 - The documentation workflows are still scoped to the `spec/` corpus.
 - Claude automation now uses a single authentication approach based on
   `CLAUDE_CODE_OAUTH_TOKEN` rather than maintaining two competing action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'scripts/**'
+      - 'deploy/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'scripts/**'
+      - 'deploy/**'
+      - '.github/workflows/ci.yml'
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,16 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
@@ -18,6 +22,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/documentation-validation.yml
+++ b/.github/workflows/documentation-validation.yml
@@ -28,6 +28,10 @@ on:
 env:
   STRICT_MODE: ${{ github.event.inputs.strict_mode || false }}
 
+concurrency:
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Markdown formatting and linting
   markdown-lint:

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -3,6 +3,17 @@ name: Vet
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'scripts/**'
+      - '.vet/**'
+      - '.github/workflows/vet.yml'
+
+concurrency:
+  group: vet-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -10,7 +21,7 @@ permissions:
 
 jobs:
   vet:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]' && secrets.OPENAI_API_KEY != ''
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -161,7 +161,9 @@ Instructions:
 - `Backlog` -> out of scope for this workflow. Do not modify.
 - `Todo` -> immediately move to `In Progress`, then start execution.
 - `In Progress` -> active implementation.
-- `Human Review` -> wait for reviewer input and poll for updates.
+- `Human Review` -> Symphony-native review checkpoint. Keep the state name, but when the active
+  Codex session has explicit operator authority to review and merge, the agent may satisfy the
+  review step here instead of waiting for a separate human hop.
 - `Merging` -> follow `.codex/skills/land/SKILL.md`.
 - `Rework` -> reopen the execution flow with a fresh plan.
 - `Done` -> terminal; no further action.
@@ -206,6 +208,8 @@ Instructions:
    - resolve all actionable PR comments or push back explicitly
    - confirm checks are green after the latest push
    - confirm every required validation item is complete
+   - if the current session already has explicit operator review/merge authority, continue straight
+     into the `Human Review` checklist in the same session instead of waiting for another pass
 
 ### Merge posture for Claude review automation
 
@@ -215,16 +219,20 @@ Instructions:
   shows the known SDK crash signature (`SDK execution error:
   Error: Claude Code process exited with code 1`) and the PR does
   not change that workflow or its plugin configuration.
-- Merge may proceed only when required repository validation is green and there are no unresolved human review findings.
+- Merge may proceed only when required repository validation is green and there are no unresolved
+  review findings.
 - Otherwise, treat a `claude-review` failure as potentially repo-local until the workflow change or failure mode is reviewed.
 
 ## Step 3: Human review and merge handling
 
-1. In `Human Review`, do not code. Poll for updates.
-2. If review feedback requires changes, move the issue to `Rework`.
-3. If approved, the issue moves to `Merging`.
-4. In `Merging`, follow the `land` skill until the PR is merged.
-5. After merge is complete, move the issue to `Done`.
+1. Keep the state name `Human Review`; it is native to Symphony.
+2. In `Human Review`, review the PR diff, comments, and current checks.
+3. If the active session has explicit operator review/merge authority and the PR is clean, treat
+   that delegated review as sufficient and move the issue to `Merging` in the same session.
+4. If review feedback or the agent's own review finds a real problem, move the issue to `Rework`.
+5. Without explicit operator delegation, poll for external reviewer updates instead of guessing.
+6. In `Merging`, follow the `land` skill until the PR is merged.
+7. After merge is complete, move the issue to `Done`.
 
 ## Step 4: Rework handling
 

--- a/crates/mister-smith-mcp/src/compatibility.rs
+++ b/crates/mister-smith-mcp/src/compatibility.rs
@@ -4340,8 +4340,10 @@ impl SmithCompatibilityServer {
 
         let mut recommended_actions = linear.data.suggested_actions.clone();
         if human_review_count > 0 {
-            recommended_actions
-                .push("inspect Human Review issues and land approved PRs".to_string());
+            recommended_actions.push(
+                "inspect Human Review issues, complete delegated review when authorized, and land merge-ready PRs"
+                    .to_string(),
+            );
         }
         if merging_count > 0 {
             recommended_actions
@@ -6697,7 +6699,7 @@ fn lifecycle_review_state(
     matching_pull_requests: &[GitHubPullRequest],
 ) -> String {
     match state_name(issue) {
-        Some("Human Review") => "awaiting_human_review".to_string(),
+        Some("Human Review") => "review_pending".to_string(),
         Some("Rework") => "rework".to_string(),
         Some("Merging") => "merge_ready".to_string(),
         Some("In Progress") if !matching_pull_requests.is_empty() => "pull_request_open".to_string(),
@@ -6769,7 +6771,7 @@ fn build_issue_lifecycle_resolution(
         Some("Backlog") if queue_role == "validated_backlog" => "plan_queue_stage".to_string(),
         Some("Todo") => "move_issue_to_in_progress".to_string(),
         Some("In Progress") => "continue_execution".to_string(),
-        Some("Human Review") => "await_review_or_route_to_rework".to_string(),
+        Some("Human Review") => "review_or_route_to_rework".to_string(),
         Some("Rework") => "restart_execution_with_fresh_plan".to_string(),
         Some("Merging") => "land_merge".to_string(),
         Some(state) if is_terminal_state(state, workflow) => "no_further_action".to_string(),

--- a/docs/linear/LINEAR.md
+++ b/docs/linear/LINEAR.md
@@ -18,22 +18,19 @@ Initiative (strategic goal)
 ### Initiatives
 
 Use initiatives as the strategic layer, not as Symphony's dispatch boundary. Historical initiatives
-remain useful for reporting and status updates, but the current forward direction is `WinYear`,
-the program that turns Mister Smith from a validated substrate into a differentiated orchestration
-operating system.
+remain useful for reporting and status updates, but the current forward direction is the
+post-recovery operating-system work captured in `docs/plans/2026-03-16-frontier-direction.md`.
 
 ### Current Strategy
 
-- `WinYear` is the active strategic direction for new operating-system work after the March 16
-  recovery landings.
-- `MS-45` through `MS-48` are the current WinYear backlog epics; keep them in `Backlog` until the
-  next execution cycle explicitly stages bounded slices.
-- `MisterSmith Validated Backlog` should hold the next WinYear epics in `Backlog` until they are
-  explicitly staged.
-- Do not move WinYear issues into the watched queue just to keep Symphony busy. Stage only the
-  next bounded runnable slice.
+- `MS-45` through `MS-48` are the current post-recovery operating-system backlog epics; keep them
+  in `Backlog` until the next execution cycle explicitly stages bounded slices.
+- `MisterSmith Validated Backlog` should hold these epics in `Backlog` until they are explicitly
+  staged.
+- Do not move these issues into the watched queue just to keep Symphony busy. Stage only the next
+  bounded runnable slice.
 - The current repo-owned direction note is
-  `docs/plans/2026-03-16-winyear-frontier-direction.md`.
+  `docs/plans/2026-03-16-frontier-direction.md`.
 
 ### Projects
 
@@ -70,7 +67,9 @@ project and in active workflow states can dispatch. Project placement is therefo
 decorative.
 
 `Human Review` is a real workflow state, but it is intentionally not part of Symphony's
-`active_states` because review handoff is not dispatch-active work.
+`active_states` because review handoff is not dispatch-active work. Keep the native state name,
+but do not require a second human hop when the active Codex session already has explicit operator
+authority to review and merge.
 
 Do not collapse all planning into a single giant `MisterSmith` project just to satisfy that current
 runtime limitation. If project switching becomes the real bottleneck, prefer a dedicated execution
@@ -252,9 +251,9 @@ Include `MS-###` in commit messages and PR titles to link them to Linear issues.
 | Todo | unstarted | Unblocked work in the watched project, ready to start |
 | In Progress | started | Actively being worked on |
 | In Review | started | Optional human-only review state; avoid using it for the Symphony path |
-| Human Review | started | Agent finished, awaiting human approval (Symphony) |
+| Human Review | started | Native Symphony review checkpoint; delegated-agent review may satisfy it when the operator has already granted authority |
 | Rework | started | Reviewer requested changes, agent restarts (Symphony) |
-| Merging | started | PR approved, agent lands the merge (Symphony) |
+| Merging | started | Review is complete, agent lands the merge (Symphony) |
 | Done | completed | Merged and verified |
 | Duplicate | canceled | Duplicate of another issue |
 | Canceled | canceled | Will not be done |
@@ -270,7 +269,7 @@ In Review → Done (PR merged)
 ```
 
 With GitHub integration, branch creation should move to `In Progress`, PR open/review-requested
-should move Symphony issues to `Human Review`, ready-to-merge work should move to `Merging`, and
+should move Symphony issues to `Human Review`, review-complete work should move to `Merging`, and
 merge to `main` should move to `Done`.
 
 ### Status Transitions (Symphony)
@@ -278,8 +277,8 @@ merge to `main` should move to `Done`.
 ```
 Todo → In Progress (agent picks up issue)
 In Progress → Human Review (agent opens PR, requests review)
-Human Review → Merging (reviewer approves)
-Human Review → Rework (reviewer requests changes)
+Human Review → Merging (delegated agent or reviewer completes review)
+Human Review → Rework (reviewer or delegated agent requests changes)
 Rework → In Progress (agent restarts with feedback)
 Merging → Done (agent lands PR merge)
 ```
@@ -303,7 +302,9 @@ Linear documents are used for reference material linked to projects:
 | Phase 9.1 Security Hardening Spec | Phase 9.1 | Security hardening specification |
 | Research Corpus Index | MisterSmith Workspace Docs | Research program navigation |
 
-Documents require a project link. For cross-cutting documents, link them to `MisterSmith Workspace Docs` as the general-purpose project. Historical phase-specific specs can stay attached to their archived phase projects.
+Documents require a project link. For cross-cutting documents, link them to
+`MisterSmith Workspace Docs` as the general-purpose project. Historical
+phase-specific specs can stay attached to their archived phase projects.
 
 ## Templates
 
@@ -315,7 +316,7 @@ default template for members or non-members.
 |----------|-----|
 | Symphony Execution-Ready Issue | Work that is truly safe to stage into the watched execution queue |
 | Validated Backlog Item | Repo-validated work that is real but not yet scheduled |
-| Human Review Handoff | PR-ready or review-ready work that needs human sign-off or merge action |
+| Human Review Handoff | PR-ready or review-ready work that needs a final review decision or merge action |
 | Workflow / CI Issue | Repo workflow, automation, CI, tooling, or release-process failures |
 
 Keep templates opinionated and small. They should enforce issue quality and routing clarity, not
@@ -382,6 +383,9 @@ Settings > Integrations > GitHub > Connect `matthewmaggio/Mister-Smith`
 - PR becomes mergeable → issue moves to Merging
 - PR merge to `main` → issue moves to Done
 - Include `MS-###` in branch names and commit messages
+- When the operator has explicitly delegated authority in the active Codex session, the agent may
+  perform the Human Review decision and advance the issue to `Merging` without waiting for another
+  human to click approve.
 
 ### Claude Code Integration (manual setup required)
 
@@ -431,7 +435,9 @@ When adding a new crate to the workspace:
 
 ## Symphony Integration
 
-[OpenAI Symphony](https://github.com/openai/symphony) orchestrates Codex agents against Linear issues. It polls for `Todo` issues, spawns a Codex `app-server` per issue, and manages the full lifecycle through the status state machine.
+[OpenAI Symphony](https://github.com/openai/symphony) orchestrates Codex agents
+against Linear issues. It polls for `Todo` issues, spawns a Codex `app-server`
+per issue, and manages the full lifecycle through the status state machine.
 
 Important: Symphony is currently scoped to one watched `project_slug`, and that value must be the
 Linear project `slugId`. Issues outside that watched project do not dispatch, even if their status
@@ -451,8 +457,8 @@ is `Todo`.
 
 - **Todo → In Progress**: Symphony picks up the issue, spawns a Codex agent
 - **In Progress → Human Review**: Agent opens a PR and requests review
-- **Human Review → Merging**: Reviewer approves the PR
-- **Human Review → Rework**: Reviewer requests changes; agent restarts
+- **Human Review → Merging**: Delegated agent review or external reviewer approval completes
+- **Human Review → Rework**: Reviewer or delegated agent requests changes; agent restarts
 - **Rework → In Progress**: Agent re-reads feedback, creates fresh plan
 - **Merging → Done**: Agent lands the PR merge via the `land` skill
 

--- a/docs/plans/2026-03-16-autonomous-review-fast-path.md
+++ b/docs/plans/2026-03-16-autonomous-review-fast-path.md
@@ -1,0 +1,55 @@
+# Autonomous Review Fast Path
+
+Date: March 16, 2026
+Status: In Progress
+
+## Objective
+
+Preserve Symphony's native `Human Review` state name while removing the extra human handoff when
+the operator has already delegated review and merge authority to Codex, and reduce avoidable PR
+latency from redundant or mis-scoped workflow automation.
+
+## Scope
+
+- `WORKFLOW.md` and `docs/linear/LINEAR.md` contract updates
+- Smith lifecycle hint updates in `crates/mister-smith-mcp/src/compatibility.rs`
+- GitHub Actions trigger, concurrency, and advisory-review scoping updates
+- workflow documentation refresh under `.github/workflows/README.md`
+- re-evaluation of the remaining open PRs under the updated contract
+
+## Assumptions
+
+- Symphony's native state machine keeps the `Human Review` and `Merging` state names.
+- Explicit operator delegation in the active Codex session is sufficient authority for the agent to
+  perform the review step and land a clean PR.
+- `vet` and automated Claude review remain advisory layers on top of substantive repository
+  validation.
+
+## Constraints
+
+- Do not rename or remove Symphony-native workflow states.
+- Do not weaken the substantive merge gate for code changes.
+- Prefer narrower workflow triggers and canceled duplicate runs over adding more required checks.
+
+## Non-goals
+
+- Replacing Symphony's state machine
+- Rebuilding the full documentation-validation workflow
+- Forcing merges that still fail the substantive repository gate
+
+## Milestones
+
+1. Update workflow contracts so `Human Review` can be satisfied by delegated-agent review.
+   Validation: targeted markdown readback.
+2. Update Smith lifecycle hints to recommend review/merge instead of passive waiting.
+   Validation: targeted `mister-smith-mcp` test/build proof.
+3. Scope PR automation to the changes that actually need it and cancel superseded runs.
+   Validation: YAML syntax checks and workflow diff review.
+4. Reassess the open PR set and execute the merge/close actions that are now honest.
+   Validation: live GitHub and Smith control-plane snapshots.
+
+## Stop Conditions
+
+- A required workflow name, state name, or external integration contract would need to change.
+- The narrower CI trigger would skip a code-changing surface that still needs the substantive gate.
+- Smith compatibility changes introduce test regressions or contradict the repo-owned workflow docs.


### PR DESCRIPTION
## Summary
- allow delegated-agent review to satisfy Symphony Human Review without renaming the native state
- scope CI, vet, and Claude review to code-changing PRs and cancel superseded runs
- update Smith lifecycle hints and repo docs to reflect the faster merge path

## Validation
- ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/vet.yml .github/workflows/claude-code-review.yml .github/workflows/documentation-validation.yml].each { |p| YAML.load_file(p); puts "OK #{p}" }'
- npx markdownlint-cli2 WORKFLOW.md docs/plans/2026-03-16-autonomous-review-fast-path.md .github/workflows/README.md --config .markdownlint.json
- cargo test -p mister-smith-mcp
- git diff --check -- WORKFLOW.md docs/linear/LINEAR.md docs/plans/2026-03-16-autonomous-review-fast-path.md .github/workflows/ci.yml .github/workflows/vet.yml .github/workflows/claude-code-review.yml .github/workflows/documentation-validation.yml .github/workflows/README.md crates/mister-smith-mcp/src/compatibility.rs

## Notes
- cargo fmt --all -- --check still reports broad pre-existing formatting drift in crates/mister-smith-mcp/src/compatibility.rs outside this targeted workflow pass.
- docs/linear/LINEAR.md still has pre-existing markdownlint debt; the touched contract sections were updated and the repo-clean markdownlint proof is on the newly added plan/workflow/readme files.