### PR TITLE
MS-90: unify result contract across task and session views

### DIFF
--- a/crates/mister-smith-app/src/autonomy.rs
+++ b/crates/mister-smith-app/src/autonomy.rs
@@ -637,12 +637,20 @@ pub(crate) fn enrich_result_preview(
     }
 }
 
+pub(crate) fn retained_result_view(
+    task_result: &Value,
+    turn_index: u32,
+    status: &str,
+) -> Option<SessionRetainedResultView> {
+    build_session_retained_result(task_result, turn_index, status)
+}
+
 pub(crate) fn retained_assistant_result(
     task_result: &Value,
     turn_index: u32,
     status: &str,
 ) -> Option<Value> {
-    build_session_retained_result(task_result, turn_index, status)
+    retained_result_view(task_result, turn_index, status)
         .map(|projection| projection.assistant_result)
 }
 
@@ -897,7 +905,7 @@ pub(crate) fn resume_provenance_from_metadata(metadata: &Value) -> Option<Resume
             })
         });
     let resumed_after_restart = transcript_entry
-        .and_then(|entry| entry.get("assistant_result"))
+        .and_then(transcript_assistant_result_payload)
         .and_then(|result| result.get("recovered_after_restart"))
         .and_then(Value::as_bool)
         .unwrap_or(false);
@@ -920,6 +928,11 @@ pub(crate) fn resume_provenance_from_metadata(metadata: &Value) -> Option<Resume
         resumed_from_workflow_id,
         resumed_from_turn_index,
     })
+}
+
+fn transcript_assistant_result_payload(entry: &Value) -> Option<&Value> {
+    let projection = entry.get("assistant_result")?;
+    projection.get("assistant_result").or(Some(projection))
 }
 
 fn render_resume_provenance(summary: &ResumeProvenanceSummary) -> String {

--- a/crates/mister-smith-app/src/conversation.rs
+++ b/crates/mister-smith-app/src/conversation.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::Utc;
 use mister_smith_config::FrameworkConfig;
-use mister_smith_core::{AgentId, SessionId, SessionStatus, TaskId};
+use mister_smith_core::{AgentId, SessionId, SessionRetainedResultView, SessionStatus, TaskId};
 use mister_smith_http::server::{
     ConversationContinueRequest, ConversationCreateRequest, ConversationEndView,
     ConversationResumeProvenanceView, ConversationServiceError, ConversationSessionService,
@@ -395,8 +395,17 @@ async fn build_session_view(
         .map(|record| (record.task_id, record.metadata))
         .collect::<HashMap<_, _>>();
     let mut turn_summaries = Vec::with_capacity(turns.len());
+    let mut last_assistant_result = None;
     for turn in turns {
         let workflow_id = TaskId::from_uuid(turn.workflow_id);
+        let assistant_result = u32::try_from(turn.turn_index).ok().and_then(|turn_index| {
+            turn.result_summary.as_ref().and_then(|task_result| {
+                crate::autonomy::retained_result_view(task_result, turn_index, &turn.status)
+            })
+        });
+        if let Some(retained_result) = assistant_result.clone() {
+            last_assistant_result = Some(retained_result);
+        }
         let resume_provenance = task_metadata_by_workflow
             .get(&turn.workflow_id)
             .and_then(resume_provenance_from_metadata)
@@ -413,6 +422,7 @@ async fn build_session_view(
             workflow_id,
             status: turn.status,
             user_message: turn.user_message,
+            assistant_result,
             resume_provenance,
         });
     }
@@ -426,6 +436,7 @@ async fn build_session_view(
         active_workflow_id: session.active_workflow_id.map(TaskId::from_uuid),
         last_completed_workflow_id: session.last_completed_workflow_id.map(TaskId::from_uuid),
         turn_count: session.turn_count.max(0) as u32,
+        last_assistant_result,
         turns: turn_summaries,
         ended_at: session.ended_at,
     })
@@ -497,10 +508,17 @@ fn retained_context_after_turn(
         .as_ref()
         .and_then(|value| {
             u32::try_from(turn.turn_index).ok().and_then(|turn_index| {
-                crate::autonomy::retained_assistant_result(value, turn_index, &turn.status)
+                crate::autonomy::retained_result_view(value, turn_index, &turn.status)
             })
         })
-        .or(result_summary)
+        .and_then(|projection| serde_json::to_value(projection).ok())
+        .or_else(|| {
+            result_summary.as_ref().and_then(|value| {
+                u32::try_from(turn.turn_index).ok().and_then(|turn_index| {
+                    crate::autonomy::retained_assistant_result(value, turn_index, &turn.status)
+                })
+            })
+        })
         .unwrap_or_else(|| json!({ "status": turn.status }));
     let summary_entry = json!({
         "turn_index": turn.turn_index,
@@ -566,6 +584,8 @@ pub(crate) struct ConversationCliSessionView {
     pub last_completed_workflow_id: Option<String>,
     pub turn_count: u32,
     #[serde(default)]
+    pub last_assistant_result: Option<SessionRetainedResultView>,
+    #[serde(default)]
     pub turns: Vec<ConversationCliTurnSummary>,
     pub ended_at: Option<String>,
 }
@@ -589,6 +609,8 @@ pub(crate) struct ConversationCliTurnSummary {
     pub workflow_id: String,
     pub status: String,
     pub user_message: String,
+    #[serde(default)]
+    pub assistant_result: Option<SessionRetainedResultView>,
     #[serde(default)]
     pub resume_provenance: Option<ConversationCliResumeProvenanceView>,
 }
@@ -747,25 +769,36 @@ pub(crate) fn render_session(view: &ConversationCliSessionView) -> String {
         .turns
         .iter()
         .map(|turn| {
+            let assistant_result = turn
+                .assistant_result
+                .as_ref()
+                .map(render_retained_result)
+                .unwrap_or_else(|| "none".to_string());
             let resume_provenance = turn
                 .resume_provenance
                 .as_ref()
                 .map(render_resume_provenance)
                 .unwrap_or_else(|| "none".to_string());
             format!(
-                "  {} {} {} resume={} {}",
+                "  {} {} {} resume={} result={} {}",
                 turn.turn_index,
                 turn.workflow_id,
                 turn.status,
                 resume_provenance,
+                assistant_result,
                 turn.user_message
             )
         })
         .collect::<Vec<_>>()
         .join("\n");
+    let last_assistant_result = view
+        .last_assistant_result
+        .as_ref()
+        .map(render_retained_result)
+        .unwrap_or_else(|| "none".to_string());
 
     format!(
-        "session_id: {}\nstatus: {}\ncoordinator_agent_id: {}\nprovider_kind: {}\nmodel_id: {}\nactive_workflow_id: {}\nlast_completed_workflow_id: {}\nturn_count: {}\nended_at: {}\nturns:\n{}",
+        "session_id: {}\nstatus: {}\ncoordinator_agent_id: {}\nprovider_kind: {}\nmodel_id: {}\nactive_workflow_id: {}\nlast_completed_workflow_id: {}\nlast_assistant_result: {}\nturn_count: {}\nended_at: {}\nturns:\n{}",
         view.session_id,
         view.status,
         view.coordinator_agent_id,
@@ -773,6 +806,7 @@ pub(crate) fn render_session(view: &ConversationCliSessionView) -> String {
         view.model_id,
         view.active_workflow_id.as_deref().unwrap_or("none"),
         view.last_completed_workflow_id.as_deref().unwrap_or("none"),
+        last_assistant_result,
         view.turn_count,
         view.ended_at.as_deref().unwrap_or("none"),
         if turns.is_empty() { "none".to_string() } else { turns }
@@ -813,6 +847,34 @@ fn render_resume_provenance(view: &ConversationCliResumeProvenanceView) -> Strin
     } else {
         parts.join(" ")
     }
+}
+
+fn render_retained_result(view: &SessionRetainedResultView) -> String {
+    let proof_outcome = view
+        .assistant_result
+        .get("proof_outcome")
+        .and_then(Value::as_str)
+        .unwrap_or("none");
+    let preview = view
+        .preview
+        .clone()
+        .or_else(|| {
+            view.assistant_result
+                .get("preview")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "none".to_string());
+    let source_fields = if view.provenance.source_fields.is_empty() {
+        "none".to_string()
+    } else {
+        view.provenance.source_fields.join("|")
+    };
+
+    format!(
+        "workflow={} status={} proof={} preview={} sources={}",
+        view.workflow_id, view.status, proof_outcome, preview, source_fields
+    )
 }
 
 #[cfg(test)]
@@ -913,16 +975,26 @@ mod tests {
         );
 
         let assistant_result = retained["transcript_summary"][0]["assistant_result"].clone();
+        assert_eq!(
+            assistant_result["workflow_id"],
+            json!(workflow_id.to_string())
+        );
+        assert_eq!(assistant_result["turn_index"], json!(2));
+        assert_eq!(assistant_result["status"], json!("completed"));
         assert_eq!(assistant_result["preview"], json!("bounded answer preview"));
         assert_eq!(
-            assistant_result["proof_outcome"],
+            assistant_result["assistant_result"]["proof_outcome"],
             json!("graph_formed_and_completed")
         );
         assert_eq!(
-            assistant_result["aggregated_result"]["summary"],
+            assistant_result["assistant_result"]["aggregated_result"]["summary"],
             json!("bounded answer preview")
         );
-        assert!(assistant_result.get("result").is_none());
+        assert_eq!(
+            assistant_result["provenance"]["source_fields"],
+            json!(["metadata.final_result", "metadata.aggregated_result"])
+        );
+        assert!(assistant_result["assistant_result"].get("result").is_none());
     }
 
     #[test]
@@ -969,11 +1041,11 @@ mod tests {
         );
 
         assert_eq!(
-            retained["last_assistant_result"]["recovered_after_restart"],
+            retained["last_assistant_result"]["assistant_result"]["recovered_after_restart"],
             json!(true)
         );
         assert_eq!(
-            retained["last_assistant_result"]["proof_outcome"],
+            retained["last_assistant_result"]["assistant_result"]["proof_outcome"],
             json!("failed_before_graph")
         );
     }
@@ -1007,7 +1079,22 @@ mod tests {
                         "turn_index": 1,
                         "workflow_id": "44444444-4444-4444-4444-444444444444",
                         "assistant_result": {
-                            "recovered_after_restart": true
+                            "workflow_id": "44444444-4444-4444-4444-444444444444",
+                            "turn_index": 1,
+                            "status": "failed",
+                            "assistant_result": {
+                                "recovered_after_restart": true
+                            },
+                            "preview": "workflow interrupted",
+                            "provenance": {
+                                "runtime_execution_mode": {
+                                    "execution_boundary": "tool_bus"
+                                },
+                                "source_fields": [
+                                    "metadata.final_result",
+                                    "metadata.aggregated_result"
+                                ]
+                            }
                         }
                     }
                 ]
@@ -1038,12 +1125,69 @@ mod tests {
             active_workflow_id: None,
             last_completed_workflow_id: Some("55555555-5555-5555-5555-555555555555".to_string()),
             turn_count: 2,
+            last_assistant_result: Some(SessionRetainedResultView {
+                workflow_id: TaskId::from_uuid(
+                    Uuid::parse_str("55555555-5555-5555-5555-555555555555").unwrap(),
+                ),
+                turn_index: 2,
+                status: "completed".to_string(),
+                assistant_result: json!({
+                    "preview": "bounded answer preview",
+                    "aggregated_result": {
+                        "summary": "bounded answer preview"
+                    },
+                    "proof_outcome": "collapsed_to_sequential"
+                }),
+                preview: Some("bounded answer preview".to_string()),
+                provenance: mister_smith_core::ResultProvenanceSummary {
+                    runtime_execution_mode: json!({
+                        "execution_boundary": "tool_bus"
+                    }),
+                    graph_state: None,
+                    graph_id: None,
+                    source_fields: vec![
+                        "metadata.final_result".to_string(),
+                        "metadata.aggregated_result".to_string(),
+                    ],
+                },
+            }),
             turns: vec![
                 ConversationCliTurnSummary {
                     turn_index: 1,
                     workflow_id: "44444444-4444-4444-4444-444444444444".to_string(),
                     status: "failed".to_string(),
                     user_message: "turn one".to_string(),
+                    assistant_result: Some(SessionRetainedResultView {
+                        workflow_id: TaskId::from_uuid(
+                            Uuid::parse_str("44444444-4444-4444-4444-444444444444").unwrap(),
+                        ),
+                        turn_index: 1,
+                        status: "failed".to_string(),
+                        assistant_result: json!({
+                            "preview": "workflow interrupted by runtime restart before session sync",
+                            "aggregated_result": {
+                                "error": "workflow interrupted by runtime restart before session sync",
+                                "recovered_after_restart": true
+                            },
+                            "proof_outcome": "failed_before_graph",
+                            "recovered_after_restart": true
+                        }),
+                        preview: Some(
+                            "workflow interrupted by runtime restart before session sync"
+                                .to_string(),
+                        ),
+                        provenance: mister_smith_core::ResultProvenanceSummary {
+                            runtime_execution_mode: json!({
+                                "execution_boundary": "tool_bus"
+                            }),
+                            graph_state: None,
+                            graph_id: None,
+                            source_fields: vec![
+                                "metadata.final_result".to_string(),
+                                "metadata.aggregated_result".to_string(),
+                            ],
+                        },
+                    }),
                     resume_provenance: Some(ConversationCliResumeProvenanceView {
                         recovered_after_restart: true,
                         resumed_after_restart: false,
@@ -1061,6 +1205,32 @@ mod tests {
                     workflow_id: "55555555-5555-5555-5555-555555555555".to_string(),
                     status: "completed".to_string(),
                     user_message: "turn two".to_string(),
+                    assistant_result: Some(SessionRetainedResultView {
+                        workflow_id: TaskId::from_uuid(
+                            Uuid::parse_str("55555555-5555-5555-5555-555555555555").unwrap(),
+                        ),
+                        turn_index: 2,
+                        status: "completed".to_string(),
+                        assistant_result: json!({
+                            "preview": "bounded answer preview",
+                            "aggregated_result": {
+                                "summary": "bounded answer preview"
+                            },
+                            "proof_outcome": "collapsed_to_sequential"
+                        }),
+                        preview: Some("bounded answer preview".to_string()),
+                        provenance: mister_smith_core::ResultProvenanceSummary {
+                            runtime_execution_mode: json!({
+                                "execution_boundary": "tool_bus"
+                            }),
+                            graph_state: None,
+                            graph_id: None,
+                            source_fields: vec![
+                                "metadata.final_result".to_string(),
+                                "metadata.aggregated_result".to_string(),
+                            ],
+                        },
+                    }),
                     resume_provenance: Some(ConversationCliResumeProvenanceView {
                         recovered_after_restart: false,
                         resumed_after_restart: true,
@@ -1084,5 +1254,9 @@ mod tests {
         );
         assert!(rendered.contains("resume=resumed_after_restart=true resumed_from_turn=1"));
         assert!(rendered.contains("resumed_from_workflow=44444444-4444-4444-4444-444444444444"));
+        assert!(rendered
+            .contains("last_assistant_result: workflow=55555555-5555-5555-5555-555555555555"));
+        assert!(rendered.contains("result=workflow=55555555-5555-5555-5555-555555555555 status=completed proof=collapsed_to_sequential preview=bounded answer preview"));
+        assert!(rendered.contains("sources=metadata.final_result|metadata.aggregated_result"));
     }
 }

--- a/crates/mister-smith-app/src/execution.rs
+++ b/crates/mister-smith-app/src/execution.rs
@@ -166,6 +166,32 @@ fn persist_step_routing_history(metadata: &mut Value, history: &[StepRoutingDeci
     }
 }
 
+struct TerminalResultViews {
+    aggregated_result: Value,
+    final_result: Value,
+    task_result: Value,
+}
+
+fn terminal_result_views(
+    status: &str,
+    canonical_result: mister_smith_core::UnifiedResultEnvelope,
+) -> Result<TerminalResultViews, String> {
+    let aggregated_result = canonical_result.aggregated_result.clone();
+    let task_result = serde_json::to_value(crate::autonomy::build_task_result_view(
+        status,
+        canonical_result.clone(),
+    ))
+    .map_err(|error| format!("failed to serialize task result view: {error}"))?;
+    let final_result = serde_json::to_value(canonical_result)
+        .map_err(|error| format!("failed to serialize canonical result: {error}"))?;
+
+    Ok(TerminalResultViews {
+        aggregated_result,
+        final_result,
+        task_result,
+    })
+}
+
 #[derive(Clone)]
 pub(crate) struct RuntimeTaskService {
     pool: PgPool,
@@ -387,21 +413,33 @@ impl RuntimeTaskService {
                 status: "failed",
             },
         );
-        let task_result = serde_json::to_value(crate::autonomy::build_task_result_view(
-            "failed",
-            final_result.clone(),
-        ))
-        .unwrap_or(Value::Null);
-        let final_result = serde_json::to_value(final_result).unwrap_or(Value::Null);
-        put_metadata(&mut metadata, "aggregated_result", aggregated_result);
-        put_metadata(&mut metadata, "final_result", final_result);
-        self.capture_autonomy_status_metadata(workflow_id, &mut metadata, Some(&task_result));
+        let result_views =
+            terminal_result_views("failed", final_result.clone()).unwrap_or(TerminalResultViews {
+                aggregated_result: aggregated_result.clone(),
+                final_result: Value::Null,
+                task_result: Value::Null,
+            });
+        put_metadata(
+            &mut metadata,
+            "aggregated_result",
+            result_views.aggregated_result.clone(),
+        );
+        put_metadata(
+            &mut metadata,
+            "final_result",
+            result_views.final_result.clone(),
+        );
+        self.capture_autonomy_status_metadata(
+            workflow_id,
+            &mut metadata,
+            Some(&result_views.task_result),
+        );
 
         self.update_root_record(
             workflow_id,
             "failed",
             metadata,
-            Some(task_result),
+            Some(result_views.task_result),
             record.started_at.or(Some(record.created_at)),
             Some(failed_at),
         )
@@ -747,23 +785,29 @@ impl RuntimeTaskService {
                 status: "completed",
             },
         );
-        let task_result = serde_json::to_value(crate::autonomy::build_task_result_view(
-            "completed",
-            final_result.clone(),
-        ))
-        .map_err(|error| format!("failed to serialize task result view: {error}"))?;
-        let final_result = serde_json::to_value(final_result)
-            .map_err(|error| format!("failed to serialize canonical result: {error}"))?;
+        let result_views = terminal_result_views("completed", final_result)?;
 
-        put_metadata(&mut metadata, "aggregated_result", aggregated_result);
-        put_metadata(&mut metadata, "final_result", final_result.clone());
+        put_metadata(
+            &mut metadata,
+            "aggregated_result",
+            result_views.aggregated_result.clone(),
+        );
+        put_metadata(
+            &mut metadata,
+            "final_result",
+            result_views.final_result.clone(),
+        );
         self.transition_workflow_complete(workflow_id);
-        self.capture_autonomy_status_metadata(workflow_id, &mut metadata, Some(&task_result));
+        self.capture_autonomy_status_metadata(
+            workflow_id,
+            &mut metadata,
+            Some(&result_views.task_result),
+        );
         self.update_root_record(
             workflow_id,
             "completed",
             metadata.clone(),
-            Some(task_result),
+            Some(result_views.task_result),
             Some(Utc::now()),
             Some(Utc::now()),
         )
@@ -773,7 +817,7 @@ impl RuntimeTaskService {
             "workflow.completed",
             "workflow.completed",
             workflow_id,
-            final_result,
+            result_views.final_result,
         )
         .await?;
 
@@ -1114,15 +1158,27 @@ impl RuntimeTaskService {
             },
         );
         let aggregated_result = final_result.aggregated_result.clone();
-        let task_result = serde_json::to_value(crate::autonomy::build_task_result_view(
-            "failed",
-            final_result.clone(),
-        ))
-        .unwrap_or(Value::Null);
-        let final_result = serde_json::to_value(final_result).unwrap_or(Value::Null);
-        put_metadata(&mut metadata, "aggregated_result", aggregated_result);
-        put_metadata(&mut metadata, "final_result", final_result);
-        self.capture_autonomy_status_metadata(workflow_id, &mut metadata, Some(&task_result));
+        let result_views =
+            terminal_result_views("failed", final_result).unwrap_or(TerminalResultViews {
+                aggregated_result: aggregated_result.clone(),
+                final_result: Value::Null,
+                task_result: Value::Null,
+            });
+        put_metadata(
+            &mut metadata,
+            "aggregated_result",
+            result_views.aggregated_result.clone(),
+        );
+        put_metadata(
+            &mut metadata,
+            "final_result",
+            result_views.final_result.clone(),
+        );
+        self.capture_autonomy_status_metadata(
+            workflow_id,
+            &mut metadata,
+            Some(&result_views.task_result),
+        );
         let coordinator_id =
             coordinator_id_from_metadata(&metadata).unwrap_or(self.default_coordinator_id);
         let _ = self
@@ -1130,7 +1186,7 @@ impl RuntimeTaskService {
                 workflow_id,
                 "failed",
                 metadata.clone(),
-                Some(task_result),
+                Some(result_views.task_result),
                 Some(Utc::now()),
                 Some(Utc::now()),
             )
@@ -1879,7 +1935,22 @@ mod tests {
                         "turn_index": 1,
                         "workflow_id": resumed_from_workflow_id,
                         "assistant_result": {
-                            "recovered_after_restart": true
+                            "workflow_id": resumed_from_workflow_id,
+                            "turn_index": 1,
+                            "status": "failed",
+                            "assistant_result": {
+                                "recovered_after_restart": true
+                            },
+                            "preview": "workflow interrupted by runtime restart before session sync",
+                            "provenance": {
+                                "runtime_execution_mode": {
+                                    "execution_boundary": "tool_bus"
+                                },
+                                "source_fields": [
+                                    "metadata.final_result",
+                                    "metadata.aggregated_result"
+                                ]
+                            }
                         }
                     }
                 ]

--- a/crates/mister-smith-app/tests/autonomy_status_tests.rs
+++ b/crates/mister-smith-app/tests/autonomy_status_tests.rs
@@ -377,6 +377,39 @@ fn enrich_result_preview_prefers_task_result_projection() {
         .provenance_lines
         .iter()
         .any(|line| line.contains("planner emitted one sequential step")));
+    assert!(preview
+        .provenance_lines
+        .iter()
+        .any(|line| line
+            .contains("session assistant_result derives from the canonical result object")));
+}
+
+#[test]
+fn enrich_result_preview_falls_back_to_metadata_final_result() {
+    let (mut view, _, _) = sample_view();
+    view.graph.state = GraphState::Completed;
+    let task_result = sample_task_result_view(
+        view.graph.workflow_id,
+        ProofOutcomeClassification::GraphFormedAndCompleted,
+    );
+    let metadata = serde_json::json!({
+        "final_result": task_result["result"].clone(),
+    });
+
+    autonomy::enrich_result_preview(&mut view, &metadata, None);
+
+    let preview = view
+        .result_preview
+        .expect("metadata.final_result should still produce an operator preview");
+    assert_eq!(preview.payload_location, "metadata.final_result");
+    assert_eq!(
+        preview.proof_outcome,
+        ProofOutcomeClassification::GraphFormedAndCompleted
+    );
+    assert_eq!(
+        preview.preview_text.as_deref(),
+        Some("bounded answer preview")
+    );
 }
 
 #[test]
@@ -419,6 +452,7 @@ fn render_status_surfaces_result_preview_block() {
         provenance_lines: vec![
             "graph formed and completed before final result publication".to_string(),
             "canonical result stored in metadata.final_result".to_string(),
+            "session assistant_result derives from the canonical result object".to_string(),
         ],
     });
 
@@ -429,6 +463,7 @@ fn render_status_surfaces_result_preview_block() {
     assert!(rendered.contains("location=task.result"));
     assert!(rendered.contains("preview=bounded answer preview"));
     assert!(rendered.contains("canonical result stored in metadata.final_result"));
+    assert!(rendered.contains("session assistant_result derives from the canonical result object"));
 }
 
 #[test]

--- a/crates/mister-smith-http/src/handlers.rs
+++ b/crates/mister-smith-http/src/handlers.rs
@@ -180,6 +180,9 @@ pub struct SessionTurnSummaryResponse {
     pub status: String,
     /// Original operator message.
     pub user_message: String,
+    /// Retained session-facing result projection for the turn, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assistant_result: Option<mister_smith_core::SessionRetainedResultView>,
     /// Restart and resume provenance derived from workflow metadata, when available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resume_provenance: Option<SessionResumeProvenanceResponse>,
@@ -229,6 +232,9 @@ pub struct SessionInspectResponse {
     pub last_completed_workflow_id: Option<TaskId>,
     /// Number of accepted turns.
     pub turn_count: u32,
+    /// Most recent retained session-facing result projection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_assistant_result: Option<mister_smith_core::SessionRetainedResultView>,
     /// Ordered turn summaries.
     pub turns: Vec<SessionTurnSummaryResponse>,
     /// Logical close time when ended.
@@ -492,6 +498,7 @@ pub async fn get_session(
         active_workflow_id: view.active_workflow_id,
         last_completed_workflow_id: view.last_completed_workflow_id,
         turn_count: view.turn_count,
+        last_assistant_result: view.last_assistant_result,
         turns: view
             .turns
             .into_iter()
@@ -500,6 +507,7 @@ pub async fn get_session(
                 workflow_id: turn.workflow_id,
                 status: turn.status,
                 user_message: turn.user_message,
+                assistant_result: turn.assistant_result,
                 resume_provenance: turn.resume_provenance.map(|provenance| {
                     SessionResumeProvenanceResponse {
                         recovered_after_restart: provenance.recovered_after_restart,
@@ -663,7 +671,7 @@ mod tests {
     };
     use mister_smith_core::{
         AuthorityPrincipal, CapabilityActionKind, DelegatedAction, DelegatedActionPolicy,
-        DelegationScope, ExternalDelegationEnvelope,
+        DelegationScope, ExternalDelegationEnvelope, SessionRetainedResultView,
     };
 
     #[derive(Clone)]
@@ -926,6 +934,34 @@ mod tests {
         let session_id = SessionId::new();
         let resumed_from_workflow_id = TaskId::new();
         let active_workflow_id = TaskId::new();
+        let retained_result = SessionRetainedResultView {
+            workflow_id: resumed_from_workflow_id,
+            turn_index: 1,
+            status: "failed".to_string(),
+            assistant_result: serde_json::json!({
+                "preview": "workflow interrupted by runtime restart before session sync",
+                "aggregated_result": {
+                    "error": "workflow interrupted by runtime restart before session sync",
+                    "recovered_after_restart": true
+                },
+                "proof_outcome": "failed_before_graph",
+                "recovered_after_restart": true
+            }),
+            preview: Some(
+                "workflow interrupted by runtime restart before session sync".to_string(),
+            ),
+            provenance: mister_smith_core::ResultProvenanceSummary {
+                runtime_execution_mode: serde_json::json!({
+                    "execution_boundary": "tool_bus"
+                }),
+                graph_state: None,
+                graph_id: None,
+                source_fields: vec![
+                    "metadata.final_result".to_string(),
+                    "metadata.aggregated_result".to_string(),
+                ],
+            },
+        };
         let state = test_state().with_conversation_service(Arc::new(FixedConversationService {
             view: ConversationSessionView {
                 session_id,
@@ -936,12 +972,14 @@ mod tests {
                 active_workflow_id: Some(active_workflow_id),
                 last_completed_workflow_id: Some(resumed_from_workflow_id),
                 turn_count: 2,
+                last_assistant_result: Some(retained_result.clone()),
                 turns: vec![
                     ConversationTurnSummaryView {
                         turn_index: 1,
                         workflow_id: resumed_from_workflow_id,
                         status: "failed".to_string(),
                         user_message: "turn one".to_string(),
+                        assistant_result: Some(retained_result),
                         resume_provenance: Some(ConversationResumeProvenanceView {
                             recovered_after_restart: true,
                             resumed_after_restart: false,
@@ -959,6 +997,7 @@ mod tests {
                         workflow_id: active_workflow_id,
                         status: "queued".to_string(),
                         user_message: "turn two".to_string(),
+                        assistant_result: None,
                         resume_provenance: Some(ConversationResumeProvenanceView {
                             recovered_after_restart: false,
                             resumed_after_restart: true,
@@ -979,6 +1018,14 @@ mod tests {
         let value = serde_json::to_value(response).expect("inspect response should serialize");
 
         assert_eq!(value["session_id"], session_id.to_string());
+        assert_eq!(
+            value["last_assistant_result"]["workflow_id"],
+            resumed_from_workflow_id.to_string()
+        );
+        assert_eq!(
+            value["turns"][0]["assistant_result"]["assistant_result"]["proof_outcome"],
+            "failed_before_graph"
+        );
         assert_eq!(
             value["turns"][0]["resume_provenance"]["recovered_after_restart"],
             true

--- a/crates/mister-smith-http/src/server.rs
+++ b/crates/mister-smith-http/src/server.rs
@@ -9,7 +9,8 @@ use axum::middleware as axum_mw;
 use axum::Router;
 use chrono::{DateTime, Utc};
 use mister_smith_core::{
-    AgentId, AgentType, ExternalDelegationEnvelope, SessionId, SessionStatus, TaskId,
+    AgentId, AgentType, ExternalDelegationEnvelope, SessionId, SessionRetainedResultView,
+    SessionStatus, TaskId,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -147,6 +148,8 @@ pub struct ConversationTurnSummaryView {
     pub status: String,
     /// Original operator message for the turn.
     pub user_message: String,
+    /// Retained session-facing result projection for the turn, when available.
+    pub assistant_result: Option<SessionRetainedResultView>,
     /// Restart and resume provenance derived from workflow metadata when available.
     pub resume_provenance: Option<ConversationResumeProvenanceView>,
 }
@@ -187,6 +190,8 @@ pub struct ConversationSessionView {
     pub last_completed_workflow_id: Option<TaskId>,
     /// Number of accepted turns.
     pub turn_count: u32,
+    /// Most recent retained session-facing result projection.
+    pub last_assistant_result: Option<SessionRetainedResultView>,
     /// Ordered turn summaries.
     pub turns: Vec<ConversationTurnSummaryView>,
     /// Logical close time when ended.

--- a/specs/015-complex-multi-agent-proof-and-unified-result-surfaces/contracts/result-surface-contract.md
+++ b/specs/015-complex-multi-agent-proof-and-unified-result-surfaces/contracts/result-surface-contract.md
@@ -75,6 +75,8 @@ Session retention keeps a bounded projection of the canonical result object.
 Expected behavior:
 
 - `assistant_result` and `last_assistant_result` derive from the canonical result object
+- retained session storage and session inspect surfaces serialize the full retained-result
+  projection at `assistant_result` / `last_assistant_result`, not only the inner assistant payload
 - retained session views must preserve result preview plus enough provenance to correlate with the
   owning workflow
 - session inspection must not silently drop assistant-result material once it was retained


### PR DESCRIPTION
## Summary
- project the full retained session result view through retained context, session inspect, and CLI rendering
- keep terminal task result serialization aligned across completed, failed, and recovered execution paths
- extend app and HTTP coverage for task/operator preview fallback and session retained-result projection

## Validation
- cargo test -p mister-smith-app --test autonomy_status_tests
- cargo test -p mister-smith-http get_session_surfaces_turn_level_restart_resume_provenance -- --nocapture
- cargo test -p mister-smith-app
- cargo build --workspace
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync