### PR TITLE
MS-93: persist proof outcome across runtime and views

### DIFF
--- a/crates/mister-smith-app/src/conversation.rs
+++ b/crates/mister-smith-app/src/conversation.rs
@@ -395,16 +395,25 @@ async fn build_session_view(
         .map(|record| (record.task_id, record.metadata))
         .collect::<HashMap<_, _>>();
     let mut turn_summaries = Vec::with_capacity(turns.len());
-    let mut last_assistant_result = None;
+    let retained_context = &session.retained_context;
+    let mut last_assistant_result = last_retained_result_from_context(retained_context);
     for turn in turns {
         let workflow_id = TaskId::from_uuid(turn.workflow_id);
-        let assistant_result = u32::try_from(turn.turn_index).ok().and_then(|turn_index| {
-            turn.result_summary.as_ref().and_then(|task_result| {
-                crate::autonomy::retained_result_view(task_result, turn_index, &turn.status)
-            })
-        });
+        let turn_index = turn.turn_index.max(0) as u32;
+        let assistant_result = retained_result_for_turn(retained_context, workflow_id, turn_index)
+            .or_else(|| {
+                turn.result_summary.as_ref().and_then(|task_result| {
+                    crate::autonomy::retained_result_view(task_result, turn_index, &turn.status)
+                })
+            });
         if let Some(retained_result) = assistant_result.clone() {
-            last_assistant_result = Some(retained_result);
+            let should_replace_last = last_assistant_result
+                .as_ref()
+                .map(|current| retained_result.turn_index >= current.turn_index)
+                .unwrap_or(true);
+            if should_replace_last {
+                last_assistant_result = Some(retained_result);
+            }
         }
         let resume_provenance = task_metadata_by_workflow
             .get(&turn.workflow_id)
@@ -483,6 +492,45 @@ fn empty_retained_context() -> Value {
         "transcript_summary": [],
         "latest_workflow_id": Value::Null,
     })
+}
+
+fn retained_result_projection_from_value(value: &Value) -> Option<SessionRetainedResultView> {
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn retained_result_for_turn(
+    retained_context: &Value,
+    workflow_id: TaskId,
+    turn_index: u32,
+) -> Option<SessionRetainedResultView> {
+    let workflow_id = workflow_id.to_string();
+    retained_context
+        .get("transcript_summary")
+        .and_then(Value::as_array)?
+        .iter()
+        .rev()
+        .find_map(|entry| {
+            let entry_turn = entry
+                .get("turn_index")
+                .and_then(Value::as_u64)
+                .and_then(|value| u32::try_from(value).ok())?;
+            let entry_workflow_id = entry.get("workflow_id").and_then(Value::as_str)?;
+            if entry_turn != turn_index || entry_workflow_id != workflow_id {
+                return None;
+            }
+
+            entry
+                .get("assistant_result")
+                .and_then(retained_result_projection_from_value)
+        })
+}
+
+fn last_retained_result_from_context(
+    retained_context: &Value,
+) -> Option<SessionRetainedResultView> {
+    retained_context
+        .get("last_assistant_result")
+        .and_then(retained_result_projection_from_value)
 }
 
 fn retained_context_after_turn(
@@ -1046,6 +1094,94 @@ mod tests {
         );
         assert_eq!(
             retained["last_assistant_result"]["assistant_result"]["proof_outcome"],
+            json!("failed_before_graph")
+        );
+    }
+
+    #[test]
+    fn retained_result_for_turn_uses_stored_projection_with_proof_outcome() {
+        let workflow_id = TaskId::new();
+        let retained_context = json!({
+            "transcript_summary": [
+                {
+                    "turn_index": 2,
+                    "workflow_id": workflow_id,
+                    "assistant_result": {
+                        "workflow_id": workflow_id,
+                        "turn_index": 2,
+                        "status": "completed",
+                        "assistant_result": {
+                            "preview": "bounded answer preview",
+                            "aggregated_result": {
+                                "summary": "bounded answer preview"
+                            },
+                            "proof_outcome": "collapsed_to_sequential"
+                        },
+                        "preview": "bounded answer preview",
+                        "provenance": {
+                            "runtime_execution_mode": {
+                                "execution_boundary": "tool_bus"
+                            },
+                            "graph_state": "completed",
+                            "graph_id": null,
+                            "source_fields": [
+                                "metadata.final_result",
+                                "metadata.aggregated_result"
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+
+        let retained_result = retained_result_for_turn(&retained_context, workflow_id, 2)
+            .expect("stored retained projection should round-trip");
+
+        assert_eq!(retained_result.workflow_id, workflow_id);
+        assert_eq!(retained_result.turn_index, 2);
+        assert_eq!(
+            retained_result.assistant_result["proof_outcome"],
+            json!("collapsed_to_sequential")
+        );
+    }
+
+    #[test]
+    fn last_retained_result_from_context_preserves_stored_proof_outcome() {
+        let workflow_id = TaskId::new();
+        let retained_context = json!({
+            "last_assistant_result": {
+                "workflow_id": workflow_id,
+                "turn_index": 3,
+                "status": "failed",
+                "assistant_result": {
+                    "preview": "planner failed before graph formation",
+                    "aggregated_result": {
+                        "error": "planner failed before graph formation"
+                    },
+                    "proof_outcome": "failed_before_graph"
+                },
+                "preview": "planner failed before graph formation",
+                "provenance": {
+                    "runtime_execution_mode": {
+                        "execution_boundary": "tool_bus"
+                    },
+                    "graph_state": null,
+                    "graph_id": null,
+                    "source_fields": [
+                        "metadata.final_result",
+                        "metadata.aggregated_result"
+                    ]
+                }
+            }
+        });
+
+        let retained_result = last_retained_result_from_context(&retained_context)
+            .expect("last retained result should round-trip");
+
+        assert_eq!(retained_result.workflow_id, workflow_id);
+        assert_eq!(retained_result.turn_index, 3);
+        assert_eq!(
+            retained_result.assistant_result["proof_outcome"],
             json!("failed_before_graph")
         );
     }

--- a/crates/mister-smith-app/src/execution.rs
+++ b/crates/mister-smith-app/src/execution.rs
@@ -1695,8 +1695,8 @@ mod tests {
         AuthorityPrincipal, BranchRecoveryStrategy, BranchState, CapabilityActionKind,
         CapabilityId, CoordinationPolicy, DelegatedAction, DelegatedActionPolicy, DelegationScope,
         ExecutionBranchId, ExecutionGraphId, ExternalDelegationEnvelope, GraphState,
-        RevocationState, SessionId, TaskShapeClassification, TaskShapeKind, TopologyKind,
-        TopologyRationale,
+        ProofOutcomeClassification, RevocationState, SessionId, TaskShapeClassification,
+        TaskShapeKind, TopologyKind, TopologyRationale,
     };
     use mister_smith_events::{
         BranchSummary, ExecutionGraphSummary, ExternalCapabilityDecisionOutcome,
@@ -1829,6 +1829,101 @@ mod tests {
         let mut record = sample_task_with_metadata(metadata);
         record.result = Some(result);
         record
+    }
+
+    #[test]
+    fn terminal_result_views_preserve_proof_outcome_across_task_and_final_results() {
+        let workflow_id = TaskId::new();
+        let cases = [
+            (
+                "success",
+                "completed",
+                json!({
+                    "steps": [{"id": "step-1"}, {"id": "step-2"}]
+                }),
+                vec![
+                    json!({
+                        "task_id": TaskId::new(),
+                        "result": { "summary": "parallel branch alpha" }
+                    }),
+                    json!({
+                        "task_id": TaskId::new(),
+                        "result": { "summary": "parallel branch beta" }
+                    }),
+                ],
+                ProofOutcomeClassification::GraphFormedAndCompleted,
+            ),
+            (
+                "collapse",
+                "completed",
+                json!({
+                    "steps": [{"id": "step-1"}]
+                }),
+                vec![json!({
+                    "task_id": TaskId::new(),
+                    "result": { "summary": "single sequential branch" }
+                })],
+                ProofOutcomeClassification::CollapsedToSequential,
+            ),
+            (
+                "failure",
+                "failed",
+                json!({
+                    "steps": [{"id": "step-1"}, {"id": "step-2"}]
+                }),
+                vec![json!({
+                    "task_id": TaskId::new(),
+                    "result": { "summary": "partial branch output" }
+                })],
+                ProofOutcomeClassification::FailedBeforeGraph,
+            ),
+        ];
+
+        for (label, status, execution_plan, step_results, expected_outcome) in cases {
+            let canonical_result = crate::autonomy::build_canonical_result_envelope(
+                crate::autonomy::CanonicalResultEnvelopeInput {
+                    workflow_id,
+                    provider_kind: PROVIDER_KIND_NAME,
+                    model_id: MODEL_ID,
+                    description: "freeze the result contract",
+                    runtime_execution_mode: json!({
+                        "execution_boundary": "tool_bus",
+                        "workflow_runner": "tokio_task"
+                    }),
+                    planner_output: json!({
+                        "steps": execution_plan
+                            .get("steps")
+                            .and_then(Value::as_array)
+                            .map(|steps| steps.len())
+                    }),
+                    execution_plan,
+                    step_results,
+                    aggregated_result: json!({
+                        "summary": format!("{label} bounded answer preview")
+                    }),
+                    status,
+                },
+            );
+
+            let result_views = terminal_result_views(status, canonical_result)
+                .expect("canonical task and final result envelopes should serialize");
+
+            assert_eq!(
+                result_views.final_result["proof_outcome"],
+                json!(expected_outcome.as_str()),
+                "final_result should retain proof outcome for {label}"
+            );
+            assert_eq!(
+                result_views.task_result["proof_outcome"],
+                json!(expected_outcome.as_str()),
+                "task.result wrapper should retain proof outcome for {label}"
+            );
+            assert_eq!(
+                result_views.task_result["result"]["proof_outcome"],
+                json!(expected_outcome.as_str()),
+                "task.result canonical envelope should retain proof outcome for {label}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mister-smith-app/tests/autonomy_status_tests.rs
+++ b/crates/mister-smith-app/tests/autonomy_status_tests.rs
@@ -443,6 +443,43 @@ fn enrich_result_preview_falls_back_to_metadata_final_result() {
 }
 
 #[test]
+fn enrich_result_preview_prefers_stored_proof_outcome_over_structural_inference() {
+    let (mut view, _, _) = sample_view();
+    view.graph.state = GraphState::Completed;
+    view.topology.topology_kind = TopologyKind::Hybrid;
+    view.topology.parallelism_width = 2;
+    view.topology.task_shape.kind = TaskShapeKind::FanoutJoin;
+    view.topology.task_shape.max_parallel_width = 2;
+    view.graph.branch_count = 2;
+    view.graph.node_count = 2;
+
+    let task_result = sample_task_result_payload(
+        view.graph.workflow_id,
+        "completed",
+        2,
+        2,
+        Some(ProofOutcomeClassification::CollapsedToSequential),
+    );
+    let metadata = serde_json::json!({
+        "final_result": task_result["result"].clone(),
+    });
+
+    autonomy::enrich_result_preview(&mut view, &metadata, Some(&task_result));
+
+    let preview = view
+        .result_preview
+        .expect("stored task result should produce an operator preview");
+    assert_eq!(
+        preview.proof_outcome,
+        ProofOutcomeClassification::CollapsedToSequential
+    );
+    assert!(preview
+        .provenance_lines
+        .iter()
+        .any(|line| line.contains("planner emitted one sequential step")));
+}
+
+#[test]
 fn classify_proof_outcome_keeps_failed_runs_in_the_single_failure_class() {
     let execution_plan = serde_json::json!({
         "steps": [


### PR DESCRIPTION
## Summary
- prefer stored retained-session projections from `retained_context` when building session views
- lock proof outcome persistence through the runtime result envelope in app-side coverage
- assert operator preview prefers stored proof outcome over structural inference

## Validation
- cargo test -p mister-smith-app --test autonomy_status_tests
- cargo test -p mister-smith-app
- cargo build --workspace