### PR TITLE
MS-97: persist accepted delegated task-ingress continuity

### DIFF
--- a/crates/mister-smith-app/src/execution.rs
+++ b/crates/mister-smith-app/src/execution.rs
@@ -19,8 +19,9 @@ use mister_smith_agents::scheduler::{
 };
 use mister_smith_agents::{AgentConfig, Orchestrator, ToolBus, TopologyCompiler, TopologySignals};
 use mister_smith_core::{
-    AgentId, AgentType, BranchState, EscalationPolicy, GraphState, GuardTarget, NodeState,
-    SupervisionStrategy, TaskId, Tool, ToolCapabilities, ToolError, ToolId, ToolSchema,
+    AgentId, AgentType, BranchState, EscalationPolicy, ExternalDelegationEnvelope, GraphState,
+    GuardTarget, NodeState, SupervisionStrategy, TaskId, Tool, ToolCapabilities, ToolError, ToolId,
+    ToolSchema,
 };
 use mister_smith_events::{AutonomyStatusView, EventBus, StepRoutingDecisionSummary};
 use mister_smith_http::server::{
@@ -51,6 +52,8 @@ pub(crate) const MODEL_ID: &str = "gpt-5.4";
 const WORKFLOW_STREAM: &str = "mister_smith_workflows";
 const WORKFLOW_SUBJECT_PATTERN: &str = "workflow.>";
 const AUTONOMY_STATUS_METADATA_KEY: &str = "autonomy_status";
+const ACCEPTED_TASK_INGRESS_METADATA_KEY: &str = "accepted_task_ingress";
+const TASK_INGRESS_REQUEST_SURFACE: &str = "POST /api/v1/tasks";
 const WORKFLOW_TOOL_NAMESPACE: &str = "workflow";
 const WORKFLOW_EXECUTE_STEP_TOOL: &str = "execute_step";
 
@@ -1501,9 +1504,39 @@ fn initial_metadata(
             "external_delegation",
             serde_json::to_value(delegation).unwrap_or(Value::Null),
         );
+
+        if request.conversation.is_none() {
+            put_metadata(
+                &mut metadata,
+                ACCEPTED_TASK_INGRESS_METADATA_KEY,
+                accepted_task_ingress_metadata(delegation),
+            );
+        }
     }
 
     metadata
+}
+
+fn accepted_task_ingress_metadata(delegation: &ExternalDelegationEnvelope) -> Value {
+    let action = delegation.action.as_ref();
+
+    json!({
+        "request_surface": TASK_INGRESS_REQUEST_SURFACE,
+        "source_metadata_key": "external_delegation",
+        "capability_id": delegation.capability.capability_id,
+        "capability_descriptor_id": delegation.capability.descriptor_id,
+        "action_descriptor_id": action.map(|action| action.descriptor_id.clone()),
+        "action_id": action.map(|action| action.action_id.clone()),
+        "action_title": action.map(|action| action.title.clone()),
+        "scope": delegation.capability.scope,
+        "required_scope": action.and_then(|action| action.required_scope),
+        "policy_action": action.map(|action| action.policy.action.clone()),
+        "policy_resource": action.map(|action| action.policy.resource.clone()),
+        "policy_scope": action.map(|action| action.policy.scope.clone()),
+        "policy_resource_id": action.and_then(|action| action.policy.resource_id.clone()),
+        "revocation_state": delegation.capability.revocation_state,
+        "chain_depth": delegation.provenance.links.len(),
+    })
 }
 
 fn persist_autonomy_status(metadata: &mut Value, view: &AutonomyStatusView) {
@@ -1982,6 +2015,87 @@ mod tests {
         assert_eq!(
             metadata["external_delegation"]["action"]["revocation_key"],
             "tool:app.workflow#execute"
+        );
+    }
+
+    #[test]
+    fn initial_metadata_persists_accepted_task_ingress_continuity_for_delegated_http_submission() {
+        let delegation = sample_external_delegation();
+        let request = TaskSubmissionRequest {
+            description: "delegated workflow".to_string(),
+            agent_type: None,
+            priority: Some("high".to_string()),
+            conversation: None,
+            delegation: Some(delegation.clone()),
+        };
+
+        let metadata = initial_metadata(&request, AgentId::new(), &[], "queued");
+        let accepted = metadata
+            .get(ACCEPTED_TASK_INGRESS_METADATA_KEY)
+            .expect("delegated HTTP submission should persist accepted task ingress continuity");
+
+        assert_eq!(
+            accepted["request_surface"],
+            json!(TASK_INGRESS_REQUEST_SURFACE)
+        );
+        assert_eq!(
+            accepted["source_metadata_key"],
+            json!("external_delegation")
+        );
+        assert_eq!(
+            accepted["capability_id"],
+            json!(delegation.capability.capability_id)
+        );
+        assert_eq!(
+            accepted["capability_descriptor_id"],
+            json!(delegation.capability.descriptor_id)
+        );
+        assert_eq!(
+            accepted["action_id"],
+            json!(delegation
+                .action
+                .as_ref()
+                .map(|action| action.action_id.clone()))
+        );
+        assert_eq!(
+            accepted["policy_resource_id"],
+            json!(delegation
+                .action
+                .as_ref()
+                .and_then(|action| action.policy.resource_id.clone()))
+        );
+        assert_eq!(
+            accepted["chain_depth"],
+            json!(delegation.provenance.links.len())
+        );
+    }
+
+    #[test]
+    fn initial_metadata_keeps_accepted_task_ingress_scope_frozen_to_http_task_submissions() {
+        let request = TaskSubmissionRequest {
+            description: "delegated session turn".to_string(),
+            agent_type: None,
+            priority: Some("high".to_string()),
+            conversation: Some(mister_smith_http::server::ConversationTurnContext {
+                session_id: SessionId::new(),
+                turn_index: 1,
+                coordinator_agent_id: AgentId::new(),
+                retained_context: json!({
+                    "transcript_summary": []
+                }),
+            }),
+            delegation: Some(sample_external_delegation()),
+        };
+
+        let metadata = initial_metadata(&request, AgentId::new(), &[], "queued");
+
+        assert!(
+            metadata.get("external_delegation").is_some(),
+            "raw delegation context should still persist for session continuity"
+        );
+        assert!(
+            metadata.get(ACCEPTED_TASK_INGRESS_METADATA_KEY).is_none(),
+            "accepted task ingress continuity must remain frozen to POST /api/v1/tasks"
         );
     }
 

--- a/crates/mister-smith-http/src/handlers.rs
+++ b/crates/mister-smith-http/src/handlers.rs
@@ -720,9 +720,29 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Default)]
+    #[derive(Clone)]
     struct RecordingTaskService {
         last_request: Arc<tokio::sync::Mutex<Option<TaskSubmissionRequest>>>,
+        response: TaskSubmissionResponse,
+    }
+
+    impl Default for RecordingTaskService {
+        fn default() -> Self {
+            Self {
+                last_request: Arc::new(tokio::sync::Mutex::new(None)),
+                response: TaskSubmissionResponse {
+                    task_id: TaskId::from_uuid(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000010")
+                            .expect("fixed task id should parse"),
+                    ),
+                    assigned_agent_id: AgentId::from_uuid(
+                        Uuid::parse_str("00000000-0000-0000-0000-000000000011")
+                            .expect("fixed agent id should parse"),
+                    ),
+                    status: "queued".to_string(),
+                },
+            }
+        }
     }
 
     impl RecordingTaskService {
@@ -742,11 +762,7 @@ mod tests {
             request: TaskSubmissionRequest,
         ) -> Result<TaskSubmissionResponse, String> {
             *self.last_request.lock().await = Some(request);
-            Ok(TaskSubmissionResponse {
-                task_id: TaskId::new(),
-                assigned_agent_id: AgentId::new(),
-                status: "queued".to_string(),
-            })
+            Ok(self.response.clone())
         }
 
         async fn get_task(&self, _task_id: TaskId) -> Result<Option<TaskStatusView>, String> {
@@ -872,19 +888,37 @@ mod tests {
 
     #[tokio::test]
     async fn create_task_returns_202_fields() {
-        let state = test_state();
+        let service = RecordingTaskService::default();
+        let state = test_state().with_task_service(Arc::new(service));
         let request = CreateTaskRequest {
             description: "Test task".to_string(),
             agent_type: None,
             priority: None,
         };
-        let result = create_task(
+        let (status, Json(response)) = create_task(
             State(state),
             ExternalDelegationBoundary(None),
             Json(request),
         )
-        .await;
-        assert!(result.is_err());
+        .await
+        .expect("task creation should succeed");
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(
+            response.task_id,
+            TaskId::from_uuid(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000010")
+                    .expect("fixed task id should parse"),
+            )
+        );
+        assert_eq!(
+            response.assigned_agent_id,
+            AgentId::from_uuid(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000011")
+                    .expect("fixed agent id should parse"),
+            )
+        );
+        assert_eq!(response.status, "queued");
     }
 
     #[tokio::test]
@@ -899,7 +933,7 @@ mod tests {
             priority: Some("high".to_string()),
         };
 
-        let (status, _response) = create_task(
+        let (status, Json(response)) = create_task(
             State(state),
             ExternalDelegationBoundary(Some(delegation.clone())),
             Json(request),
@@ -911,7 +945,10 @@ mod tests {
 
         let recorded = service.last_request().await;
         assert_eq!(recorded.description, "Delegated task");
+        assert_eq!(recorded.priority.as_deref(), Some("high"));
+        assert!(recorded.conversation.is_none());
         assert_eq!(recorded.delegation, Some(delegation));
+        assert_eq!(response.status, "queued");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- persist an accepted delegated task-ingress continuity marker in workflow metadata for delegated POST /api/v1/tasks submissions only
- keep raw external_delegation persistence and no-fabrication coverage intact while proving the task-ingress scope stays frozen to HTTP task submission
- tighten handler coverage so POST /api/v1/tasks returns the runtime response shape and keeps delegated forwarding bounded to task ingress

## Validation
- cargo test -p mister-smith-http
- cargo test -p mister-smith-app
- cargo build --workspace

Refs: MS-97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for task delegation metadata handling and submission responses.
  * Enhanced test infrastructure for deterministic task service behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->