### PR TITLE
MS-98: project accepted ingress continuity on workflow status

### DIFF
--- a/crates/mister-smith-agents/src/tool_bus.rs
+++ b/crates/mister-smith-agents/src/tool_bus.rs
@@ -11,6 +11,7 @@ use mister_smith_core::{
 use mister_smith_events::{
     AutonomyEvent, AutonomyEventEnvelope, CapabilitySummary, EventBus,
     ExternalCapabilityDecisionOutcome, ExternalCapabilityDecisionSummary,
+    ExternalCapabilityDecisionSurface,
 };
 use mister_smith_mcp::client::McpClient;
 use mister_smith_mcp::errors::McpError;
@@ -1065,6 +1066,7 @@ fn external_capability_decision_from_validated(
     ));
 
     ExternalCapabilityDecisionSummary {
+        boundary_surface: Some(ExternalCapabilityDecisionSurface::ToolBus),
         branch_id,
         capability_id: Some(capability.capability_id),
         capability_descriptor_id: capability.descriptor_id.clone(),
@@ -1161,6 +1163,7 @@ fn external_capability_decision_from_claims(
     }
 
     ExternalCapabilityDecisionSummary {
+        boundary_surface: Some(ExternalCapabilityDecisionSurface::ToolBus),
         branch_id,
         capability_id: capability.map(|capability| capability.capability_id),
         capability_descriptor_id: capability

--- a/crates/mister-smith-agents/tests/tool_bus_tests.rs
+++ b/crates/mister-smith-agents/tests/tool_bus_tests.rs
@@ -7,7 +7,9 @@ use mister_smith_core::{
     AgentId, AuthorityPrincipal, DelegationScope, Tool, ToolCapabilities, ToolError, ToolId,
     ToolSchema,
 };
-use mister_smith_events::{AutonomyEvent, EventBus, ExternalCapabilityDecisionOutcome};
+use mister_smith_events::{
+    AutonomyEvent, EventBus, ExternalCapabilityDecisionOutcome, ExternalCapabilityDecisionSurface,
+};
 use mister_smith_security::audit::{
     events::{AuditEventType, AuditOutcome},
     AuditLogger,
@@ -665,6 +667,10 @@ async fn invoke_publishes_allowed_external_capability_decision_for_privileged_to
 
     let decision = recv_external_capability_decision(&mut rx).await;
     assert_eq!(decision.outcome, ExternalCapabilityDecisionOutcome::Allowed);
+    assert_eq!(
+        decision.boundary_surface,
+        Some(ExternalCapabilityDecisionSurface::ToolBus)
+    );
     assert_eq!(decision.branch_id, Some(branch_id));
     assert!(decision.observed_at.is_some());
     assert_eq!(

--- a/crates/mister-smith-app/src/autonomy.rs
+++ b/crates/mister-smith-app/src/autonomy.rs
@@ -11,15 +11,16 @@ use axum::Json;
 use chrono::{DateTime, Utc};
 use mister_smith_config::FrameworkConfig;
 use mister_smith_core::{
-    AgentId, CoordinationPolicy, ExecutionGraphId, GraphState, OperatorResultPreview,
-    ProofOutcomeClassification, ResultProvenanceSummary, SessionId, SessionRetainedResultView,
-    TaskId, TaskResultView, TaskShapeClassification, TaskShapeKind, TopologyKind,
-    TopologyRationale, UnifiedResultEnvelope,
+    AgentId, CapabilityId, CoordinationPolicy, DelegationScope, ExecutionGraphId, GraphState,
+    OperatorResultPreview, ProofOutcomeClassification, ResultProvenanceSummary, RevocationState,
+    SessionId, SessionRetainedResultView, TaskId, TaskResultView, TaskShapeClassification,
+    TaskShapeKind, TopologyKind, TopologyRationale, UnifiedResultEnvelope,
 };
 use mister_smith_events::autonomy::merge_operator_result_preview;
 use mister_smith_events::{
     AutonomyStatusView, EventBus, ExternalCapabilityDecisionOutcome,
-    ExternalCapabilityDecisionSummary, ResumeProvenanceSummary, StepRoutingDecisionSummary,
+    ExternalCapabilityDecisionSummary, ExternalCapabilityDecisionSurface, ResumeProvenanceSummary,
+    StepRoutingDecisionSummary,
 };
 use mister_smith_persistence::postgres::queries;
 use reqwest::Client;
@@ -29,6 +30,8 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 const RESULT_PREVIEW_MAX_CHARS: usize = 160;
+const ACCEPTED_TASK_INGRESS_METADATA_KEY: &str = "accepted_task_ingress";
+const TASK_INGRESS_REQUEST_SURFACE: &str = "POST /api/v1/tasks";
 
 /// Serializable list of workflow IDs with autonomy status projections.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -182,8 +185,8 @@ pub async fn status_from_bus(
 }
 
 /// Resolve autonomy status directly from the in-process event bus and enrich
-/// it with persisted session linkage when available.
-pub async fn status_from_bus_with_session_linkage(
+/// it with persisted workflow metadata continuity when available.
+pub async fn status_from_bus_with_metadata_continuity(
     event_bus: Arc<EventBus>,
     pool: PgPool,
     workflow_id: &str,
@@ -199,6 +202,7 @@ pub async fn status_from_bus_with_session_linkage(
         })?
     {
         enrich_session_linkage(&mut view, &record.metadata);
+        enrich_accepted_task_ingress_continuity(&mut view, &record.metadata);
         enrich_step_routing_history(&mut view, &record.metadata);
         enrich_result_preview(&mut view, &record.metadata, record.result.as_ref());
     }
@@ -523,6 +527,142 @@ pub(crate) fn enrich_session_linkage(view: &mut AutonomyStatusView, metadata: &s
     }
 }
 
+pub(crate) fn enrich_accepted_task_ingress_continuity(
+    view: &mut AutonomyStatusView,
+    metadata: &Value,
+) {
+    if view.external_capability_decisions.iter().any(|decision| {
+        decision.boundary_surface == Some(ExternalCapabilityDecisionSurface::TaskIngress)
+    }) {
+        return;
+    }
+
+    let Some(accepted_ingress) = metadata
+        .get(ACCEPTED_TASK_INGRESS_METADATA_KEY)
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+
+    let Some(request_surface) = accepted_ingress
+        .get("request_surface")
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if request_surface != TASK_INGRESS_REQUEST_SURFACE {
+        return;
+    }
+
+    let source_metadata_key = accepted_ingress
+        .get("source_metadata_key")
+        .and_then(Value::as_str)
+        .unwrap_or("external_delegation");
+    let capability_descriptor_id = accepted_ingress
+        .get("capability_descriptor_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let action_descriptor_id = accepted_ingress
+        .get("action_descriptor_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let action_id = accepted_ingress
+        .get("action_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let action_title = accepted_ingress
+        .get("action_title")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let scope = accepted_ingress
+        .get("scope")
+        .and_then(parse_enum_value::<DelegationScope>);
+    let required_scope = accepted_ingress
+        .get("required_scope")
+        .and_then(parse_enum_value::<DelegationScope>);
+    let policy_action = accepted_ingress
+        .get("policy_action")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let policy_resource = accepted_ingress
+        .get("policy_resource")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let policy_scope = accepted_ingress
+        .get("policy_scope")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let policy_resource_id = accepted_ingress
+        .get("policy_resource_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let revocation_state = accepted_ingress
+        .get("revocation_state")
+        .and_then(parse_enum_value::<RevocationState>);
+    let chain_depth = accepted_ingress
+        .get("chain_depth")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or_default();
+
+    let mut rationale = vec![
+        format!("accepted delegated task ingress remained authorized at {request_surface}"),
+        format!(
+            "continuity projected from workflow metadata {ACCEPTED_TASK_INGRESS_METADATA_KEY} sourced from {source_metadata_key}"
+        ),
+    ];
+    if let Some(descriptor_id) = capability_descriptor_id.as_deref() {
+        rationale.push(format!(
+            "capability descriptor at accepted task ingress was '{descriptor_id}'"
+        ));
+    }
+    if let Some(descriptor_id) = action_descriptor_id.as_deref() {
+        rationale.push(format!(
+            "accepted task ingress requested descriptor '{descriptor_id}'"
+        ));
+    }
+    if let Some(required_scope) = required_scope {
+        rationale.push(format!(
+            "accepted task ingress required scope {:?} while the capability carried {:?}",
+            required_scope, scope
+        ));
+    }
+    if let (Some(action), Some(policy_scope), Some(resource)) = (
+        policy_action.as_deref(),
+        policy_scope.as_deref(),
+        policy_resource.as_deref(),
+    ) {
+        rationale.push(format!(
+            "policy continuity preserved as {action}/{policy_scope}/{resource}"
+        ));
+    }
+
+    view.external_capability_decisions
+        .push(ExternalCapabilityDecisionSummary {
+            boundary_surface: Some(ExternalCapabilityDecisionSurface::TaskIngress),
+            branch_id: None,
+            capability_id: accepted_ingress
+                .get("capability_id")
+                .and_then(parse_enum_value::<CapabilityId>),
+            capability_descriptor_id,
+            action_descriptor_id,
+            action_id,
+            action_title,
+            scope,
+            required_scope,
+            policy_action,
+            policy_resource,
+            policy_scope,
+            policy_resource_id,
+            revocation_state,
+            chain_depth,
+            outcome: ExternalCapabilityDecisionOutcome::Allowed,
+            observed_at: None,
+            rationale,
+        });
+    sort_external_capability_decisions(&mut view.external_capability_decisions);
+}
+
 pub(crate) fn enrich_step_routing_history(view: &mut AutonomyStatusView, metadata: &Value) {
     if !view.step_routing_history.is_empty() {
         return;
@@ -533,6 +673,46 @@ pub(crate) fn enrich_step_routing_history(view: &mut AutonomyStatusView, metadat
     if let Ok(history) = serde_json::from_value::<Vec<StepRoutingDecisionSummary>>(raw) {
         view.step_routing_history = history;
     }
+}
+
+fn sort_external_capability_decisions(decisions: &mut [ExternalCapabilityDecisionSummary]) {
+    decisions.sort_by(|left, right| {
+        left.observed_at.cmp(&right.observed_at).then_with(|| {
+            external_capability_decision_sort_key(left)
+                .cmp(&external_capability_decision_sort_key(right))
+        })
+    });
+}
+
+fn external_capability_decision_sort_key(decision: &ExternalCapabilityDecisionSummary) -> String {
+    format!(
+        "{}:{}:{}:{}:{}:{}",
+        decision
+            .boundary_surface
+            .map(|surface| format!("{surface:?}"))
+            .unwrap_or_else(|| "none".to_string()),
+        decision
+            .branch_id
+            .map(|branch_id| branch_id.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        decision
+            .capability_id
+            .map(|capability_id| capability_id.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        decision.action_id.as_deref().unwrap_or("none"),
+        decision.action_descriptor_id.as_deref().unwrap_or("none"),
+        match decision.outcome {
+            ExternalCapabilityDecisionOutcome::Allowed => "allowed",
+            ExternalCapabilityDecisionOutcome::Rejected => "rejected",
+        }
+    )
+}
+
+fn parse_enum_value<T>(value: &Value) -> Option<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_value(value.clone()).ok()
 }
 
 pub(crate) struct CanonicalResultEnvelopeInput<'a> {
@@ -1335,6 +1515,13 @@ fn render_external_capability_decision(summary: &ExternalCapabilityDecisionSumma
         ExternalCapabilityDecisionOutcome::Allowed => "allowed",
         ExternalCapabilityDecisionOutcome::Rejected => "rejected",
     };
+    let boundary_surface = summary
+        .boundary_surface
+        .map(|surface| match surface {
+            ExternalCapabilityDecisionSurface::ToolBus => "tool_bus",
+            ExternalCapabilityDecisionSurface::TaskIngress => "task_ingress",
+        })
+        .unwrap_or("unknown");
     let branch_id = summary
         .branch_id
         .map(|branch_id| branch_id.to_string())
@@ -1382,8 +1569,9 @@ fn render_external_capability_decision(summary: &ExternalCapabilityDecisionSumma
     };
 
     format!(
-        "{} branch={} observed_at={} outcome={} capability_descriptor={} action_descriptor={} action_id={} title={} scope={} required_scope={} state={} depth={} policy={} resource_id={} rationale={}",
+        "{} surface={} branch={} observed_at={} outcome={} capability_descriptor={} action_descriptor={} action_id={} title={} scope={} required_scope={} state={} depth={} policy={} resource_id={} rationale={}",
         capability_id,
+        boundary_surface,
         branch_id,
         observed_at,
         outcome,

--- a/crates/mister-smith-app/src/bootstrap.rs
+++ b/crates/mister-smith-app/src/bootstrap.rs
@@ -356,7 +356,7 @@ async fn start_http_server(
                 let pool = autonomy_pool.clone();
                 let task_service = autonomy_task_service_for_status.clone();
                 async move {
-                    match autonomy::status_from_bus_with_session_linkage(
+                    match autonomy::status_from_bus_with_metadata_continuity(
                         event_bus,
                         pool,
                         &workflow_id,

--- a/crates/mister-smith-app/src/conversation.rs
+++ b/crates/mister-smith-app/src/conversation.rs
@@ -1099,6 +1099,69 @@ mod tests {
     }
 
     #[test]
+    fn retained_context_after_turn_does_not_relabel_autonomy_status_surfaces() {
+        let workflow_id = TaskId::new();
+        let turn = SessionTurnRecord {
+            turn_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            turn_index: 3,
+            workflow_id: *workflow_id.as_ref(),
+            user_message: "Continue the delegated workflow".to_string(),
+            result_summary: None,
+            status: "completed".to_string(),
+            created_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+        };
+
+        let retained = retained_context_after_turn(
+            &empty_retained_context(),
+            &turn,
+            workflow_id,
+            Some(json!({
+                "workflow_id": workflow_id,
+                "status": "completed",
+                "proof_outcome": "graph_formed_and_completed",
+                "external_capability_decisions": [
+                    {
+                        "boundary_surface": "task_ingress",
+                        "action_id": "tool:agent.echo#execute"
+                    }
+                ],
+                "result": {
+                    "workflow_id": workflow_id,
+                    "provider_kind": "openai_chatgpt",
+                    "model_id": "gpt-5.4",
+                    "description": "continue the delegated workflow",
+                    "runtime_execution_mode": {
+                        "execution_boundary": "tool_bus"
+                    },
+                    "planner_output": {
+                        "steps": 1
+                    },
+                    "execution_plan": {
+                        "steps": [{"id": "step-1"}]
+                    },
+                    "step_results": [],
+                    "aggregated_result": {
+                        "summary": "bounded answer preview"
+                    },
+                    "proof_outcome": "graph_formed_and_completed"
+                }
+            })),
+        );
+
+        let assistant_result = retained["last_assistant_result"]["assistant_result"].clone();
+        assert!(assistant_result
+            .get("external_capability_decisions")
+            .is_none());
+        assert!(assistant_result.get("boundary_surface").is_none());
+        assert_eq!(
+            retained["last_assistant_result"]["preview"],
+            json!("bounded answer preview")
+        );
+    }
+
+    #[test]
     fn retained_result_for_turn_uses_stored_projection_with_proof_outcome() {
         let workflow_id = TaskId::new();
         let retained_context = json!({

--- a/crates/mister-smith-app/src/execution.rs
+++ b/crates/mister-smith-app/src/execution.rs
@@ -1412,6 +1412,7 @@ impl RuntimeTaskService {
             return;
         };
         crate::autonomy::enrich_session_linkage(&mut view, metadata);
+        crate::autonomy::enrich_accepted_task_ingress_continuity(&mut view, metadata);
         crate::autonomy::enrich_step_routing_history(&mut view, metadata);
         crate::autonomy::enrich_result_preview(&mut view, metadata, task_result);
         persist_autonomy_status(metadata, &view);
@@ -1557,6 +1558,7 @@ fn recover_persisted_autonomy_status(record: &TaskRecord) -> Option<AutonomyStat
         )?
     };
     crate::autonomy::enrich_session_linkage(&mut view, &record.metadata);
+    crate::autonomy::enrich_accepted_task_ingress_continuity(&mut view, &record.metadata);
     crate::autonomy::enrich_step_routing_history(&mut view, &record.metadata);
     crate::autonomy::enrich_result_preview(&mut view, &record.metadata, record.result.as_ref());
     Some(view)
@@ -2119,9 +2121,47 @@ mod tests {
     }
 
     #[test]
+    fn recover_persisted_autonomy_status_synthesizes_task_ingress_decision_from_frozen_metadata() {
+        let view = sample_autonomy_view();
+        let delegation = sample_external_delegation();
+        let mut metadata = json!({
+            "external_delegation": delegation.clone(),
+            ACCEPTED_TASK_INGRESS_METADATA_KEY: accepted_task_ingress_metadata(&delegation),
+        });
+        persist_autonomy_status(&mut metadata, &view);
+        let record = sample_task_with_metadata(metadata);
+
+        let recovered = recover_persisted_autonomy_status(&record)
+            .expect("persisted autonomy status should synthesize task-ingress continuity");
+        let summary = recovered
+            .external_capability_decisions
+            .first()
+            .expect("accepted task ingress should surface as one boundary decision");
+
+        assert_eq!(
+            summary.boundary_surface,
+            Some(mister_smith_events::ExternalCapabilityDecisionSurface::TaskIngress)
+        );
+        assert_eq!(summary.outcome, ExternalCapabilityDecisionOutcome::Allowed);
+        assert_eq!(summary.branch_id, None);
+        assert_eq!(
+            summary.action_id.as_deref(),
+            Some("tool:app.workflow#execute")
+        );
+        assert!(summary
+            .rationale
+            .iter()
+            .any(|line| line.contains("POST /api/v1/tasks")));
+        assert!(summary.rationale.iter().any(|line| {
+            line.contains("accepted_task_ingress sourced from external_delegation")
+        }));
+    }
+
+    #[test]
     fn recover_persisted_autonomy_status_preserves_allowed_external_capability_decision_snapshot() {
         let mut view = sample_autonomy_view();
         view.external_capability_decisions = vec![ExternalCapabilityDecisionSummary {
+            boundary_surface: Some(mister_smith_events::ExternalCapabilityDecisionSurface::ToolBus),
             branch_id: Some(ExecutionBranchId::new()),
             capability_id: Some(CapabilityId::new()),
             capability_descriptor_id: Some("tool:app.workflow".to_string()),
@@ -2179,6 +2219,7 @@ mod tests {
     {
         let mut view = sample_autonomy_view();
         view.external_capability_decisions = vec![ExternalCapabilityDecisionSummary {
+            boundary_surface: Some(mister_smith_events::ExternalCapabilityDecisionSurface::ToolBus),
             branch_id: Some(ExecutionBranchId::new()),
             capability_id: Some(CapabilityId::new()),
             capability_descriptor_id: Some("tool:app.other".to_string()),

--- a/crates/mister-smith-app/tests/autonomy_status_tests.rs
+++ b/crates/mister-smith-app/tests/autonomy_status_tests.rs
@@ -16,8 +16,9 @@ use mister_smith_core::{
 use mister_smith_events::{
     AutonomyEvent, AutonomyEventEnvelope, AutonomyStatusView, BranchSummary, CapabilitySummary,
     CheckpointRecordSummary, ContextPressureSummary, DelegationAlert, ExecutionGraphSummary,
-    ExternalCapabilityDecisionOutcome, ExternalCapabilityDecisionSummary, ResumeProvenanceSummary,
-    RoutingDecisionSummary, StepRoutingDecisionSummary, TopologyPlanSummary,
+    ExternalCapabilityDecisionOutcome, ExternalCapabilityDecisionSummary,
+    ExternalCapabilityDecisionSurface, ResumeProvenanceSummary, RoutingDecisionSummary,
+    StepRoutingDecisionSummary, TopologyPlanSummary,
 };
 
 fn sample_task_shape(kind: TaskShapeKind) -> TaskShapeClassification {
@@ -197,6 +198,7 @@ fn sample_view() -> (AutonomyStatusView, GuardDecisionId, ExecutionBranchId) {
             message: "operator review required".to_string(),
         }],
         external_capability_decisions: vec![ExternalCapabilityDecisionSummary {
+            boundary_surface: Some(ExternalCapabilityDecisionSurface::ToolBus),
             branch_id: Some(branch_id),
             capability_id: Some(capability_id),
             capability_descriptor_id: Some("tool:agent.echo".to_string()),
@@ -272,6 +274,30 @@ fn sample_step_routing_history(
         triggered_checkpoints: vec![],
         change_rationale: vec![format!("action changed to {action}")],
     }
+}
+
+fn sample_accepted_task_ingress_metadata(
+    capability_id: mister_smith_core::CapabilityId,
+) -> serde_json::Value {
+    serde_json::json!({
+        "accepted_task_ingress": {
+            "request_surface": "POST /api/v1/tasks",
+            "source_metadata_key": "external_delegation",
+            "capability_id": capability_id,
+            "capability_descriptor_id": "tool:agent.echo",
+            "action_descriptor_id": "tool:agent.echo",
+            "action_id": "tool:agent.echo#execute",
+            "action_title": "execute agent.echo",
+            "scope": "InvokeTool",
+            "required_scope": "InvokeTool",
+            "policy_action": "execute",
+            "policy_resource": "echo",
+            "policy_scope": "agent",
+            "policy_resource_id": "agent.echo",
+            "revocation_state": "Active",
+            "chain_depth": 1
+        }
+    })
 }
 
 fn sample_task_result_view(
@@ -354,11 +380,55 @@ fn render_status_surfaces_operator_rationale_and_history() {
     assert!(rendered.contains("lineage="));
     assert!(rendered.contains("delegation revoked before tool execution"));
     assert!(rendered.contains("external capability decisions:"));
+    assert!(rendered.contains("surface=tool_bus"));
     assert!(rendered.contains("outcome=allowed"));
     assert!(rendered.contains(&format!("branch={branch_id}")));
     assert!(rendered.contains("tool:agent.echo#execute"));
     assert!(rendered.contains("required scope InvokeTool matched capability scope InvokeTool"));
     assert!(rendered.contains("control-plane state unavailable"));
+}
+
+#[test]
+fn enrich_accepted_task_ingress_continuity_surfaces_task_ingress_decision() {
+    let (mut view, _, _) = sample_view();
+    let capability_id = view
+        .external_capability_decisions
+        .first()
+        .and_then(|decision| decision.capability_id)
+        .expect("sample view should include one capability decision");
+    view.external_capability_decisions.clear();
+
+    autonomy::enrich_accepted_task_ingress_continuity(
+        &mut view,
+        &sample_accepted_task_ingress_metadata(capability_id),
+    );
+
+    let summary = view
+        .external_capability_decisions
+        .first()
+        .expect("accepted task ingress should project one boundary decision");
+    assert_eq!(
+        summary.boundary_surface,
+        Some(ExternalCapabilityDecisionSurface::TaskIngress)
+    );
+    assert_eq!(summary.outcome, ExternalCapabilityDecisionOutcome::Allowed);
+    assert_eq!(summary.branch_id, None);
+    assert_eq!(
+        summary.action_id.as_deref(),
+        Some("tool:agent.echo#execute")
+    );
+    assert!(summary
+        .rationale
+        .iter()
+        .any(|line| line.contains("POST /api/v1/tasks")));
+    assert!(summary
+        .rationale
+        .iter()
+        .any(|line| { line.contains("accepted_task_ingress sourced from external_delegation") }));
+
+    let rendered = autonomy::render_status(&view);
+    assert!(rendered.contains("surface=task_ingress"));
+    assert!(rendered.contains("branch=none"));
 }
 
 #[test]

--- a/crates/mister-smith-events/src/autonomy.rs
+++ b/crates/mister-smith-events/src/autonomy.rs
@@ -249,9 +249,22 @@ pub enum ExternalCapabilityDecisionOutcome {
     Rejected,
 }
 
+/// Runtime surface that emitted an external capability boundary decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalCapabilityDecisionSurface {
+    /// Delegated external action at the ToolBus runtime boundary.
+    ToolBus,
+    /// Accepted delegated task ingress at `POST /api/v1/tasks`.
+    TaskIngress,
+}
+
 /// Operator-visible explanation of one external capability boundary decision.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExternalCapabilityDecisionSummary {
+    /// Runtime surface that emitted the boundary decision, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boundary_surface: Option<ExternalCapabilityDecisionSurface>,
     /// Branch that exercised the external capability boundary, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch_id: Option<ExecutionBranchId>,

--- a/crates/mister-smith-events/src/bus.rs
+++ b/crates/mister-smith-events/src/bus.rs
@@ -420,7 +420,11 @@ fn delegation_capability_key(capability: &CapabilitySummary) -> String {
 
 fn external_capability_decision_key(decision: &ExternalCapabilityDecisionSummary) -> String {
     format!(
-        "{}:{}:{}:{}:{}",
+        "{}:{}:{}:{}:{}:{}",
+        decision
+            .boundary_surface
+            .map(|surface| format!("{surface:?}"))
+            .unwrap_or_else(|| "none".to_string()),
         decision
             .branch_id
             .map(|branch_id| branch_id.to_string())

--- a/crates/mister-smith-events/src/lib.rs
+++ b/crates/mister-smith-events/src/lib.rs
@@ -38,8 +38,8 @@ pub use autonomy::{
     AutonomyEvent, AutonomyEventEnvelope, AutonomyEventType, AutonomyStatusView, BranchSummary,
     CapabilitySummary, CheckpointRecordSummary, ContextPressureSummary, DelegationAlert,
     ExecutionGraphSummary, ExternalCapabilityDecisionOutcome, ExternalCapabilityDecisionSummary,
-    ResumeProvenanceSummary, RoutingDecisionSummary, StepRoutingDecisionSummary,
-    TopologyPlanSummary,
+    ExternalCapabilityDecisionSurface, ResumeProvenanceSummary, RoutingDecisionSummary,
+    StepRoutingDecisionSummary, TopologyPlanSummary,
 };
 pub use builder::EventBuilder;
 pub use bus::EventBus;

--- a/crates/mister-smith-events/tests/autonomy_event_tests.rs
+++ b/crates/mister-smith-events/tests/autonomy_event_tests.rs
@@ -12,8 +12,8 @@ use mister_smith_events::{
     AutonomyEvent, AutonomyEventEnvelope, AutonomyEventType, AutonomyStatusView, BranchSummary,
     CapabilitySummary, CheckpointRecordSummary, ContextPressureSummary, DelegationAlert, EventBus,
     EventType, ExecutionGraphSummary, ExternalCapabilityDecisionOutcome,
-    ExternalCapabilityDecisionSummary, ResumeProvenanceSummary, RoutingDecisionSummary,
-    StepRoutingDecisionSummary, TopologyPlanSummary,
+    ExternalCapabilityDecisionSummary, ExternalCapabilityDecisionSurface, ResumeProvenanceSummary,
+    RoutingDecisionSummary, StepRoutingDecisionSummary, TopologyPlanSummary,
 };
 use serde::de::DeserializeOwned;
 
@@ -106,6 +106,7 @@ fn sample_external_capability_decision(
     scope: DelegationScope,
 ) -> ExternalCapabilityDecisionSummary {
     ExternalCapabilityDecisionSummary {
+        boundary_surface: Some(ExternalCapabilityDecisionSurface::ToolBus),
         branch_id: None,
         capability_id: Some(capability_id),
         capability_descriptor_id: Some("tool:agent.echo".to_string()),
@@ -125,6 +126,35 @@ fn sample_external_capability_decision(
         rationale: vec![
             "descriptor 'tool:agent.echo' matched the requested external action".to_string(),
             "required scope InvokeTool matched capability scope InvokeTool".to_string(),
+        ],
+    }
+}
+
+fn sample_task_ingress_decision(
+    capability_id: CapabilityId,
+    scope: DelegationScope,
+) -> ExternalCapabilityDecisionSummary {
+    ExternalCapabilityDecisionSummary {
+        boundary_surface: Some(ExternalCapabilityDecisionSurface::TaskIngress),
+        branch_id: None,
+        capability_id: Some(capability_id),
+        capability_descriptor_id: Some("tool:agent.echo".to_string()),
+        action_descriptor_id: Some("tool:agent.echo".to_string()),
+        action_id: Some("tool:agent.echo#execute".to_string()),
+        action_title: Some("execute agent.echo".to_string()),
+        scope: Some(scope),
+        required_scope: Some(scope),
+        policy_action: Some("execute".to_string()),
+        policy_resource: Some("echo".to_string()),
+        policy_scope: Some("agent".to_string()),
+        policy_resource_id: Some("agent.echo".to_string()),
+        revocation_state: Some(RevocationState::Active),
+        chain_depth: 1,
+        outcome: ExternalCapabilityDecisionOutcome::Allowed,
+        observed_at: None,
+        rationale: vec![
+            "accepted delegated task ingress remained authorized at POST /api/v1/tasks".to_string(),
+            "continuity projected from workflow metadata accepted_task_ingress sourced from external_delegation".to_string(),
         ],
     }
 }
@@ -498,10 +528,10 @@ fn autonomy_status_view_serializes_with_typed_summaries() {
                 message: "operator review required for widened authority".to_string(),
             },
         ],
-        external_capability_decisions: vec![sample_external_capability_decision(
-            CapabilityId::new(),
-            DelegationScope::InvokeTool,
-        )],
+        external_capability_decisions: vec![
+            sample_external_capability_decision(CapabilityId::new(), DelegationScope::InvokeTool),
+            sample_task_ingress_decision(CapabilityId::new(), DelegationScope::InvokeTool),
+        ],
         profiles: vec![ProfileSnapshot {
             profile_id: ProfileSnapshotId::new(),
             target: ProfileTarget::Branch,
@@ -932,6 +962,10 @@ async fn event_bus_assembles_operator_visible_autonomy_projection() {
         view.external_capability_decisions[0].outcome,
         ExternalCapabilityDecisionOutcome::Allowed
     );
+    assert_eq!(
+        view.external_capability_decisions[0].boundary_surface,
+        Some(ExternalCapabilityDecisionSurface::ToolBus)
+    );
     assert!(view.external_capability_decisions[0]
         .rationale
         .iter()
@@ -943,6 +977,10 @@ async fn event_bus_assembles_operator_visible_autonomy_projection() {
     assert_eq!(
         view.external_capability_decisions[1].outcome,
         ExternalCapabilityDecisionOutcome::Rejected
+    );
+    assert_eq!(
+        view.external_capability_decisions[1].boundary_surface,
+        Some(ExternalCapabilityDecisionSurface::ToolBus)
     );
     assert_eq!(
         view.interventions[0].rationale,
@@ -1437,7 +1475,8 @@ async fn delegation_decision_projection_preserves_branch_and_retry_history() {
         .external_capability_decisions
         .iter()
         .any(|decision| decision.branch_id == Some(branch_a)
-            && decision.outcome == ExternalCapabilityDecisionOutcome::Rejected));
+            && decision.outcome == ExternalCapabilityDecisionOutcome::Rejected
+            && decision.boundary_surface == Some(ExternalCapabilityDecisionSurface::ToolBus)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- synthesize accepted task-ingress continuity into workflow autonomy status from frozen metadata
- add a backward-compatible  discriminator so task-ingress and ToolBus decisions stay distinct on the shared operator surface
- extend app, event, agent, and conversation coverage for status rendering, projection parity, and retained-session compatibility

## Validation
- cargo test -p mister-smith-app -p mister-smith-events -p mister-smith-agents
- cargo build --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task-ingress workflow support for autonomy status tracking and decision metadata.

* **Refactor**
  * Enhanced external capability decision tracking with execution boundary surface identification (tool-bus and task-ingress).
  * Improved autonomy status metadata enrichment and continuity handling.

* **Tests**
  * Extended coverage for boundary surface tracking, decision rendering, and metadata continuity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->