### PR TITLE
docs(packet-016): refresh final validation evidence

### DIFF
--- a/docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md
+++ b/docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md
@@ -185,6 +185,8 @@ cargo test -p mister-smith-http
 cargo test -p mister-smith-app --test autonomy_status_tests
 cargo test -p mister-smith-events --test autonomy_event_tests
 cargo build --workspace
+npx markdownlint-cli2 docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md --config .markdownlint.json
+scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync
 ```
 
 ### Refresh Results
@@ -203,6 +205,11 @@ cargo build --workspace
     outcome summaries remain green
 - `cargo build --workspace`
   - succeeded with no compile errors across the full Rust workspace
+- `npx markdownlint-cli2 docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md --config .markdownlint.json`
+  - passed with no markdownlint violations in the refreshed packet-016 proof note
+- `scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync`
+  - passed after the refreshed validation-evidence branch was pushed, confirming the task-owned
+    worktree stayed synced and reviewable
 
 ### Final Slice Outcome
 


### PR DESCRIPTION
## Summary
- refresh the packet-016 evaluation note for MS-100 with current final-validation evidence
- record the green HTTP, app, and event coverage results plus workspace build proof
- keep the note bounded to packet-016 review readiness without widening runtime scope

## Validation
- cargo test -p mister-smith-http
- cargo test -p mister-smith-app --test autonomy_status_tests
- cargo test -p mister-smith-events --test autonomy_event_tests
- cargo build --workspace
- npx markdownlint-cli2 docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md --config .markdownlint.json
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync

Refs MS-100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded planning note to include both interim and final validation entries for the packet.
  * Added a "Final Validation Refresh" section documenting refreshed provenance, test/build/lint results, and workspace sync verification.
  * Clarified final outcomes: targeted validation set and build succeeded on the refreshed branch and the note records both original proof and final refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->