### PR TITLE
feat: surface orchestration-quality provenance

### DIFF
--- a/crates/mister-smith-app/src/autonomy.rs
+++ b/crates/mister-smith-app/src/autonomy.rs
@@ -12,9 +12,11 @@ use chrono::{DateTime, Utc};
 use mister_smith_config::FrameworkConfig;
 use mister_smith_core::{
     AgentId, CapabilityId, CoordinationPolicy, DelegationScope, ExecutionGraphId, GraphState,
-    OperatorResultPreview, ProofOutcomeClassification, ResultProvenanceSummary, RevocationState,
-    SessionId, SessionRetainedResultView, TaskId, TaskResultView, TaskShapeClassification,
-    TaskShapeKind, TopologyKind, TopologyRationale, UnifiedResultEnvelope,
+    OperatorResultPreview, OrchestrationQualityView, ProofOutcomeClassification,
+    RepairDirectiveAction, ResultProvenanceSummary, RevocationState, SessionId,
+    SessionRetainedResultView, StepEvaluationRecord, TaskId, TaskResultView,
+    TaskShapeClassification, TaskShapeKind, TopologyKind, TopologyRationale, UnifiedResultEnvelope,
+    VerifierVerdict,
 };
 use mister_smith_events::autonomy::merge_operator_result_preview;
 use mister_smith_events::{
@@ -103,6 +105,14 @@ pub(crate) struct ResumeProvenanceDetails {
     pub recovery_reason: Option<String>,
     pub resumed_from_workflow_id: Option<TaskId>,
     pub resumed_from_turn_index: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+struct StepEvaluationCandidate {
+    record: StepEvaluationRecord,
+    plan_index: usize,
+    repair_attempt_count: u32,
+    verdict_rank: u8,
 }
 
 /// Derive the local autonomy inspection base URL from framework config.
@@ -763,10 +773,12 @@ pub(crate) fn build_task_result_view(
     status: &str,
     canonical_result: UnifiedResultEnvelope,
 ) -> TaskResultView {
+    let orchestration_quality = orchestration_quality_view(&canonical_result);
     TaskResultView {
         workflow_id: canonical_result.workflow_id,
         status: status.to_string(),
         proof_outcome: canonical_result.proof_outcome,
+        orchestration_quality,
         result: canonical_result,
     }
 }
@@ -940,6 +952,7 @@ fn operator_result_preview(
         proof_outcome: canonical_result.proof_outcome,
         preview_text: preview_text(&canonical_result.aggregated_result),
         payload_location: payload_location.to_string(),
+        orchestration_quality: orchestration_quality_view(canonical_result),
         provenance_lines: result_preview_provenance(canonical_result, payload_location, view),
     }
 }
@@ -1242,6 +1255,9 @@ fn result_preview_provenance(
     if let Some(step_line) = latest_step_routing_provenance(view) {
         lines.push(step_line);
     }
+    if let Some(orchestration_quality) = orchestration_quality_view(canonical_result) {
+        lines.push(render_orchestration_quality_line(&orchestration_quality));
+    }
     lines.extend([
         "canonical result stored in metadata.final_result".to_string(),
         "aggregated payload nested under metadata.aggregated_result".to_string(),
@@ -1249,6 +1265,215 @@ fn result_preview_provenance(
         "session assistant_result derives from the canonical result object".to_string(),
     ]);
     lines
+}
+
+fn orchestration_quality_view(
+    canonical_result: &UnifiedResultEnvelope,
+) -> Option<OrchestrationQualityView> {
+    let plan_index_by_step = execution_plan_step_indices(&canonical_result.execution_plan);
+    let candidates = step_evaluation_candidates(canonical_result, &plan_index_by_step);
+    let terminal = select_terminal_step_evaluation(&candidates)?;
+    let recovered_repair_action = terminal
+        .record
+        .repair_directive
+        .as_ref()
+        .map(|directive| directive.action)
+        .or_else(|| recover_prior_repair_action(&candidates, &terminal.record));
+    let clarification_attempt_count = terminal
+        .record
+        .clarification_request
+        .as_ref()
+        .map(|request| request.attempt_count)
+        .unwrap_or(0);
+    let checkpoint_ref = terminal
+        .record
+        .failure_context_checkpoint
+        .as_ref()
+        .and_then(|checkpoint| checkpoint.checkpoint_ref.clone())
+        .or_else(|| terminal.record.checkpoint_ref.clone());
+    let last_stable_step_id = terminal
+        .record
+        .failure_context_checkpoint
+        .as_ref()
+        .and_then(|checkpoint| checkpoint.last_stable_step_id.clone());
+    let failure_context_ref = failure_context_ref(&terminal.record);
+
+    Some(OrchestrationQualityView {
+        step_id: terminal.record.step_id.clone(),
+        verdict: terminal.record.verdict,
+        repair_action: recovered_repair_action,
+        clarification_attempt_count,
+        checkpoint_ref,
+        last_stable_step_id,
+        failure_context_ref,
+        outcome_summary: orchestration_outcome_summary(
+            terminal.record.verdict,
+            recovered_repair_action,
+        ),
+    })
+}
+
+fn execution_plan_step_indices(execution_plan: &Value) -> BTreeMap<String, usize> {
+    execution_plan
+        .get("steps")
+        .and_then(Value::as_array)
+        .map(|steps| {
+            steps
+                .iter()
+                .enumerate()
+                .filter_map(|(index, step)| {
+                    step.get("id")
+                        .and_then(Value::as_str)
+                        .map(|step_id| (step_id.to_string(), index + 1))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn step_evaluation_candidates(
+    canonical_result: &UnifiedResultEnvelope,
+    plan_index_by_step: &BTreeMap<String, usize>,
+) -> Vec<StepEvaluationCandidate> {
+    canonical_result
+        .step_results
+        .iter()
+        .filter_map(|step_result| {
+            let evaluation = step_result
+                .get("step_evaluation")
+                .cloned()
+                .and_then(|value| serde_json::from_value::<StepEvaluationRecord>(value).ok())?;
+            let repair_attempt_count = evaluation
+                .failure_context_checkpoint
+                .as_ref()
+                .map(|checkpoint| checkpoint.attempt_count)
+                .or_else(|| {
+                    evaluation
+                        .clarification_request
+                        .as_ref()
+                        .map(|request| request.attempt_count)
+                })
+                .unwrap_or(0);
+
+            Some(StepEvaluationCandidate {
+                plan_index: plan_index_by_step
+                    .get(&evaluation.step_id)
+                    .copied()
+                    .unwrap_or(0),
+                repair_attempt_count,
+                verdict_rank: if evaluation.verdict == VerifierVerdict::Accepted {
+                    1
+                } else {
+                    0
+                },
+                record: evaluation,
+            })
+        })
+        .collect()
+}
+
+fn select_terminal_step_evaluation(
+    candidates: &[StepEvaluationCandidate],
+) -> Option<&StepEvaluationCandidate> {
+    candidates.iter().max_by_key(|candidate| {
+        (
+            candidate.plan_index,
+            candidate.repair_attempt_count,
+            candidate.verdict_rank,
+        )
+    })
+}
+
+fn recover_prior_repair_action(
+    candidates: &[StepEvaluationCandidate],
+    terminal_record: &StepEvaluationRecord,
+) -> Option<RepairDirectiveAction> {
+    let terminal_failure_context = failure_context_ref(terminal_record);
+
+    let by_failure_context = terminal_failure_context
+        .as_deref()
+        .and_then(|terminal_failure_ref| {
+            candidates
+                .iter()
+                .filter(|candidate| {
+                    failure_context_ref(&candidate.record).as_deref() == Some(terminal_failure_ref)
+                })
+                .filter_map(|candidate| {
+                    candidate
+                        .record
+                        .repair_directive
+                        .as_ref()
+                        .map(|directive| (candidate.repair_attempt_count, directive.action))
+                })
+                .max_by_key(|(attempt_count, _)| *attempt_count)
+                .map(|(_, action)| action)
+        });
+
+    by_failure_context.or_else(|| {
+        candidates
+            .iter()
+            .filter(|candidate| candidate.record.step_id == terminal_record.step_id)
+            .filter_map(|candidate| {
+                candidate
+                    .record
+                    .repair_directive
+                    .as_ref()
+                    .map(|directive| (candidate.repair_attempt_count, directive.action))
+            })
+            .max_by_key(|(attempt_count, _)| *attempt_count)
+            .map(|(_, action)| action)
+    })
+}
+
+fn failure_context_ref(record: &StepEvaluationRecord) -> Option<String> {
+    record
+        .failure_context_checkpoint
+        .as_ref()
+        .map(|checkpoint| checkpoint.failure_context_ref.clone())
+        .or_else(|| {
+            record
+                .repair_directive
+                .as_ref()
+                .map(|directive| directive.failure_context_ref.clone())
+        })
+}
+
+fn orchestration_outcome_summary(
+    verdict: VerifierVerdict,
+    repair_action: Option<RepairDirectiveAction>,
+) -> String {
+    match (verdict, repair_action) {
+        (VerifierVerdict::Accepted, Some(action)) => {
+            format!("accepted_after_{}", action.as_str())
+        }
+        (VerifierVerdict::Accepted, None) => "accepted_without_repair".to_string(),
+        (VerifierVerdict::Rejected, Some(action)) => {
+            format!("rejected_with_{}", action.as_str())
+        }
+        (VerifierVerdict::Rejected, None) => "rejected_without_repair".to_string(),
+    }
+}
+
+fn render_orchestration_quality_line(summary: &OrchestrationQualityView) -> String {
+    let repair_action = summary
+        .repair_action
+        .map(RepairDirectiveAction::as_str)
+        .unwrap_or("none");
+    let checkpoint_ref = summary.checkpoint_ref.as_deref().unwrap_or("none");
+    let last_stable_step = summary.last_stable_step_id.as_deref().unwrap_or("none");
+    let failure_context = summary.failure_context_ref.as_deref().unwrap_or("none");
+
+    format!(
+        "orchestration quality step={} verdict={} repair={} clarification_attempts={} checkpoint={} last_stable_step={} failure_context={} outcome={}",
+        summary.step_id,
+        summary.verdict.as_str(),
+        repair_action,
+        summary.clarification_attempt_count,
+        checkpoint_ref,
+        last_stable_step,
+        failure_context,
+        summary.outcome_summary
+    )
 }
 
 fn runtime_execution_mode_provenance(runtime_execution_mode: &Value) -> Option<String> {
@@ -1535,6 +1760,48 @@ fn render_result_preview(summary: &OperatorResultPreview) -> String {
             rendered.push_str("\n  - ");
             rendered.push_str(line);
         }
+    }
+    if let Some(orchestration_quality) = summary.orchestration_quality.as_ref() {
+        let repair_action = orchestration_quality
+            .repair_action
+            .map(RepairDirectiveAction::as_str)
+            .unwrap_or("none");
+        rendered.push_str("\n  orchestration_quality:");
+        rendered.push_str("\n  - step=");
+        rendered.push_str(&orchestration_quality.step_id);
+        rendered.push_str(" verdict=");
+        rendered.push_str(orchestration_quality.verdict.as_str());
+        rendered.push_str(" repair=");
+        rendered.push_str(repair_action);
+        rendered.push_str(" clarification_attempts=");
+        rendered.push_str(
+            &orchestration_quality
+                .clarification_attempt_count
+                .to_string(),
+        );
+        rendered.push_str(" checkpoint=");
+        rendered.push_str(
+            orchestration_quality
+                .checkpoint_ref
+                .as_deref()
+                .unwrap_or("none"),
+        );
+        rendered.push_str(" last_stable_step=");
+        rendered.push_str(
+            orchestration_quality
+                .last_stable_step_id
+                .as_deref()
+                .unwrap_or("none"),
+        );
+        rendered.push_str(" failure_context=");
+        rendered.push_str(
+            orchestration_quality
+                .failure_context_ref
+                .as_deref()
+                .unwrap_or("none"),
+        );
+        rendered.push_str(" outcome=");
+        rendered.push_str(&orchestration_quality.outcome_summary);
     }
     rendered
 }

--- a/crates/mister-smith-app/tests/autonomy_status_tests.rs
+++ b/crates/mister-smith-app/tests/autonomy_status_tests.rs
@@ -7,11 +7,13 @@ mod observability;
 
 use mister_smith_core::{
     AgentId, BranchRecoveryStrategy, BranchState, BudgetPolicy, BudgetScope, CheckpointId,
-    CoordinationPolicy, ExecutionBranchId, ExecutionGraphId, FailureClass, GraphState,
-    GuardDecision, GuardDecisionId, GuardEvidence, HealthState, InterventionRecord,
-    InterventionRecordId, InterventionType, MemorySnapshotId, ProfileSnapshotId, ProfileTarget,
-    ProofOutcomeClassification, ProvenanceChain, ProvenanceLink, RevocationState, TaskId,
-    TaskShapeClassification, TaskShapeKind, TeamSizingDecision, TopologyKind, TopologyRationale,
+    CoordinationPolicy, ExecutionBranchId, ExecutionGraphId, FailureClass,
+    FailureContextCheckpoint, GraphState, GuardDecision, GuardDecisionId, GuardEvidence,
+    HandoffClarificationRequest, HealthState, InterventionRecord, InterventionRecordId,
+    InterventionType, MemorySnapshotId, OrchestrationQualityView, ProfileSnapshotId, ProfileTarget,
+    ProofOutcomeClassification, ProvenanceChain, ProvenanceLink, RepairDirective,
+    RepairDirectiveAction, RevocationState, StepEvaluationRecord, TaskId, TaskShapeClassification,
+    TaskShapeKind, TeamSizingDecision, TopologyKind, TopologyRationale, VerifierVerdict,
 };
 use mister_smith_events::{
     AutonomyEvent, AutonomyEventEnvelope, AutonomyStatusView, BranchSummary, CapabilitySummary,
@@ -300,33 +302,102 @@ fn sample_accepted_task_ingress_metadata(
     })
 }
 
-fn sample_task_result_view(
+fn sample_step_evaluation_record(
     workflow_id: TaskId,
-    proof_outcome: ProofOutcomeClassification,
-) -> serde_json::Value {
-    sample_task_result_payload(workflow_id, "completed", 1, 1, Some(proof_outcome))
+    step_id: &str,
+    verdict: VerifierVerdict,
+    repair_action: Option<RepairDirectiveAction>,
+    clarification_attempt_count: u32,
+    checkpoint_ref: Option<&str>,
+    last_stable_step_id: Option<&str>,
+    failure_context_ref: Option<&str>,
+) -> StepEvaluationRecord {
+    let repair_directive = if verdict == VerifierVerdict::Rejected {
+        repair_action.map(|action| RepairDirective {
+            action,
+            issued_by: "verifier.runtime".to_string(),
+            failure_context_ref: failure_context_ref
+                .unwrap_or("draft-outline/failure")
+                .to_string(),
+            retry_budget_remaining: 1,
+        })
+    } else {
+        None
+    };
+
+    let clarification_request = if clarification_attempt_count > 0 {
+        Some(HandoffClarificationRequest {
+            source_step_id: step_id.to_string(),
+            target_step_id: "write-brief".to_string(),
+            missing_constraints: vec!["budget ceiling".to_string()],
+            attempt_count: clarification_attempt_count,
+            expires_at: Some(chrono::Utc::now()),
+        })
+    } else {
+        None
+    };
+
+    let failure_context_checkpoint = if failure_context_ref.is_some()
+        || checkpoint_ref.is_some()
+        || last_stable_step_id.is_some()
+    {
+        Some(FailureContextCheckpoint {
+            failed_step_id: step_id.to_string(),
+            last_stable_step_id: last_stable_step_id.map(ToOwned::to_owned),
+            checkpoint_ref: checkpoint_ref.map(ToOwned::to_owned),
+            failure_context_ref: failure_context_ref
+                .unwrap_or("draft-outline/failure")
+                .to_string(),
+            failure_code: Some("missing_constraint".to_string()),
+            reason: "missing context".to_string(),
+            attempt_count: clarification_attempt_count.max(1),
+        })
+    } else {
+        None
+    };
+
+    StepEvaluationRecord {
+        workflow_id,
+        step_id: step_id.to_string(),
+        verdict,
+        confidence: Some(0.91),
+        reason: match verdict {
+            VerifierVerdict::Accepted => "accepted after bounded repair".to_string(),
+            VerifierVerdict::Rejected => "missing context".to_string(),
+        },
+        failure_code: if verdict == VerifierVerdict::Rejected {
+            Some("missing_constraint".to_string())
+        } else {
+            None
+        },
+        checkpoint_ref: checkpoint_ref.map(ToOwned::to_owned),
+        repair_directive,
+        clarification_request,
+        failure_context_checkpoint,
+    }
 }
 
-fn sample_task_result_payload(
+fn sample_step_result_with_evaluation(
+    step_id: &str,
+    step_evaluation: StepEvaluationRecord,
+) -> serde_json::Value {
+    serde_json::json!({
+        "task_id": TaskId::new(),
+        "step_id": step_id,
+        "result": {
+            "summary": "bounded answer preview"
+        },
+        "step_evaluation": step_evaluation
+    })
+}
+
+fn sample_task_result_payload_with_details(
     workflow_id: TaskId,
     status: &str,
-    execution_step_count: usize,
-    step_result_count: usize,
+    execution_steps: Vec<serde_json::Value>,
+    step_results: Vec<serde_json::Value>,
     proof_outcome: Option<ProofOutcomeClassification>,
 ) -> serde_json::Value {
-    let execution_steps = (1..=execution_step_count)
-        .map(|index| serde_json::json!({ "id": format!("step-{index}") }))
-        .collect::<Vec<_>>();
-    let step_results = (0..step_result_count)
-        .map(|_| {
-            serde_json::json!({
-                "task_id": TaskId::new(),
-                "result": {
-                    "summary": "bounded answer preview"
-                }
-            })
-        })
-        .collect::<Vec<_>>();
     let proof_outcome = proof_outcome.map(ProofOutcomeClassification::as_str);
 
     serde_json::json!({
@@ -357,6 +428,70 @@ fn sample_task_result_payload(
             },
             "proof_outcome": proof_outcome
         }
+    })
+}
+
+fn sample_task_result_view(
+    workflow_id: TaskId,
+    proof_outcome: ProofOutcomeClassification,
+) -> serde_json::Value {
+    sample_task_result_payload(workflow_id, "completed", 1, 1, Some(proof_outcome))
+}
+
+fn sample_task_result_payload(
+    workflow_id: TaskId,
+    status: &str,
+    execution_step_count: usize,
+    step_result_count: usize,
+    proof_outcome: Option<ProofOutcomeClassification>,
+) -> serde_json::Value {
+    let execution_steps = (1..=execution_step_count)
+        .map(|index| serde_json::json!({ "id": format!("step-{index}") }))
+        .collect::<Vec<_>>();
+    let step_results = (0..step_result_count)
+        .map(|_| {
+            serde_json::json!({
+                "task_id": TaskId::new(),
+                "result": {
+                    "summary": "bounded answer preview"
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    sample_task_result_payload_with_details(
+        workflow_id,
+        status,
+        execution_steps,
+        step_results,
+        proof_outcome,
+    )
+}
+
+fn sample_canonical_result(
+    workflow_id: TaskId,
+    status: &str,
+    execution_steps: Vec<serde_json::Value>,
+    step_results: Vec<serde_json::Value>,
+) -> mister_smith_core::UnifiedResultEnvelope {
+    autonomy::build_canonical_result_envelope(autonomy::CanonicalResultEnvelopeInput {
+        workflow_id,
+        provider_kind: "openai_chatgpt",
+        model_id: "gpt-5.4",
+        description: "freeze the result contract",
+        runtime_execution_mode: serde_json::json!({
+            "execution_boundary": "tool_bus",
+            "workflow_runner": "tokio_task",
+            "routing_policy": "round_robin",
+            "registered_provider_count": 1,
+            "budget_root": "disabled"
+        }),
+        planner_output: serde_json::json!({ "steps": execution_steps.len() }),
+        execution_plan: serde_json::json!({ "steps": execution_steps }),
+        step_results,
+        aggregated_result: serde_json::json!({
+            "summary": "bounded answer preview"
+        }),
+        status,
     })
 }
 
@@ -662,6 +797,296 @@ fn classify_proof_outcome_covers_success_collapse_and_failure_visible_matrix() {
 }
 
 #[test]
+fn build_task_result_view_surfaces_accepted_without_repair_orchestration_quality() {
+    let workflow_id = TaskId::new();
+    let canonical_result = sample_canonical_result(
+        workflow_id,
+        "completed",
+        vec![serde_json::json!({ "id": "draft-outline" })],
+        vec![sample_step_result_with_evaluation(
+            "draft-outline",
+            sample_step_evaluation_record(
+                workflow_id,
+                "draft-outline",
+                VerifierVerdict::Accepted,
+                None,
+                0,
+                None,
+                None,
+                None,
+            ),
+        )],
+    );
+
+    let summary = autonomy::build_task_result_view("completed", canonical_result)
+        .orchestration_quality
+        .expect("accepted evaluation should surface orchestration quality");
+
+    assert_eq!(
+        summary,
+        OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Accepted,
+            repair_action: None,
+            clarification_attempt_count: 0,
+            checkpoint_ref: None,
+            last_stable_step_id: None,
+            failure_context_ref: None,
+            outcome_summary: "accepted_without_repair".to_string(),
+        }
+    );
+}
+
+#[test]
+fn build_task_result_view_surfaces_rejected_retry_orchestration_quality() {
+    let workflow_id = TaskId::new();
+    let canonical_result = sample_canonical_result(
+        workflow_id,
+        "failed",
+        vec![serde_json::json!({ "id": "draft-outline" })],
+        vec![sample_step_result_with_evaluation(
+            "draft-outline",
+            sample_step_evaluation_record(
+                workflow_id,
+                "draft-outline",
+                VerifierVerdict::Rejected,
+                Some(RepairDirectiveAction::RetryStep),
+                0,
+                Some("checkpoint-retry"),
+                Some("collect-evidence"),
+                Some("draft-outline/retry"),
+            ),
+        )],
+    );
+
+    let summary = autonomy::build_task_result_view("failed", canonical_result)
+        .orchestration_quality
+        .expect("rejected evaluation should surface orchestration quality");
+
+    assert_eq!(
+        summary,
+        OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Rejected,
+            repair_action: Some(RepairDirectiveAction::RetryStep),
+            clarification_attempt_count: 0,
+            checkpoint_ref: Some("checkpoint-retry".to_string()),
+            last_stable_step_id: Some("collect-evidence".to_string()),
+            failure_context_ref: Some("draft-outline/retry".to_string()),
+            outcome_summary: "rejected_with_retry_step".to_string(),
+        }
+    );
+}
+
+#[test]
+fn enrich_result_preview_surfaces_accepted_after_clarify_orchestration_quality() {
+    let (mut view, _, _) = sample_view();
+    view.graph.state = GraphState::Completed;
+    view.step_routing_history[0].triggered_checkpoints =
+        vec!["budget_policy".to_string(), "confidence_review".to_string()];
+    let workflow_id = view.graph.workflow_id;
+    let task_result = sample_task_result_payload_with_details(
+        workflow_id,
+        "completed",
+        vec![serde_json::json!({ "id": "draft-outline" })],
+        vec![
+            sample_step_result_with_evaluation(
+                "draft-outline",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "draft-outline",
+                    VerifierVerdict::Accepted,
+                    None,
+                    2,
+                    Some("checkpoint-clarify"),
+                    Some("collect-evidence"),
+                    Some("draft-outline/clarify"),
+                ),
+            ),
+            sample_step_result_with_evaluation(
+                "draft-outline",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "draft-outline",
+                    VerifierVerdict::Rejected,
+                    Some(RepairDirectiveAction::ClarifyHandoff),
+                    1,
+                    Some("checkpoint-clarify"),
+                    Some("collect-evidence"),
+                    Some("draft-outline/clarify"),
+                ),
+            ),
+        ],
+        Some(ProofOutcomeClassification::CollapsedToSequential),
+    );
+
+    autonomy::enrich_result_preview(&mut view, &serde_json::json!({}), Some(&task_result));
+
+    let preview = view
+        .result_preview
+        .clone()
+        .expect("accepted clarify path should produce a preview");
+    assert_eq!(
+        preview.orchestration_quality,
+        Some(OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Accepted,
+            repair_action: Some(RepairDirectiveAction::ClarifyHandoff),
+            clarification_attempt_count: 2,
+            checkpoint_ref: Some("checkpoint-clarify".to_string()),
+            last_stable_step_id: Some("collect-evidence".to_string()),
+            failure_context_ref: Some("draft-outline/clarify".to_string()),
+            outcome_summary: "accepted_after_clarify_handoff".to_string(),
+        })
+    );
+    assert!(preview.provenance_lines.iter().any(|line| {
+        line.contains("latest step routing tier=llm-tier action=continue")
+            && line.contains("budget_policy")
+            && line.contains("confidence_review")
+    }));
+    assert!(preview.provenance_lines.iter().any(|line| {
+        line.contains("orchestration quality step=draft-outline verdict=accepted")
+            && line.contains("repair=clarify_handoff")
+            && line.contains("clarification_attempts=2")
+            && line.contains("checkpoint=checkpoint-clarify")
+            && line.contains("last_stable_step=collect-evidence")
+            && line.contains("failure_context=draft-outline/clarify")
+            && line.contains("outcome=accepted_after_clarify_handoff")
+    }));
+
+    let rendered = autonomy::render_status(&view);
+    assert!(rendered.contains("orchestration_quality:"));
+    assert!(rendered.contains("step=draft-outline verdict=accepted repair=clarify_handoff"));
+    assert!(rendered.contains(
+        "clarification_attempts=2 checkpoint=checkpoint-clarify last_stable_step=collect-evidence"
+    ));
+    assert!(rendered
+        .contains("failure_context=draft-outline/clarify outcome=accepted_after_clarify_handoff"));
+}
+
+#[test]
+fn enrich_result_preview_recovers_replan_checkpoint_lineage() {
+    let (mut view, _, _) = sample_view();
+    view.graph.state = GraphState::Completed;
+    let workflow_id = view.graph.workflow_id;
+    let task_result = sample_task_result_payload_with_details(
+        workflow_id,
+        "completed",
+        vec![
+            serde_json::json!({ "id": "collect-evidence" }),
+            serde_json::json!({ "id": "draft-outline" }),
+        ],
+        vec![
+            sample_step_result_with_evaluation(
+                "draft-outline",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "draft-outline",
+                    VerifierVerdict::Rejected,
+                    Some(RepairDirectiveAction::ReplanFromCheckpoint),
+                    1,
+                    Some("checkpoint-replan"),
+                    Some("collect-evidence"),
+                    Some("draft-outline/replan"),
+                ),
+            ),
+            sample_step_result_with_evaluation(
+                "draft-outline",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "draft-outline",
+                    VerifierVerdict::Accepted,
+                    None,
+                    2,
+                    Some("checkpoint-replan"),
+                    Some("collect-evidence"),
+                    Some("draft-outline/replan"),
+                ),
+            ),
+        ],
+        Some(ProofOutcomeClassification::GraphFormedAndCompleted),
+    );
+
+    autonomy::enrich_result_preview(&mut view, &serde_json::json!({}), Some(&task_result));
+
+    let summary = view
+        .result_preview
+        .expect("accepted replan path should produce a preview")
+        .orchestration_quality
+        .expect("accepted replan path should retain orchestration quality");
+    assert_eq!(
+        summary,
+        OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Accepted,
+            repair_action: Some(RepairDirectiveAction::ReplanFromCheckpoint),
+            clarification_attempt_count: 2,
+            checkpoint_ref: Some("checkpoint-replan".to_string()),
+            last_stable_step_id: Some("collect-evidence".to_string()),
+            failure_context_ref: Some("draft-outline/replan".to_string()),
+            outcome_summary: "accepted_after_replan_from_checkpoint".to_string(),
+        }
+    );
+}
+
+#[test]
+fn enrich_result_preview_uses_execution_plan_order_over_step_result_position() {
+    let (mut view, _, _) = sample_view();
+    view.graph.state = GraphState::Completed;
+    let workflow_id = view.graph.workflow_id;
+    let task_result = sample_task_result_payload_with_details(
+        workflow_id,
+        "completed",
+        vec![
+            serde_json::json!({ "id": "collect-evidence" }),
+            serde_json::json!({ "id": "draft-outline" }),
+            serde_json::json!({ "id": "publish" }),
+        ],
+        vec![
+            sample_step_result_with_evaluation(
+                "publish",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "publish",
+                    VerifierVerdict::Accepted,
+                    None,
+                    0,
+                    None,
+                    None,
+                    None,
+                ),
+            ),
+            sample_step_result_with_evaluation(
+                "draft-outline",
+                sample_step_evaluation_record(
+                    workflow_id,
+                    "draft-outline",
+                    VerifierVerdict::Accepted,
+                    None,
+                    3,
+                    Some("checkpoint-clarify"),
+                    Some("collect-evidence"),
+                    Some("draft-outline/clarify"),
+                ),
+            ),
+        ],
+        Some(ProofOutcomeClassification::GraphFormedAndCompleted),
+    );
+
+    autonomy::enrich_result_preview(&mut view, &serde_json::json!({}), Some(&task_result));
+
+    let summary = view
+        .result_preview
+        .expect("preview should be retained")
+        .orchestration_quality
+        .expect("terminal evaluation should be projected");
+    assert_eq!(summary.step_id, "publish");
+    assert_eq!(summary.verdict, VerifierVerdict::Accepted);
+    assert_eq!(summary.repair_action, None);
+    assert_eq!(summary.outcome_summary, "accepted_without_repair");
+}
+
+#[test]
 fn render_status_surfaces_result_preview_block() {
     let (mut view, _, _) = sample_view();
     view.result_preview = Some(mister_smith_core::OperatorResultPreview {
@@ -669,6 +1094,7 @@ fn render_status_surfaces_result_preview_block() {
         proof_outcome: ProofOutcomeClassification::GraphFormedAndCompleted,
         preview_text: Some("bounded answer preview".to_string()),
         payload_location: "task.result".to_string(),
+        orchestration_quality: None,
         provenance_lines: vec![
             "graph formed and completed before final result publication".to_string(),
             "provider=openai_chatgpt model=gpt-5.4".to_string(),
@@ -699,6 +1125,7 @@ fn enrich_result_preview_merges_existing_structural_provenance() {
         proof_outcome: ProofOutcomeClassification::GraphFormedAndCompleted,
         preview_text: Some("structural preview only".to_string()),
         payload_location: "task.result".to_string(),
+        orchestration_quality: None,
         provenance_lines: vec![
             "projection observed graph state Completed with topology Sequential (1 branch(es), 3 node(s))".to_string(),
             "routing history retained 1 decision(s)".to_string(),

--- a/crates/mister-smith-core/src/autonomy.rs
+++ b/crates/mister-smith-core/src/autonomy.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 
 use crate::enums::{
     BudgetPolicy, BudgetScope, CoordinationPolicy, DelegationScope, FailureClass, HealthState,
-    InterventionType, ProfileTarget, RevocationState, SemanticSignalKind, TopologyKind,
-    VerifierVerdict,
+    InterventionType, ProfileTarget, RepairDirectiveAction, RevocationState, SemanticSignalKind,
+    TopologyKind, VerifierVerdict,
 };
 use crate::ids::{
     AgentId, CapabilityId, CheckpointId, ContextBudgetId, ExecutionBranchId, ExecutionGraphId,
@@ -216,6 +216,36 @@ pub struct StepEvaluationRecord {
     pub failure_context_checkpoint: Option<FailureContextCheckpoint>,
 }
 
+fn is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
+/// Operator-facing projection of verifier and repair history for one workflow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestrationQualityView {
+    /// Stable identifier for the latest evaluated workflow step or handoff.
+    pub step_id: String,
+    /// Final verifier verdict visible to operators.
+    pub verdict: VerifierVerdict,
+    /// Bounded repair action when a repair path was taken.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repair_action: Option<RepairDirectiveAction>,
+    /// Number of clarification attempts retained for the rendered step.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub clarification_attempt_count: u32,
+    /// Stable checkpoint reference anchoring the repair branch when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    /// Last stable upstream step retained for local repair when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_stable_step_id: Option<String>,
+    /// Stable failure-context reference retained across repair attempts when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_context_ref: Option<String>,
+    /// Bounded operator-facing summary of the final repair-loop outcome.
+    pub outcome_summary: String,
+}
+
 /// First-class clarification request emitted for a weak handoff.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HandoffClarificationRequest {
@@ -239,10 +269,13 @@ pub struct TaskResultView {
     pub workflow_id: TaskId,
     /// Terminal workflow status.
     pub status: String,
-    /// Canonical result envelope exposed by the task surface.
-    pub result: UnifiedResultEnvelope,
     /// Task-facing outcome classification.
     pub proof_outcome: ProofOutcomeClassification,
+    /// Bounded verifier and repair provenance when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestration_quality: Option<OrchestrationQualityView>,
+    /// Canonical result envelope exposed by the task surface.
+    pub result: UnifiedResultEnvelope,
 }
 
 /// Shared provenance summary reused by session and operator result projections.
@@ -290,6 +323,9 @@ pub struct OperatorResultPreview {
     pub preview_text: Option<String>,
     /// Where the full result comes from, for example `task.result`.
     pub payload_location: String,
+    /// Bounded verifier and repair provenance when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestration_quality: Option<OrchestrationQualityView>,
     /// Compact explanation of how the result was produced and classified.
     pub provenance_lines: Vec<String>,
 }
@@ -610,5 +646,23 @@ mod tests {
         let json = serde_json::to_string(&record).unwrap();
         let deserialized: StepEvaluationRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, record);
+    }
+
+    #[test]
+    fn orchestration_quality_view_serde_roundtrip() {
+        let summary = OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Accepted,
+            repair_action: Some(RepairDirectiveAction::ClarifyHandoff),
+            clarification_attempt_count: 1,
+            checkpoint_ref: Some("checkpoint-clarify".to_string()),
+            last_stable_step_id: Some("collect-evidence".to_string()),
+            failure_context_ref: Some("draft-outline/clarify".to_string()),
+            outcome_summary: "accepted_after_clarify_handoff".to_string(),
+        };
+
+        let json = serde_json::to_string(&summary).unwrap();
+        let deserialized: OrchestrationQualityView = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, summary);
     }
 }

--- a/crates/mister-smith-core/src/lib.rs
+++ b/crates/mister-smith-core/src/lib.rs
@@ -21,10 +21,10 @@ pub use autonomy::{
     AuthorityPrincipal, CapabilityActionKind, ContextBudget, DelegatedAction,
     DelegatedActionPolicy, DelegationCapability, ExternalDelegationEnvelope, GuardDecision,
     GuardEvidence, GuardTarget, HandoffClarificationRequest, InterventionRecord, MetricWindow,
-    OperatorResultPreview, ProfileSnapshot, ProofOutcomeClassification, ProvenanceChain,
-    ProvenanceLink, ResultProvenanceSummary, SemanticSignal, SessionRetainedResultView,
-    StepEvaluationRecord, TaskResultView, TaskShapeClassification, TaskShapeKind,
-    TeamSizingDecision, TopologyPlan, TopologyRationale, UnifiedResultEnvelope,
+    OperatorResultPreview, OrchestrationQualityView, ProfileSnapshot, ProofOutcomeClassification,
+    ProvenanceChain, ProvenanceLink, ResultProvenanceSummary, SemanticSignal,
+    SessionRetainedResultView, StepEvaluationRecord, TaskResultView, TaskShapeClassification,
+    TaskShapeKind, TeamSizingDecision, TopologyPlan, TopologyRationale, UnifiedResultEnvelope,
 };
 
 // Core enums

--- a/crates/mister-smith-core/tests/trait_compilation_tests.rs
+++ b/crates/mister-smith-core/tests/trait_compilation_tests.rs
@@ -469,8 +469,9 @@ fn autonomy_ids_enums_and_errors_are_available() {
     let task_result = TaskResultView {
         workflow_id,
         status: "completed".to_string(),
-        result: canonical_result.clone(),
         proof_outcome: canonical_result.proof_outcome,
+        orchestration_quality: None,
+        result: canonical_result.clone(),
     };
     let session_result = SessionRetainedResultView {
         workflow_id,
@@ -488,6 +489,7 @@ fn autonomy_ids_enums_and_errors_are_available() {
         proof_outcome: canonical_result.proof_outcome,
         preview_text: Some("bounded answer preview".to_string()),
         payload_location: "task.result".to_string(),
+        orchestration_quality: None,
         provenance_lines: vec![
             "canonical result stored in metadata.final_result".to_string(),
             "aggregated payload nested under metadata.aggregated_result".to_string(),

--- a/crates/mister-smith-events/src/autonomy.rs
+++ b/crates/mister-smith-events/src/autonomy.rs
@@ -559,6 +559,7 @@ pub fn infer_result_preview_from_projection(
         proof_outcome,
         preview_text,
         payload_location: "task.result".to_string(),
+        orchestration_quality: None,
         provenance_lines,
     })
 }
@@ -575,6 +576,9 @@ pub fn merge_operator_result_preview(
     }
     if merged.payload_location.is_empty() {
         merged.payload_location = fallback.payload_location.clone();
+    }
+    if merged.orchestration_quality.is_none() {
+        merged.orchestration_quality = fallback.orchestration_quality.clone();
     }
     for line in &fallback.provenance_lines {
         if !merged.provenance_lines.contains(line) {

--- a/crates/mister-smith-events/tests/autonomy_event_tests.rs
+++ b/crates/mister-smith-events/tests/autonomy_event_tests.rs
@@ -3,11 +3,14 @@ use mister_smith_core::{
     CapabilityId, CheckpointId, ContextBudgetId, CoordinationPolicy, DelegationScope,
     ExecutionBranchId, ExecutionGraphId, FailureClass, GraphState, GuardDecision, GuardDecisionId,
     GuardEvidence, HealthState, InterventionRecordId, InterventionType, OperatorResultPreview,
-    ProfileSnapshot, ProfileSnapshotId, ProfileTarget, ProofOutcomeClassification, ProvenanceChain,
-    ProvenanceLink, ResultProvenanceSummary, RevocationState, TaskId, TaskShapeClassification,
-    TaskShapeKind, TeamSizingDecision, TopologyKind, TopologyRationale,
+    OrchestrationQualityView, ProfileSnapshot, ProfileSnapshotId, ProfileTarget,
+    ProofOutcomeClassification, ProvenanceChain, ProvenanceLink, RepairDirectiveAction,
+    ResultProvenanceSummary, RevocationState, TaskId, TaskShapeClassification, TaskShapeKind,
+    TeamSizingDecision, TopologyKind, TopologyRationale, VerifierVerdict,
 };
-use mister_smith_events::autonomy::infer_proof_outcome_from_projection;
+use mister_smith_events::autonomy::{
+    infer_proof_outcome_from_projection, merge_operator_result_preview,
+};
 use mister_smith_events::{
     AutonomyEvent, AutonomyEventEnvelope, AutonomyEventType, AutonomyStatusView, BranchSummary,
     CapabilitySummary, CheckpointRecordSummary, ContextPressureSummary, DelegationAlert, EventBus,
@@ -168,12 +171,56 @@ fn sample_result_preview(
         proof_outcome,
         preview_text: Some("bounded answer preview".to_string()),
         payload_location: "task.result".to_string(),
+        orchestration_quality: None,
         provenance_lines: vec![
             "canonical result stored in metadata.final_result".to_string(),
             "aggregated payload nested under metadata.aggregated_result".to_string(),
             "session assistant_result derives from the canonical result object".to_string(),
         ],
     }
+}
+
+#[test]
+fn merge_operator_result_preview_preserves_orchestration_quality_from_fallback() {
+    let workflow_id = TaskId::new();
+    let preferred = OperatorResultPreview {
+        workflow_id,
+        proof_outcome: ProofOutcomeClassification::GraphFormedAndCompleted,
+        preview_text: Some("preferred preview".to_string()),
+        payload_location: "task.result".to_string(),
+        orchestration_quality: None,
+        provenance_lines: vec!["preferred provenance".to_string()],
+    };
+    let fallback = OperatorResultPreview {
+        workflow_id,
+        proof_outcome: ProofOutcomeClassification::GraphFormedAndCompleted,
+        preview_text: Some("fallback preview".to_string()),
+        payload_location: "task.result".to_string(),
+        orchestration_quality: Some(OrchestrationQualityView {
+            step_id: "draft-outline".to_string(),
+            verdict: VerifierVerdict::Accepted,
+            repair_action: Some(RepairDirectiveAction::ClarifyHandoff),
+            clarification_attempt_count: 2,
+            checkpoint_ref: Some("checkpoint-clarify".to_string()),
+            last_stable_step_id: Some("collect-evidence".to_string()),
+            failure_context_ref: Some("draft-outline/clarify".to_string()),
+            outcome_summary: "accepted_after_clarify_handoff".to_string(),
+        }),
+        provenance_lines: vec!["fallback provenance".to_string()],
+    };
+
+    let merged = merge_operator_result_preview(&preferred, &fallback);
+
+    assert_eq!(
+        merged.orchestration_quality,
+        fallback.orchestration_quality.clone()
+    );
+    assert!(merged
+        .provenance_lines
+        .contains(&"preferred provenance".to_string()));
+    assert!(merged
+        .provenance_lines
+        .contains(&"fallback provenance".to_string()));
 }
 
 fn sample_graph_summary(
@@ -1059,6 +1106,7 @@ async fn event_bus_aggregates_the_frozen_proof_outcome_matrix() {
             proof_outcome: ProofOutcomeClassification::GraphFormedAndCompleted,
             preview_text: Some("workflow completed with 2 branch(es) across 4 node(s)".to_string()),
             payload_location: "task.result".to_string(),
+            orchestration_quality: None,
             provenance_lines: vec![
                 "graph formed and completed before final result publication".to_string(),
                 format!(


### PR DESCRIPTION
## Summary
- add a shared orchestration-quality summary to task and operator result views
- derive verifier verdict, repair action, and stable checkpoint lineage from persisted step evaluations
- extend autonomy and event coverage for repair selection, checkpoint lineage, and preview merge fallback

## Validation
- cargo test -p mister-smith-app
- cargo clippy -p mister-smith-app -- -D warnings
- cargo test -p mister-smith-core
- cargo clippy -p mister-smith-core -- -D warnings
- cargo test -p mister-smith-events
- cargo clippy -p mister-smith-events -- -D warnings
- cargo build --workspace
- git diff --check
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task results and previews now include detailed orchestration quality information, including verifier verdicts, applied repair actions, clarification attempt counts, checkpoint references, last stable step identifiers, and failure context metadata.

* **Tests**
  * Added comprehensive test coverage for orchestration quality computation across repair and clarification workflows, result preview rendering, and preview merging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->