### PR TITLE
docs(prompt-improver): add MS-103 live evaluation handoff

### DIFF
--- a/docs/prompt-improver-spec/final-prompts/mister-smith-ms-103-packet-020-live-evaluation-handoff.md
+++ b/docs/prompt-improver-spec/final-prompts/mister-smith-ms-103-packet-020-live-evaluation-handoff.md
@@ -1,0 +1,239 @@
+# Mister Smith MS-103 Packet-020 Live Evaluation Handoff
+
+You are Codex in a fresh session working in:
+
+- <repo_root>`/Users/macmain/MisterSmith`</repo_root>
+
+Your mission in this session is to perform bounded **live runtime evaluations** for the completed
+packet-020 parent issue:
+
+- <linear_issue>`MS-103`</linear_issue>
+- Title: `Packet 020: Verifier-gated adaptive orchestration`
+- Current known state at handoff:
+  - parent issue `MS-103` is `Done`
+  - child slices `MS-104` through `MS-107` are landed and `Done`
+  - packet `020` is landed on `main`
+  - local repo is clean synced `main` at
+    <starting_main_sha>`e360323b85183e83351d118f3d24e376d9f22a8b`</starting_main_sha>
+  - no newer post-packet-020 bounded phase is frozen yet
+- Packet source:
+  <packet_source>`/Users/macmain/MisterSmith/specs/020-verifier-gated-adaptive-orchestration/`</packet_source>
+- Suggested evidence note:
+  <evidence_note_path>`/Users/macmain/MisterSmith/docs/plans/2026-03-27-packet-020-live-evaluation.md`</evidence_note_path>
+- Suggested artifact root:
+  <artifact_root>`/Users/macmain/MisterSmith/docs/plans/artifacts/packet-020-live-evaluation/`</artifact_root>
+- Base URL when using HTTP surfaces:
+  <base_url>`http://127.0.0.1:8080`</base_url>
+
+If the session date differs from the handoff date, keep the artifact slug but update the date
+prefix in `<evidence_note_path>` and `<artifact_root>` to match the actual evaluation date.
+
+Before running anything, read:
+
+1. `/Users/macmain/MisterSmith/AGENTS.md`
+2. `/Users/macmain/MisterSmith/WORKFLOW.md`
+3. `/Users/macmain/MisterSmith/docs/linear/LINEAR.md`
+4. `/Users/macmain/MisterSmith/docs/current-state.md`
+5. `/Users/macmain/MisterSmith/docs/ms_recent_context.md`
+6. `/Users/macmain/MisterSmith/docs/plans/2026-03-26-verifier-gated-adaptive-orchestration.md`
+7. `/Users/macmain/MisterSmith/docs/plans/2026-03-26-packet-019-budget-aware-runtime-proof.md`
+8. `/Users/macmain/MisterSmith/docs/plans/2026-03-15-first-live-multi-agent-runtime-proof.md`
+9. `/Users/macmain/MisterSmith/specs/020-verifier-gated-adaptive-orchestration/spec.md`
+10. `/Users/macmain/MisterSmith/specs/020-verifier-gated-adaptive-orchestration/quickstart.md`
+11. `/Users/macmain/MisterSmith/specs/020-verifier-gated-adaptive-orchestration/tasks.md`
+
+Then ground on the live runtime and packet-020 surfaces before choosing an evaluation procedure:
+
+- `/Users/macmain/MisterSmith/crates/mister-smith-app/src/execution.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-app/src/autonomy.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-app/src/agent_inspection.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-core/src/autonomy.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-core/src/supervision.rs`
+- `/Users/macmain/MisterSmith/scripts/live_runtime_proof_smoke.py`
+
+Follow this control-plane posture:
+
+1. fetch the current issue/control-plane state for `MS-103`
+2. do **not** reopen `MS-103` or restage `MS-104` through `MS-107` just to run evaluation
+3. execute directly in `/Users/macmain/MisterSmith`
+4. do not create or use git worktrees
+5. do not create a new implementation lane unless a real defect is found and durable follow-up is
+   required later
+
+## Objective
+
+By the end of this session, you must:
+
+1. verify the current packet-020 runtime path from code and docs
+2. run at least one real live runtime-backed evaluation on the shipped baseline path
+3. attempt one bounded packet-020-focused probe run if the current path supports it
+4. capture durable evidence rather than terminal output only
+5. state clearly what packet `020` proves live, what remains deterministic-only, and what follow-up
+   gap exists if the live path does not expose the expected behavior
+
+## Core Constraints
+
+- do **real live runs**, not a mock-only or code-only audit
+- keep proof boundaries explicit: observed live evidence versus inference from code
+- do not use Linear or Symphony as the primary truth source for runtime behavior
+- do not change provider/model selection silently
+- do not mistake packet-019 baseline proof for packet-020 proof unless the transcript actually
+  shows verifier or repair behavior
+- do not widen into implementation, router changes, benchmark claims, or UI work
+- leave one durable evidence note in the repo at `<evidence_note_path>`
+
+## Evaluation-Only Boundary
+
+This session is for evaluation, not implementation.
+
+- do not patch code, change runtime semantics, or refresh packet docs just to make the run look
+  better
+- do not reopen `MS-103` or any child slice unless a real defect is found and a later follow-up
+  issue is genuinely needed
+- do not create a branch or PR unless you are explicitly asked to fix a discovered defect after the
+  evaluation
+
+## Live Evaluation Shape
+
+Use the narrowest honest live procedure supported by current `main`.
+
+At minimum, perform:
+
+1. **one baseline live run** that confirms the current shipped runtime path still works
+2. **one bounded packet-020 probe run** that can reveal verifier, clarification, retry, re-plan,
+   or orchestration-quality provenance behavior if the current path supports it
+
+You may use `scripts/live_runtime_proof_smoke.py` as the baseline entrypoint if it remains the
+narrowest honest live path, but do not treat it as packet-020 proof by itself. If the baseline run
+only re-proves the packet-019 path, you must either follow it with a packet-020-focused probe run
+or say explicitly that packet `020` remains unproven live.
+
+If the current code or runtime surfaces cannot honestly trigger packet-020 behavior without
+unsupported changes, stop and record that boundary clearly instead of forcing a false positive.
+
+## Run Selection Rule
+
+When choosing the live procedure:
+
+1. prefer an existing repo-native smoke harness, CLI path, or HTTP task surface over ad hoc
+   evaluation code
+2. prefer a task shape that produces real planner and executor behavior plus a plausible weak
+   handoff or local-repair opportunity
+3. use only current supported knobs, configs, and task wording; do not invent hidden flags or
+   synthetic control paths
+4. stop after the narrowest honest bounded probe rather than turning the session into an open-ended
+   search for a packet-020 event
+
+## Environment Verification
+
+Before running anything, verify and record:
+
+- current branch and worktree state
+- local infrastructure required by the chosen live path
+- NATS and JetStream availability
+- PostgreSQL availability
+- current provider auth surface
+- current runtime base URL if HTTP surfaces are used
+- whether the existing smoke harness or HTTP task path is the right entrypoint for packet-020
+  evaluation
+
+If any prerequisite is missing or broken, attempt bounded local recovery if it is reversible. Stop
+if the blocker prevents an honest live run.
+
+## Evidence Checklist
+
+You must capture and cite the following where available:
+
+- runtime startup command and environment assumptions
+- readiness proof
+- submitted task payload(s)
+- accepted task or workflow identifier(s)
+- task result payload(s)
+- autonomy list or autonomy status output
+- runtime log lines showing the actual execution path
+- current provider and model used by each run
+- routing policy and tier metadata when present
+- packet-020-specific provenance fields when present, including verifier verdict, repair action,
+  clarification count, checkpoint reference, last stable step, failure-context reference, and
+  outcome summary
+
+If a packet-020 field is absent, say whether that absence is expected, unexpected, or unclear from
+current code.
+
+## Evaluation Questions
+
+Your final evaluation must answer:
+
+1. Did the live run(s) use the current runtime path described by the code?
+2. What exact provider/model path did each run use?
+3. What did the baseline run prove?
+4. Did any run prove packet-020-specific live behavior?
+5. Which packet-020 fields or behaviors were directly observed, which were absent, and which were
+   only inferred from code?
+6. If packet-020 behavior did not appear, what prevented an honest proof?
+7. What parts of packet `020` remain deterministic-only on current evidence?
+8. Do the observed results match `docs/current-state.md` and the packet-020 closure note?
+9. What is the narrowest honest next step if a proof gap or regression remains?
+
+## Durable Artifact Requirement
+
+Write one durable evidence note to `<evidence_note_path>` and store supporting artifacts under
+`<artifact_root>`.
+
+That note must include:
+
+- objective
+- date and environment used
+- files read for grounding
+- commands run
+- task payloads and identifiers
+- logs and operator evidence captured
+- what packet `020` proved live
+- what packet `020` did not prove live
+- what remains deterministic-only
+- blockers, mismatches, and recommended next step
+
+## Do Not Claim
+
+Do not claim any of the following unless you directly proved them in this session:
+
+- a new benchmark gain or broader orchestration-quality claim
+- broader provider proof beyond the actual run(s)
+- packet-020 live proof if you only reproduced the packet-019 baseline
+- clarification, retry, or re-plan proof without a transcript that actually shows it
+- full production readiness
+
+## Anti-Patterns
+
+Avoid these failure modes:
+
+- turning a baseline-only run into a packet-020 success claim
+- reopening closed implementation work because a live probe was inconclusive
+- adding one-off instrumentation or code changes just to manufacture a verifier event
+- writing only a narrative summary without durable evidence files
+
+## Stop Conditions
+
+Stop and report clearly if:
+
+- required local infrastructure cannot be brought up
+- provider auth for the current shipped baseline is unavailable
+- the runtime never becomes ready
+- the chosen live path cannot submit a real runtime-backed task
+- packet-020 behavior cannot be honestly exercised without code changes or unsupported flags
+
+If you stop, leave a durable blocker note instead of a false success claim.
+
+## Final Response Requirements
+
+At the end of the session:
+
+- provide a concise summary
+- link to the durable evidence note
+- list the live runs attempted
+- state the exact provider/model used
+- state what packet `020` proved live
+- state which packet-020 fields and behaviors were observed, absent, or only inferred
+- state what remains deterministic-only or unproven
+- state blockers or concrete defects, if any
+- state the narrowest honest next step

--- a/docs/prompt-improver-spec/implementation_plan.md
+++ b/docs/prompt-improver-spec/implementation_plan.md
@@ -1,169 +1,210 @@
-# Implementation Plan — Mister Smith MS-106 Orchestration Provenance Handoff Prompt
+# Implementation Plan — Mister Smith MS-103 Packet-020 Live Evaluation Handoff Prompt
 
 ## Step 1: Example Identification
 
 ### Source Prompt (normalized from user request)
 
-Create a continuation prompt for the next Mister Smith task after `MS-105`, using the
-`prompt-improver` workflow so the next session receives a clear, bounded, repo-grounded briefing.
+Create a fresh-session handoff prompt for live runtime evaluations of completed packet `020`
+parent issue `MS-103`, using the prompt-improver workflow and current repo truth from `MS-103`
+through `MS-107`.
 
-### Normalized Example
+### External Examples
+
+#### Example 1
 
 ```text
 {
-  input: "Produce a prompt for the next task after the just-landed packet-020 slice.",
-  ideal_output: "A fresh-session handoff prompt that identifies the real next Linear issue, grounds
-  the agent on current repo and packet authority, preserves Smith-first workflow requirements, and
-  keeps the next implementation slice bounded to its actual acceptance criteria."
+  input: "Write a live-run evaluation handoff for Mister Smith.",
+  ideal_output: "A fresh-session prompt that grounds the receiving agent on current runtime docs,
+  verifies the actual live path from code, requires durable evidence capture, and distinguishes
+  live proof from code inference."
 }
 ```
 
-### What the example demonstrates
+Source: `docs/prompt-improver-spec/final-prompts/mister-smith-live-run-trace-evaluation.md`
 
-- the output should be a briefing for a new agent session, not execution of the next task
-- the prompt must identify the actual next issue from current repo and Linear state instead of
-  guessing from packet headings alone
-- the prompt should carry forward the repo's Smith-first control-plane discipline
-- the prompt must preserve bounded scope and clean-closure expectations
+#### Example 2
+
+```text
+{
+  input: "Write a bounded packet implementation handoff for a specific Linear slice.",
+  ideal_output: "A repo-grounded prompt with exact issue context, reading order, workflow rules,
+  bounded scope, validation expectations, and clean-closure requirements."
+}
+```
+
+Source:
+`docs/prompt-improver-spec/final-prompts/mister-smith-ms-106-orchestration-provenance-handoff.md`
+
+### What the examples demonstrate
+
+- the prompt should be a direct fresh-session briefing, not a reusable generic template
+- live evaluation prompts need explicit proof-boundary language and durable artifact requirements
+- issue-specific handoff prompts work best when they include current known state plus instructions
+  to verify mutable state before acting
+- the receiving agent should be told what to prove and what not to overclaim, without pre-solving
+  the evaluation outcomes
 
 ## Step 2: Planning Analysis
 
 ### Intent Summary
 
-**What**: Produce a fresh-session handoff prompt for the next packet-020 implementation slice.
+**What**: Produce a handoff prompt for a new Codex session to run live evaluations against the
+completed packet-020 runtime path after `MS-103` through `MS-107` closed on `main`.
 
-**Who**: A new Codex session operating in `/Users/macmain/MisterSmith`.
+**Who**: A fresh Codex session operating in `/Users/macmain/MisterSmith`.
 
-**Why**: `MS-105` is now landed, so the next session needs a concise but fully grounded prompt for
-`MS-106` without re-deriving the packet state from scratch.
+**Why**: The next session needs to validate what packet `020` actually proves live on the shipped
+runtime path, without reopening implementation work or overstating claims beyond observed
+evidence.
 
 ### Deployment Summary
 
 - **Target environment**: fresh Codex session in `/Users/macmain/MisterSmith`
-- **Primary task**: execute `MS-106` end to end
-- **Control-plane posture**: Smith-first, with current issue state checked before mutation
-- **Expected outcome**: a prompt that is immediately usable to start `MS-106` from clean synced
-  `main`
+- **Primary task**: run bounded live runtime evaluations for completed packet `020`
+- **Control-plane posture**: verify issue state, but execute locally and directly instead of using
+  Symphony or reopening the completed implementation lane
+- **Expected outcome**: one durable evaluation note plus supporting artifacts that separate
+  baseline live proof, packet-020-specific live evidence, and remaining deterministic-only claims
 
 ### Task Flowchart
 
 ```mermaid
 graph TD
-    A["Start fresh Codex session"] --> B["Read repo authority docs and packet 020 files"]
-    B --> C["Fetch current MS-106 control-plane state"]
-    C --> D["Stage issue into watched queue if still in validated backlog"]
-    D --> E["Move issue to In Progress and reconcile single workpad comment"]
-    E --> F["Implement bounded provenance surfaces for task and autonomy views"]
-    F --> G["Run honest app-focused validation and doc checks"]
-    G --> H["Push, review, merge, and return repo to clean synced main"]
-    H --> I["Update Linear/workpad and report closure"]
+    A["Start fresh Codex session"] --> B["Read repo authority docs and packet 020 closure notes"]
+    B --> C["Fetch current MS-103 control-plane state"]
+    C --> D["Ground on current runtime and packet-020 code surfaces"]
+    D --> E["Verify local infra, auth, and live entrypoint readiness"]
+    E --> F["Run one baseline live runtime evaluation"]
+    F --> G["Run one bounded packet-020 probe evaluation if the path supports it"]
+    G --> H["Inspect task and autonomy outputs plus runtime logs"]
+    H --> I["Write durable evaluation note and artifact index"]
+    I --> J["Report what packet 020 proved live versus what remains deterministic-only"]
 ```
 
-### Lessons from Current Repo State
+### Lessons from Examples and Current Repo Truth
 
-- the next bounded packet-020 slice is `MS-106`, not a generic packet heading
-- `MS-106` is currently `Backlog` in `MisterSmith Validated Backlog`, so the prompt should tell
-  the next session to verify and, if still necessary, stage it into `MisterSmith Execution Queue`
-- the issue is blocked by `MS-105`, but that blocker is now landed and `MS-105` is `Done`
-- the runtime/core contract work for verifier verdicts, clarification, and failure-context
-  checkpoint lineage is already present from `MS-104` and `MS-105`
-- the next slice is about projecting that provenance on task/autonomy inspection surfaces and
-  keeping deterministic versus live-proof boundaries explicit
+- `MS-103` is already `Done`, so the handoff should not tell the receiving agent to reopen or
+  restage the packet just to run evaluation
+- packet `020` closure is documented in
+  `docs/plans/2026-03-26-verifier-gated-adaptive-orchestration.md`, and its quickstart already
+  defines the live-proof boundary as one bounded runtime transcript
+- packet `019` already has a bounded repeatable live proof on the current shipped baseline, so the
+  new prompt should reuse that baseline as grounding without confusing packet-019 proof with
+  packet-020 proof
+- the receiving agent needs a two-part evaluation posture:
+  - confirm the current baseline live runtime path still works
+  - attempt a bounded packet-020-specific transcript that honestly shows verifier or repair
+    behavior, or record that the current path could not trigger it
+- the prompt must be explicit that the goal is evaluation, not implementation, router changes, or
+  benchmark claims
 
 ### Chain-of-Thought Approach
 
-Yes. The prompt should tell the next session to:
+Yes. The prompt should require the receiving agent to:
 
-1. ground on current repo and issue truth
-2. refresh the issue/control-plane state before mutating it
-3. implement only the bounded provenance projection slice
-4. validate the affected behavior honestly
-5. finish the git/PR/Linear closure lane
+1. verify current repo and issue truth
+2. inspect code and existing proof harnesses before choosing the live procedure
+3. run the narrowest honest live evaluation(s)
+4. compare observed evidence with packet-020 claims
+5. record proof boundaries and follow-up gaps explicitly
 
 ### Output Format
 
 Markdown.
 
-The prompt should give:
+The handoff prompt should provide:
 
-- the mission and exact issue identifier
+- the mission and current known packet state
 - the file-reading order
-- the bounded scope and non-goals
-- validation requirements
-- closure requirements
-- a short final-response format
+- current control-plane rules for a completed parent issue
+- live evaluation goals and boundaries
+- required evidence and durable artifact locations
+- stop conditions and final-response requirements
 
 ### Variable Plan
 
 | Variable | XML Tag | Description |
 | -------- | ------- | ----------- |
 | Repo root | `<repo_root>` | Absolute path to the Mister Smith repo |
-| Next issue | `<linear_issue>` | The next Linear issue to execute |
+| Parent issue | `<linear_issue>` | Completed parent packet issue to evaluate |
 | Packet source | `<packet_source>` | Packet 020 spec directory |
-| Suggested branch | `<branch_name>` | Linear-provided branch name for the next slice |
-| Merge base | `<starting_main_sha>` | Current clean synced `main` commit at handoff |
+| Current main SHA | `<starting_main_sha>` | Current clean synced `main` commit at handoff |
+| Base URL | `<base_url>` | Runtime base URL when HTTP surfaces are used |
+| Artifact root | `<artifact_root>` | Directory for collected evaluation artifacts |
+| Evidence note path | `<evidence_note_path>` | Durable markdown note for the evaluation summary |
 
 ### Structural Notes
 
-- preserve the user's preferred direct task-handoff format rather than turning the prompt into a
-  generic reusable template
-- include current known repo state, but instruct the receiving agent to verify it before acting
-- keep the prompt specific enough to start `MS-106` immediately without pre-solving the actual code
-  changes
-- include Smith-first lifecycle steps because the next issue starts in backlog rather than already
-  in progress
+- keep the prompt direct and issue-specific rather than turning it into a generic evaluation
+  template
+- front-load the fact that packet `020` is already landed and completed
+- preserve the repo's "clarify, do not overclaim" proof-boundary posture
+- instruct the receiving agent to prefer existing live harnesses and runtime surfaces over ad hoc
+  one-off evaluation code
+- explicitly forbid reopening `MS-103` or child issues unless evaluation reveals a real defect
 
 ### Ambiguities & Questions
 
-None that block prompt creation. The next task is concretely identified as `MS-106`, and the
-prompt can instruct the next session to verify any mutable state before acting.
+None that block prompt creation.
+
+The prompt can instruct the receiving agent to choose the narrowest honest live method from current
+repo surfaces and to stop if packet-020 behavior cannot be triggered without unsupported changes.
 
 ### Prompt Filename
 
-`mister-smith-ms-106-orchestration-provenance-handoff`
+`mister-smith-ms-103-packet-020-live-evaluation-handoff`
 
 ### Constraint Preservation Checklist
 
-- [x] The output remains a prompt, not execution of the next issue
-- [x] Smith-first workflow expectations are preserved
-- [x] Bounded packet-020 scope is preserved
-- [x] Clean-closure expectations are preserved
-- [x] Deterministic versus live-proof boundaries remain explicit
+- [x] The output remains a handoff prompt, not execution of the evaluation
+- [x] Live proof versus deterministic proof boundaries remain explicit
+- [x] The prompt does not reopen closed implementation scope
+- [x] The prompt stays grounded in current packet-020 repo truth
+- [x] The prompt requires durable evidence instead of terminal-only narration
 
 ## Step 4: Critique & Revision Plan
 
 ### Issues Identified
 
-1. **"continue with the next task"** → Problem: on its own, this is ambiguous because packet task
-   headings and actual Linear issues can diverge → Revision: explicitly identify `MS-106` as the
-   next real issue and tell the receiving agent to verify current state before acting.
-2. **A handoff prompt can drift into implementing the issue.** → Problem: too much detail would
-   start doing the next session's work → Revision: keep the prompt focused on mission, scope,
-   reading order, validation, and closure, not a step-by-step patch design.
-3. **Backlog-to-queue lifecycle is easy to miss.** → Problem: the next issue is still in
-   validated backlog, so a generic prompt could skip Smith-first staging → Revision: include
-   explicit control-plane staging instructions with verification-first language.
-4. **The prompt could blur deterministic and live-proof expectations.** → Problem: `MS-106`
-   touches docs and operator-facing provenance, so the next session could overclaim runtime proof
-   → Revision: add a hard boundary that docs must keep deterministic versus live-proof language
-   explicit.
+1. **"attempt one bounded packet-020-focused probe run if the current path supports it"** →
+   Problem: this is directionally correct but still too open-ended about how to choose that run →
+   Revision: add a run-selection rule that prefers existing harnesses and current runtime surfaces,
+   then stops after one honest bounded probe instead of turning into an exploration program.
+2. **"Suggested evidence note: `<evidence_note_path>`...2026-03-27..."** → Problem: the fixed
+   date is useful as a handoff default but could be mistaken for a hard requirement in a later
+   session → Revision: tell the receiving agent to keep the slug but update the date prefix if the
+   session date differs.
+3. **The draft lacked an explicit evaluation-only anti-pattern section.** → Problem: a capable
+   receiving agent might still widen into implementation or issue reopening once a defect appears →
+   Revision: add an anti-patterns section that forbids reopening completed work, patching code, or
+   turning evaluation into a new development lane unless explicitly asked later.
+4. **"You may use `scripts/live_runtime_proof_smoke.py` as the baseline entrypoint..."** →
+   Problem: the draft did not explicitly say to follow a baseline-only result with either a
+   packet-020 probe or a clear statement that packet-020 remains unproven live → Revision: make
+   that proof-boundary rule explicit.
+5. **The final response requirements were still slightly summary-heavy.** → Problem: the receiving
+   agent could summarize the run without naming the actual packet-020 fields observed or missing →
+   Revision: require an explicit statement of which packet-020 fields and behaviors were observed,
+   absent, or only inferred.
 
 ### Areas Needing Expansion
 
-- exact next-issue identification and current known status
-- the dependency on `MS-105`-landed provenance fields
-- closure requirements so the new session does not stop at PR open
+- explicit run-selection guidance for the packet-020 probe
+- explicit anti-patterns for evaluation-only work
+- artifact path guidance when the receiving session date differs from the handoff date
+- stronger final reporting requirements around packet-020-specific observed fields
 
 ### Structural Improvements
 
-- front-load current known state and verification instructions
-- separate scope from non-goals clearly
-- include a dedicated Smith-first workflow section
-- include a final-response shape that matches the repo's recent delivery style
+- add a dedicated **Evaluation-Only Boundary** section
+- add a dedicated **Run Selection Rule** section after the live evaluation shape
+- add a short **Anti-Patterns** section near the stop conditions
+- tighten the final response requirements around observed packet-020 evidence
 
 ### Constraint Preservation Check
 
-- [x] The handoff remains a prompt, not partial implementation
-- [x] All bounded-scope constraints are preserved
-- [x] The repo's lifecycle/closure discipline is preserved
-- [x] The prompt stays specific to `MS-106` instead of becoming generic
+- [x] All core "do not overclaim" boundaries are preserved
+- [x] The prompt still avoids doing the receiving agent's job
+- [x] The prompt remains specific to `MS-103` packet-020 evaluation
+- [x] The prompt stays evaluation-focused rather than implementation-focused

--- a/docs/prompt-improver-spec/task.md
+++ b/docs/prompt-improver-spec/task.md
@@ -1,16 +1,13 @@
-# Task Checklist — Mister Smith MS-106 Orchestration Provenance Handoff Prompt
+# Task Checklist — Mister Smith MS-103 Packet-020 Live Evaluation Handoff Prompt
 
 ## Steps 1-3: Planning and Initial Draft
 
-- [x] Step 1: normalized the user request into a concrete next-task handoff objective
-- [x] Step 2: identified `MS-106` as the real next packet-020 issue and documented repo,
-  control-plane, scope, and validation constraints
-- [x] Step 3: drafted a fresh-session handoff prompt for executing `MS-106`
+- [x] Step 1: normalized the user request into a packet-020 live-evaluation handoff objective
+- [x] Step 2: identified current repo, issue, proof-boundary, and artifact requirements
+- [x] Step 3: drafted a fresh-session handoff prompt for evaluating completed packet `020`
 
 ## Steps 4-6: Critique and Finalization
 
-- [x] Step 4: critiqued the draft for ambiguity, scope drift, and lifecycle omissions
-- [x] Step 5: strengthened the prompt with explicit Smith-first staging, bounded provenance scope,
-  and closure requirements
-- [x] Step 6: finalized the prompt and saved it to
-  `docs/prompt-improver-spec/final-prompts/mister-smith-ms-106-orchestration-provenance-handoff.md`
+- [x] Step 4: critiqued the draft for ambiguity, over-prescription, and proof-boundary gaps
+- [x] Step 5: strengthened the prompt with clearer evaluation structure and artifact expectations
+- [x] Step 6: finalized the prompt, created the walkthrough, and removed the draft file

--- a/docs/prompt-improver-spec/walkthrough.md
+++ b/docs/prompt-improver-spec/walkthrough.md
@@ -1,50 +1,54 @@
-# Walkthrough — Mister Smith MS-106 Orchestration Provenance Handoff Prompt
+# Walkthrough — Mister Smith MS-103 Packet-020 Live Evaluation Handoff Prompt
 
 ## Original Prompt Summary
 
-Produce a prompt to continue with the next task after the just-landed packet-020 slice, using the
-`prompt-improver` workflow.
+The source request asked for a handoff prompt, written through the prompt-improver workflow, for a
+new session to perform live evaluations of the completed packet-020 parent issue `MS-103` after
+the closure of `MS-103` through `MS-107`.
 
 ## Key Improvements Made
 
-- identified the real next task as `MS-106` instead of assuming the next packet heading alone was
-  sufficient
-- grounded the prompt on current repo, packet, and Linear issue truth
-- preserved Smith-first staging requirements because `MS-106` is still in backlog
-- kept the prompt bounded to provenance projection and inspection surfaces rather than solving the
-  implementation itself
-- made validation and clean-closure expectations explicit
+- converted the high-level ask into a repo-grounded fresh-session handoff prompt tied to current
+  packet-020 closure truth
+- combined the strongest parts of the existing live-run evaluation prompt and the issue-specific
+  implementation handoff prompt
+- made the live-proof boundary explicit:
+  - baseline live proof is not automatically packet-020 proof
+  - packet-020 claims must come from the actual transcript and operator surfaces
+- added an evaluation-only boundary so the receiving agent does not reopen closed work or patch
+  code just to force a result
+- added a run-selection rule so the receiving agent chooses the narrowest honest live method
+  without turning the session into an open-ended exploration exercise
+- added explicit durable artifact expectations and final reporting requirements for observed versus
+  inferred packet-020 fields
 
 ## Before / After Comparison
 
-### Before
+### Scope framing
 
-- generic request for a continuation prompt
-- no explicit next issue id
-- no control-plane staging instructions
-- no explicit scope guardrails or validation requirements
+- Before: "write a handoff prompt for evaluations"
+- After: a prompt that names the exact parent issue, current closure state, read order, current
+  code surfaces, and proof boundaries
 
-### After
+### Live-proof boundary
 
-- concrete fresh-session prompt for `MS-106`
-- direct reading order through repo authority and packet-020 docs
-- Smith-first issue staging and workpad reconciliation instructions
-- bounded scope, non-goals, validation, and closure sections
+- Before: implied live evaluations, but no explicit separation between packet-019 baseline proof
+  and packet-020 proof
+- After: the prompt explicitly forbids treating a baseline-only run as packet-020 proof
+
+### Session boundary
+
+- Before: no explicit guard against reopening completed work or slipping into implementation
+- After: the prompt states that the session is evaluation-only and forbids reopening or patching
+  unless a later follow-up is explicitly requested
 
 ## How To Use The Improved Prompt
 
-Start a new Codex session in `/Users/macmain/MisterSmith` and give it the final prompt from:
-
-`docs/prompt-improver-spec/final-prompts/mister-smith-ms-106-orchestration-provenance-handoff.md`
-
-The receiving session should then:
-
-1. verify current repo and issue state
-2. stage `MS-106` into the watched queue if needed
-3. execute the bounded provenance-projection slice
-4. validate honestly
-5. finish the full git/PR/Linear closure lane
+1. Start a fresh Codex session in `/Users/macmain/MisterSmith`.
+2. Paste the final prompt from the file below.
+3. Let the receiving agent ground on current repo truth, run the live evaluations, and write the
+   durable evaluation note plus artifacts.
 
 ## Final Prompt Location
 
-`docs/prompt-improver-spec/final-prompts/mister-smith-ms-106-orchestration-provenance-handoff.md`
+- `docs/prompt-improver-spec/final-prompts/mister-smith-ms-103-packet-020-live-evaluation-handoff.md`


### PR DESCRIPTION
## Summary
- add a prompt-improver artifact bundle for a new MS-103 packet-020 live-evaluation handoff
- create a final fresh-session prompt focused on bounded live runs, durable evidence capture, and explicit proof boundaries
- keep the handoff evaluation-only so the receiving agent does not reopen packet-020 implementation work

## Validation
- npx markdownlint-cli2 docs/prompt-improver-spec/implementation_plan.md docs/prompt-improver-spec/task.md docs/prompt-improver-spec/walkthrough.md docs/prompt-improver-spec/final-prompts/mister-smith-ms-103-packet-020-live-evaluation-handoff.md --config .markdownlint.json
- git diff --check
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new session specification document for live evaluation procedures with detailed environment requirements, evidence checklists, and evaluation constraints.
  * Updated implementation and task planning documentation to refocus on bounded live evaluation work with clarified proof boundaries and artifact management.
  * Refined walkthrough guidance with updated control flow, evaluation-only constraints, and reporting requirements for evaluation artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->