### PR TITLE
feat(supervision): add bounded profile fingerprints

### DIFF
--- a/crates/mister-smith-agents/src/guard.rs
+++ b/crates/mister-smith-agents/src/guard.rs
@@ -2,7 +2,8 @@
 
 use mister_smith_core::{
     FailureClass, GuardDecision, GuardDecisionId, GuardError, GuardEvidence, GuardTarget,
-    HealthState, InterventionType, SupervisionDecisionBasis,
+    HealthState, InterventionType, ProfileFingerprint, SemanticSignalKind,
+    SupervisionDecisionBasis,
 };
 
 use crate::execution_graph::BranchCheckpoint;
@@ -197,6 +198,17 @@ impl Guard {
                 "no supervisory evidence available for a non-trivial intervention".to_string(),
             ));
         };
+        let decision_basis = assessment
+            .and_then(ProfileAssessment::fingerprint)
+            .filter(|fingerprint| fingerprint_reinforces(profile, intervention, fingerprint))
+            .map(|fingerprint| {
+                evidence_notes.push(format!(
+                    "fingerprint reinforced live signal classification via {}",
+                    fingerprint.target_selector
+                ));
+                SupervisionDecisionBasis::FingerprintReinforced
+            })
+            .unwrap_or(SupervisionDecisionBasis::LiveSignalsOnly);
 
         Ok(GuardDecision {
             decision_id: GuardDecisionId::new(),
@@ -204,7 +216,7 @@ impl Guard {
             intervention,
             evidence: GuardEvidence {
                 profile_id: Some(profile.profile_id),
-                decision_basis: SupervisionDecisionBasis::LiveSignalsOnly,
+                decision_basis,
                 signal_descriptions,
                 checkpoint_ids: context
                     .checkpoints
@@ -216,5 +228,35 @@ impl Guard {
             target_scope: context.target.clone(),
             operator_visibility: true,
         })
+    }
+}
+
+fn fingerprint_reinforces(
+    profile: &mister_smith_core::ProfileSnapshot,
+    intervention: InterventionType,
+    fingerprint: &ProfileFingerprint,
+) -> bool {
+    let prefers_intervention = fingerprint.preferred_interventions.contains(&intervention);
+    let live_modes = profile
+        .semantic_signals
+        .iter()
+        .map(|signal| failure_mode_label(signal.signal_kind))
+        .collect::<Vec<_>>();
+    let matches_failure_mode = live_modes.iter().any(|mode| {
+        fingerprint
+            .dominant_failure_modes
+            .iter()
+            .any(|candidate| candidate == mode)
+    });
+    prefers_intervention || matches_failure_mode
+}
+
+fn failure_mode_label(signal_kind: SemanticSignalKind) -> &'static str {
+    match signal_kind {
+        SemanticSignalKind::Stalled => "stalled",
+        SemanticSignalKind::Repetitive => "repetitive",
+        SemanticSignalKind::LowConfidence => "low_confidence",
+        SemanticSignalKind::MissingContext => "missing_context",
+        SemanticSignalKind::PolicyConflict => "policy_conflict",
     }
 }

--- a/crates/mister-smith-agents/src/profile.rs
+++ b/crates/mister-smith-agents/src/profile.rs
@@ -2,10 +2,11 @@
 
 use chrono::Utc;
 use mister_smith_core::ExecutionBranchId;
-use mister_smith_core::ProfileSnapshot;
 use mister_smith_core::{
-    GuardTarget, HealthState, ProfileSnapshotId, ProfileTarget, SemanticSignal,
+    GuardTarget, HealthState, ProfileFingerprint, ProfileSnapshot, ProfileSnapshotId,
+    ProfileTarget, SemanticSignal,
 };
+use mister_smith_persistence::ProfileFingerprintStore;
 
 use crate::execution_graph::ExecutionGraph;
 
@@ -13,6 +14,7 @@ use crate::execution_graph::ExecutionGraph;
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProfileAssessment {
     snapshot: Option<ProfileSnapshot>,
+    fingerprint: Option<ProfileFingerprint>,
     target: Option<GuardTarget>,
     notes: Vec<String>,
 }
@@ -22,6 +24,7 @@ impl ProfileAssessment {
     pub fn new(snapshot: Option<ProfileSnapshot>, notes: Vec<String>) -> Self {
         Self {
             snapshot,
+            fingerprint: None,
             target: None,
             notes,
         }
@@ -35,6 +38,11 @@ impl ProfileAssessment {
     /// Borrow the runtime target associated with this profile, when known.
     pub fn target(&self) -> Option<&GuardTarget> {
         self.target.as_ref()
+    }
+
+    /// Borrow the advisory fingerprint that reinforced this assessment, when any.
+    pub fn fingerprint(&self) -> Option<&ProfileFingerprint> {
+        self.fingerprint.as_ref()
     }
 
     /// Resolve the owning branch for the current target when graph context exists.
@@ -58,6 +66,15 @@ impl ProfileAssessment {
     /// Attach a concrete runtime target to this assessment.
     pub fn with_target(mut self, target: GuardTarget) -> Self {
         self.target = Some(target);
+        self
+    }
+
+    /// Attach a current advisory fingerprint to this assessment.
+    pub fn with_fingerprint(mut self, fingerprint: ProfileFingerprint) -> Self {
+        if let Some(snapshot) = self.snapshot.as_mut() {
+            snapshot.fingerprint_ref = Some(ProfileFingerprintStore::reference(&fingerprint));
+        }
+        self.fingerprint = Some(fingerprint);
         self
     }
 

--- a/crates/mister-smith-agents/tests/guard_tests.rs
+++ b/crates/mister-smith-agents/tests/guard_tests.rs
@@ -10,8 +10,8 @@ use mister_smith_agents::{
 };
 use mister_smith_core::{
     BranchState, ExecutionBranchId, ExecutionNodeId, FailureClass, GraphState, GuardTarget,
-    HealthState, InterventionType, SemanticSignal, SemanticSignalKind, SupervisionDecisionBasis,
-    TaskId,
+    HealthState, InterventionType, ProfileFingerprint, ProfileFingerprintId, ProfileTarget,
+    SemanticSignal, SemanticSignalKind, SupervisionDecisionBasis, TaskId,
 };
 use serde_json::json;
 
@@ -77,13 +77,38 @@ fn semantic_profile_context(branch_id: ExecutionBranchId) -> GuardContext {
     GuardContext::new(GuardTarget::Branch(branch_id)).with_profile(assessment)
 }
 
+fn profile_fingerprint(
+    branch_id: ExecutionBranchId,
+    dominant_failure_modes: Vec<&str>,
+    preferred_interventions: Vec<InterventionType>,
+) -> ProfileFingerprint {
+    ProfileFingerprint {
+        fingerprint_id: ProfileFingerprintId::new(),
+        target_kind: "branch".to_string(),
+        target_selector: branch_id.to_string(),
+        source_refs: vec!["workflow:test".to_string()],
+        summary_payload: json!({
+            "health_state": "degraded",
+            "signal_count": 1,
+        }),
+        dominant_failure_modes: dominant_failure_modes
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        preferred_interventions,
+        confidence: 0.84,
+        updated_at: Utc::now(),
+        expires_at: Utc::now() + chrono::Duration::hours(6),
+    }
+}
+
 fn branch_graph() -> (
     ExecutionGraph,
     Vec<TaskId>,
     ExecutionBranchId,
     ExecutionNodeId,
 ) {
-    let compiler = TopologyCompiler::default();
+    let compiler = TopologyCompiler;
     let workflow_id = TaskId::new();
     let graph = compiler
         .compile(
@@ -149,7 +174,7 @@ fn checkpointed_branch_graph() -> (
     ExecutionNodeId,
     ExecutionNodeId,
 ) {
-    let compiler = TopologyCompiler::default();
+    let compiler = TopologyCompiler;
     let workflow_id = TaskId::new();
     let mut graph = compiler
         .compile(
@@ -307,6 +332,91 @@ fn guard_classifies_semantic_drift_as_context_refresh() {
 }
 
 #[test]
+fn guard_marks_decision_as_fingerprint_reinforced_when_advisory_context_matches() {
+    let (_, _, branch_id, _) = branch_graph();
+    let guard = Guard::new(GuardPolicy::default());
+    let decision = guard
+        .evaluate(
+            &GuardContext::new(GuardTarget::Branch(branch_id)).with_profile(
+                ProfileAssessment::new(
+                    Some(mister_smith_core::ProfileSnapshot {
+                        profile_id: mister_smith_core::ProfileSnapshotId::new(),
+                        target: ProfileTarget::Branch,
+                        health_state: HealthState::Degraded,
+                        latency_window: None,
+                        error_window: None,
+                        semantic_signals: vec![semantic_signal(
+                            SemanticSignalKind::MissingContext,
+                            75,
+                            "missing branch-local repair context",
+                        )],
+                        fingerprint_ref: None,
+                        updated_at: Utc::now(),
+                    }),
+                    Vec::new(),
+                )
+                .with_fingerprint(profile_fingerprint(
+                    branch_id,
+                    vec!["missing_context"],
+                    vec![InterventionType::ContextRefresh],
+                )),
+            ),
+        )
+        .expect("guard decision should succeed");
+
+    assert_eq!(decision.intervention, InterventionType::ContextRefresh);
+    assert_eq!(
+        decision.evidence.decision_basis,
+        SupervisionDecisionBasis::FingerprintReinforced
+    );
+    assert!(decision
+        .evidence
+        .notes
+        .iter()
+        .any(|note| note.contains("fingerprint reinforced")));
+}
+
+#[test]
+fn guard_ignores_non_matching_fingerprint_context() {
+    let (_, _, branch_id, _) = branch_graph();
+    let guard = Guard::new(GuardPolicy::default());
+    let decision = guard
+        .evaluate(
+            &GuardContext::new(GuardTarget::Branch(branch_id)).with_profile(
+                ProfileAssessment::new(
+                    Some(mister_smith_core::ProfileSnapshot {
+                        profile_id: mister_smith_core::ProfileSnapshotId::new(),
+                        target: ProfileTarget::Branch,
+                        health_state: HealthState::Degraded,
+                        latency_window: None,
+                        error_window: None,
+                        semantic_signals: vec![semantic_signal(
+                            SemanticSignalKind::MissingContext,
+                            75,
+                            "missing branch-local repair context",
+                        )],
+                        fingerprint_ref: None,
+                        updated_at: Utc::now(),
+                    }),
+                    Vec::new(),
+                )
+                .with_fingerprint(profile_fingerprint(
+                    branch_id,
+                    vec!["policy_conflict"],
+                    vec![InterventionType::Retry],
+                )),
+            ),
+        )
+        .expect("guard decision should succeed");
+
+    assert_eq!(decision.intervention, InterventionType::ContextRefresh);
+    assert_eq!(
+        decision.evidence.decision_basis,
+        SupervisionDecisionBasis::LiveSignalsOnly
+    );
+}
+
+#[test]
 fn guard_falls_back_conservatively_when_profile_or_control_plane_is_missing() {
     let (_, _, branch_id, _) = branch_graph();
     let guard = Guard::new(GuardPolicy::default());
@@ -366,7 +476,7 @@ fn intervention_engine_isolates_branch_without_restarting_other_branches() {
 
     assert_eq!(decision.intervention, InterventionType::BranchIsolation);
 
-    let record = InterventionEngine::default()
+    let record = InterventionEngine
         .apply(&decision, &scheduler, &mut graph)
         .expect("intervention should apply");
 
@@ -530,7 +640,7 @@ fn intervention_engine_retries_only_pending_nodes_from_latest_checkpoint() {
     scheduler.start(&branch_a_task_2).unwrap();
     scheduler.fail(&branch_a_task_2, "stalled").unwrap();
 
-    let record = InterventionEngine::default()
+    let record = InterventionEngine
         .apply(
             &branch_decision(branch_id, InterventionType::Retry),
             &scheduler,
@@ -558,7 +668,7 @@ fn intervention_engine_propagates_branch_scheduler_failures() {
     let (mut graph, _task_ids, branch_id, ..) = checkpointed_branch_graph();
     let scheduler = Arc::new(TaskScheduler::new());
 
-    let error = InterventionEngine::default()
+    let error = InterventionEngine
         .apply(
             &branch_decision(branch_id, InterventionType::Retry),
             &scheduler,
@@ -600,7 +710,7 @@ fn intervention_engine_escalation_cancels_branch_recovery_scope() {
         .unwrap();
     scheduler.start(&branch_a_task_2).unwrap();
 
-    InterventionEngine::default()
+    InterventionEngine
         .apply(
             &branch_decision(branch_id, InterventionType::Escalation),
             &scheduler,
@@ -620,7 +730,7 @@ fn intervention_engine_escalation_cancels_branch_recovery_scope() {
 
 #[test]
 fn intervention_engine_graph_abort_fails_all_scheduled_work() {
-    let (mut graph, task_ids, _, ..) = checkpointed_branch_graph();
+    let (mut graph, task_ids, ..) = checkpointed_branch_graph();
     let scheduler = scheduler_for_graph(&task_ids);
     let running_task_id = task_ids[0];
 
@@ -644,7 +754,7 @@ fn intervention_engine_graph_abort_fails_all_scheduled_work() {
         operator_visibility: true,
     };
 
-    InterventionEngine::default()
+    InterventionEngine
         .apply(&decision, &scheduler, &mut graph)
         .expect("graph abort should apply");
 

--- a/crates/mister-smith-app/src/execution.rs
+++ b/crates/mister-smith-app/src/execution.rs
@@ -28,9 +28,10 @@ use mister_smith_config::{
 use mister_smith_core::{
     AgentId, AgentType, BranchState, EscalationPolicy, ExecutionNodeId, ExternalDelegationEnvelope,
     FailureContextCheckpoint, GraphState, GuardTarget, HandoffClarificationRequest, LlmError,
-    NodeState, RepairDirective, RepairDirectiveAction, SemanticSignal, SemanticSignalKind,
-    StepEvaluationRecord, SupervisionStrategy, TaskId, Tool, ToolCapabilities, ToolError, ToolId,
-    ToolSchema, VerifierVerdict,
+    NodeState, ProfileFingerprint, RepairDirective, RepairDirectiveAction,
+    SemanticSignal, SemanticSignalKind, StepEvaluationRecord, SupervisionStrategy, TaskId, Tool,
+    ToolCapabilities, ToolError, ToolId, ToolSchema,
+    VerifierVerdict,
 };
 use mister_smith_events::{AutonomyStatusView, EventBus, StepRoutingDecisionSummary};
 use mister_smith_http::server::{
@@ -47,7 +48,10 @@ use mister_smith_nats::{JetStreamConfig, JetStreamManager, NatsTransport};
 use mister_smith_persistence::postgres::migrations::MigrationRunner;
 use mister_smith_persistence::postgres::queries::{self, TaskRecord};
 use mister_smith_persistence::repository::task::TaskRepository;
-use mister_smith_persistence::{PostgresConnection, Repository};
+use mister_smith_persistence::{
+    kv::buckets::{KvBucketManager, AGENT_STATE},
+    KvConfig, PostgresConnection, ProfileFingerprintStore, Repository,
+};
 use mister_smith_supervision::SupervisedSystem;
 use mister_smith_transport::{MessageEnvelope, MessagePriority};
 use serde::Deserialize;
@@ -570,6 +574,21 @@ async fn ensure_runtime_budget_kv_store(
         .map_err(|error| {
             format!("JetStream budget bucket '{bucket}' initialization failed: {error}")
         })
+}
+
+async fn runtime_profile_fingerprint_store(
+    jetstream: &JetStreamManager,
+) -> Result<ProfileFingerprintStore, String> {
+    let mut manager = KvBucketManager::new(jetstream.context().clone(), KvConfig::default());
+    manager
+        .initialize_buckets()
+        .await
+        .map_err(|error| format!("JetStream fingerprint bucket initialization failed: {error}"))?;
+    let store = manager
+        .bucket(AGENT_STATE)
+        .map_err(|error| format!("JetStream fingerprint bucket lookup failed: {error}"))?
+        .clone();
+    Ok(ProfileFingerprintStore::new(store))
 }
 
 async fn build_runtime_budget_enforcer_with_bucket(
@@ -2098,19 +2117,42 @@ impl RuntimeTaskService {
         let Some(plan) = plan else {
             return Ok(());
         };
+        let RuntimeSupervisionPlan {
+            target,
+            assessment,
+            checkpoints,
+        } = plan;
+        let current_fingerprint = self.load_current_runtime_fingerprint(&target).await?;
+        let assessment = match current_fingerprint.as_ref() {
+            Some(fingerprint) => assessment.with_fingerprint(fingerprint.clone()),
+            None => assessment,
+        };
+        let snapshot = assessment.snapshot().cloned();
 
-        self.orchestrator
+        let (decision, _record) = self
+            .orchestrator
             .supervise(
                 &workflow_id,
-                GuardContext::new(plan.target)
-                    .with_profile(plan.assessment)
-                    .with_checkpoints(plan.checkpoints),
+                GuardContext::new(target.clone())
+                    .with_profile(assessment)
+                    .with_checkpoints(checkpoints),
             )
             .await
-            .map(|_| ())
             .map_err(|error| {
                 format!("runtime supervision failed for workflow {workflow_id}: {error}")
-            })
+            })?;
+        if let Some(snapshot) = snapshot.as_ref() {
+            let fingerprint = build_runtime_profile_fingerprint(
+                workflow_id,
+                &target,
+                snapshot,
+                &decision,
+                current_fingerprint.as_ref(),
+            );
+            self.persist_runtime_profile_fingerprint(&fingerprint).await?;
+        }
+
+        Ok(())
     }
 
     async fn supervise_runtime_transition(
@@ -2140,6 +2182,40 @@ impl RuntimeTaskService {
             .ok_or_else(|| format!("execution graph missing for workflow {workflow_id}"))?;
         let plan = runtime_supervision_plan_for_failed_step(&graph, task, failed_step)?;
         self.record_runtime_supervision(workflow_id, plan).await
+    }
+
+    async fn load_current_runtime_fingerprint(
+        &self,
+        target: &GuardTarget,
+    ) -> Result<Option<ProfileFingerprint>, String> {
+        let target_kind = runtime_fingerprint_target_kind(target);
+        let target_selector = runtime_fingerprint_target_selector(target);
+        runtime_profile_fingerprint_store(self.jetstream.as_ref())
+            .await?
+            .current(target_kind, &target_selector)
+            .await
+            .map_err(|error| {
+                format!(
+                    "runtime fingerprint lookup failed for workflow target {target_kind}:{target_selector}: {error}"
+                )
+            })
+    }
+
+    async fn persist_runtime_profile_fingerprint(
+        &self,
+        fingerprint: &ProfileFingerprint,
+    ) -> Result<(), String> {
+        runtime_profile_fingerprint_store(self.jetstream.as_ref())
+            .await?
+            .save(fingerprint)
+            .await
+            .map(|_| ())
+            .map_err(|error| {
+                format!(
+                    "runtime fingerprint persistence failed for {}:{}: {error}",
+                    fingerprint.target_kind, fingerprint.target_selector
+                )
+            })
     }
 
     fn spawn_workflow_runner(
@@ -4220,6 +4296,118 @@ fn runtime_checkpoints_for_target(
         .and_then(|branch_id| graph.latest_checkpoint(&branch_id).cloned())
         .into_iter()
         .collect()
+}
+
+fn runtime_fingerprint_target_kind(target: &GuardTarget) -> &'static str {
+    match target {
+        GuardTarget::Node(_) => "agent",
+        GuardTarget::Branch(_) => "branch",
+        GuardTarget::Graph(_) => "topology",
+        GuardTarget::Provider(_) => "provider",
+    }
+}
+
+fn runtime_fingerprint_target_selector(target: &GuardTarget) -> String {
+    match target {
+        GuardTarget::Node(node_id) => node_id.to_string(),
+        GuardTarget::Branch(branch_id) => branch_id.to_string(),
+        GuardTarget::Graph(graph_id) => graph_id.to_string(),
+        GuardTarget::Provider(provider) => provider.clone(),
+    }
+}
+
+fn runtime_health_label(health_state: mister_smith_core::HealthState) -> &'static str {
+    match health_state {
+        mister_smith_core::HealthState::Healthy => "healthy",
+        mister_smith_core::HealthState::Degraded => "degraded",
+        mister_smith_core::HealthState::Unhealthy => "unhealthy",
+        mister_smith_core::HealthState::Unknown => "unknown",
+    }
+}
+
+fn runtime_signal_kind_label(signal_kind: SemanticSignalKind) -> &'static str {
+    match signal_kind {
+        SemanticSignalKind::Stalled => "stalled",
+        SemanticSignalKind::Repetitive => "repetitive",
+        SemanticSignalKind::LowConfidence => "low_confidence",
+        SemanticSignalKind::MissingContext => "missing_context",
+        SemanticSignalKind::PolicyConflict => "policy_conflict",
+    }
+}
+
+fn runtime_intervention_label(intervention: mister_smith_core::InterventionType) -> &'static str {
+    match intervention {
+        mister_smith_core::InterventionType::Retry => "retry",
+        mister_smith_core::InterventionType::Failover => "failover",
+        mister_smith_core::InterventionType::ContextRefresh => "context_refresh",
+        mister_smith_core::InterventionType::BranchIsolation => "branch_isolation",
+        mister_smith_core::InterventionType::Reassignment => "reassignment",
+        mister_smith_core::InterventionType::Escalation => "escalation",
+        mister_smith_core::InterventionType::Abort => "abort",
+    }
+}
+
+fn runtime_fingerprint_confidence(
+    snapshot: &mister_smith_core::ProfileSnapshot,
+    existing: Option<&ProfileFingerprint>,
+) -> f32 {
+    let live = snapshot
+        .semantic_signals
+        .iter()
+        .map(|signal| f32::from(signal.severity) / 100.0)
+        .fold(0.55, f32::max)
+        .min(0.95);
+    existing.map(|fingerprint| fingerprint.confidence.max(live)).unwrap_or(live)
+}
+
+fn build_runtime_profile_fingerprint(
+    workflow_id: TaskId,
+    target: &GuardTarget,
+    snapshot: &mister_smith_core::ProfileSnapshot,
+    decision: &mister_smith_core::GuardDecision,
+    existing: Option<&ProfileFingerprint>,
+) -> ProfileFingerprint {
+    let target_kind = runtime_fingerprint_target_kind(target).to_string();
+    let target_selector = runtime_fingerprint_target_selector(target);
+    let updated_at = Utc::now();
+    let dominant_failure_modes = snapshot
+        .semantic_signals
+        .iter()
+        .map(|signal| runtime_signal_kind_label(signal.signal_kind).to_string())
+        .collect::<Vec<_>>();
+    let source_refs = std::iter::once(format!("workflow:{workflow_id}"))
+        .chain(
+            decision
+                .evidence
+                .checkpoint_ids
+                .iter()
+                .map(|checkpoint_id| format!("checkpoint:{checkpoint_id}")),
+        )
+        .collect::<Vec<_>>();
+
+    ProfileFingerprint {
+        fingerprint_id: existing
+            .map(|fingerprint| fingerprint.fingerprint_id)
+            .unwrap_or_default(),
+        target_kind,
+        target_selector,
+        source_refs,
+        summary_payload: json!({
+            "health_state": runtime_health_label(snapshot.health_state),
+            "signal_kinds": snapshot
+                .semantic_signals
+                .iter()
+                .map(|signal| runtime_signal_kind_label(signal.signal_kind))
+                .collect::<Vec<_>>(),
+            "decision_basis": decision.evidence.decision_basis.as_str(),
+            "intervention": runtime_intervention_label(decision.intervention),
+        }),
+        dominant_failure_modes,
+        preferred_interventions: vec![decision.intervention],
+        confidence: runtime_fingerprint_confidence(snapshot, existing),
+        expires_at: updated_at + chrono::Duration::hours(6),
+        updated_at,
+    }
 }
 
 fn runtime_supervision_plan(

--- a/crates/mister-smith-core/tests/trait_compilation_tests.rs
+++ b/crates/mister-smith-core/tests/trait_compilation_tests.rs
@@ -579,6 +579,38 @@ fn autonomy_ids_enums_and_errors_are_available() {
 }
 
 #[test]
+fn profile_fingerprint_serializes_as_structured_summary_without_transcript_payload() {
+    let fingerprint = ProfileFingerprint {
+        fingerprint_id: ProfileFingerprintId::new(),
+        target_kind: "branch".to_string(),
+        target_selector: "branch-a".to_string(),
+        source_refs: vec![
+            "workflow:packet-021".to_string(),
+            "checkpoint:checkpoint-1".to_string(),
+        ],
+        summary_payload: serde_json::json!({
+            "health_state": "degraded",
+            "signal_kinds": ["missing_context"],
+            "decision_basis": "live_signals_only",
+        }),
+        dominant_failure_modes: vec!["missing_context".to_string()],
+        preferred_interventions: vec![InterventionType::ContextRefresh],
+        confidence: 0.82,
+        updated_at: chrono::Utc::now(),
+        expires_at: chrono::Utc::now() + chrono::Duration::hours(6),
+    };
+
+    let encoded = serde_json::to_value(&fingerprint).expect("fingerprint should serialize");
+    assert_eq!(encoded["target_kind"], "branch");
+    assert!(encoded["summary_payload"].is_object());
+    assert_eq!(
+        encoded["summary_payload"]["signal_kinds"][0],
+        serde_json::json!("missing_context")
+    );
+    assert!(encoded["summary_payload"]["raw_transcript"].is_null());
+}
+
+#[test]
 fn autonomy_error_types_compile_as_standard_errors() {
     assert_error_traits::<TopologyError>();
     assert_error_traits::<MemoryError>();

--- a/crates/mister-smith-persistence/src/kv/fingerprints.rs
+++ b/crates/mister-smith-persistence/src/kv/fingerprints.rs
@@ -1,0 +1,201 @@
+//! Typed JetStream KV helpers for packet-021 profile fingerprints.
+
+use async_nats::jetstream::kv::Store;
+use chrono::Utc;
+
+use mister_smith_core::{PersistenceError, ProfileFingerprint, ProfileFingerprintRef};
+
+use super::state::{ConflictStrategy, StateManager};
+
+const PROFILE_FINGERPRINT_PREFIX: &str = "profile-fingerprint";
+const DISALLOWED_SUMMARY_KEYS: &[&str] = &[
+    "transcript",
+    "transcripts",
+    "raw_transcript",
+    "raw_transcripts",
+    "raw_payload",
+    "messages",
+    "message_history",
+];
+
+/// Build the stable KV key for a persisted profile fingerprint.
+pub fn profile_fingerprint_key(target_kind: &str, target_selector: &str) -> String {
+    format!(
+        "{PROFILE_FINGERPRINT_PREFIX}:{}:{}",
+        normalize_key_segment(target_kind),
+        normalize_key_segment(target_selector),
+    )
+}
+
+/// Typed persistence facade for advisory profile fingerprints.
+pub struct ProfileFingerprintStore {
+    state: StateManager,
+}
+
+impl ProfileFingerprintStore {
+    /// Create a new store over an existing JetStream KV bucket.
+    pub fn new(store: Store) -> Self {
+        Self {
+            state: StateManager::new(store, ConflictStrategy::LastWriteWins),
+        }
+    }
+
+    /// Save or replace a fingerprint keyed by target kind and selector.
+    pub async fn save(
+        &self,
+        fingerprint: &ProfileFingerprint,
+    ) -> Result<u64, PersistenceError> {
+        validate_profile_fingerprint(fingerprint)?;
+        self.state
+            .save(
+                &profile_fingerprint_key(&fingerprint.target_kind, &fingerprint.target_selector),
+                fingerprint,
+            )
+            .await
+    }
+
+    /// Load a fingerprint for the given target, returning `None` when absent.
+    pub async fn get(
+        &self,
+        target_kind: &str,
+        target_selector: &str,
+    ) -> Result<Option<ProfileFingerprint>, PersistenceError> {
+        let fingerprint = self
+            .state
+            .get(&profile_fingerprint_key(target_kind, target_selector))
+            .await?;
+        if let Some(fingerprint) = fingerprint.as_ref() {
+            validate_profile_fingerprint(fingerprint)?;
+        }
+        Ok(fingerprint)
+    }
+
+    /// Load the current non-expired fingerprint for the given target, when any.
+    pub async fn current(
+        &self,
+        target_kind: &str,
+        target_selector: &str,
+    ) -> Result<Option<ProfileFingerprint>, PersistenceError> {
+        Ok(self
+            .get(target_kind, target_selector)
+            .await?
+            .filter(|fingerprint| fingerprint.expires_at > Utc::now()))
+    }
+
+    /// Build the lightweight operator-facing reference for a fingerprint.
+    pub fn reference(fingerprint: &ProfileFingerprint) -> ProfileFingerprintRef {
+        ProfileFingerprintRef {
+            fingerprint_id: fingerprint.fingerprint_id,
+            fingerprint_key: profile_fingerprint_key(
+                &fingerprint.target_kind,
+                &fingerprint.target_selector,
+            ),
+            confidence: fingerprint.confidence,
+            expires_at: fingerprint.expires_at,
+        }
+    }
+}
+
+fn validate_profile_fingerprint(
+    fingerprint: &ProfileFingerprint,
+) -> Result<(), PersistenceError> {
+    if fingerprint.target_kind.trim().is_empty() {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint target_kind must not be empty".to_string(),
+        ));
+    }
+    if fingerprint.target_selector.trim().is_empty() {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint target_selector must not be empty".to_string(),
+        ));
+    }
+    if fingerprint.source_refs.is_empty() {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint must include at least one source reference".to_string(),
+        ));
+    }
+    if !fingerprint.summary_payload.is_object() {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint summary_payload must be a JSON object".to_string(),
+        ));
+    }
+    if contains_disallowed_summary_content(&fingerprint.summary_payload) {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint summary_payload must not duplicate raw transcript content"
+                .to_string(),
+        ));
+    }
+    if !(0.0..=1.0).contains(&fingerprint.confidence) {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint confidence must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+    if fingerprint.expires_at <= fingerprint.updated_at {
+        return Err(PersistenceError::SerializationFailed(
+            "profile fingerprint expires_at must be after updated_at".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn contains_disallowed_summary_content(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Object(map) => map.iter().any(|(key, value)| {
+            DISALLOWED_SUMMARY_KEYS.contains(&key.as_str())
+                || contains_disallowed_summary_content(value)
+        }),
+        serde_json::Value::Array(values) => values.iter().any(contains_disallowed_summary_content),
+        _ => false,
+    }
+}
+
+fn normalize_key_segment(value: &str) -> String {
+    value
+        .trim()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use mister_smith_core::{InterventionType, ProfileFingerprint, ProfileFingerprintId};
+
+    #[test]
+    fn profile_fingerprint_key_normalizes_segments() {
+        assert_eq!(
+            profile_fingerprint_key("Executor", "branch/A"),
+            "profile-fingerprint:executor:branch_a"
+        );
+    }
+
+    #[test]
+    fn validation_rejects_summary_payload_with_raw_transcript_fields() {
+        let fingerprint = ProfileFingerprint {
+            fingerprint_id: ProfileFingerprintId::new(),
+            target_kind: "executor".to_string(),
+            target_selector: "branch-a".to_string(),
+            source_refs: vec!["workflow:test".to_string()],
+            summary_payload: serde_json::json!({
+                "health_state": "degraded",
+                "raw_transcript": "verbatim transcript",
+            }),
+            dominant_failure_modes: vec!["missing_context".to_string()],
+            preferred_interventions: vec![InterventionType::ContextRefresh],
+            confidence: 0.82,
+            updated_at: Utc::now(),
+            expires_at: Utc::now() + Duration::hours(6),
+        };
+
+        let error = validate_profile_fingerprint(&fingerprint).expect_err("should reject");
+        assert!(matches!(error, PersistenceError::SerializationFailed(_)));
+    }
+}

--- a/crates/mister-smith-persistence/src/kv/mod.rs
+++ b/crates/mister-smith-persistence/src/kv/mod.rs
@@ -1,5 +1,6 @@
 //! JetStream KV distributed state layer.
 
 pub mod buckets;
+pub mod fingerprints;
 pub mod state;
 pub mod watch;

--- a/crates/mister-smith-persistence/src/lib.rs
+++ b/crates/mister-smith-persistence/src/lib.rs
@@ -30,6 +30,7 @@ pub use error::from_sqlx_error;
 // Core types
 pub use hybrid::manager::HybridStateManager;
 pub use hybrid::router::{DataRouter, DataType, StorageLayer};
+pub use kv::fingerprints::{profile_fingerprint_key, ProfileFingerprintStore};
 pub use kv::state::{
     branch_checkpoint_state_key, branch_resume_state_key, ConflictStrategy, Operation, StateChange,
     StateManager,

--- a/crates/mister-smith-persistence/tests/kv_tests.rs
+++ b/crates/mister-smith-persistence/tests/kv_tests.rs
@@ -5,11 +5,13 @@
 
 use std::time::Duration;
 
-use mister_smith_core::HealthStatus;
+use chrono::{Duration as ChronoDuration, Utc};
+use mister_smith_core::{HealthStatus, InterventionType, ProfileFingerprint, ProfileFingerprintId};
 use mister_smith_persistence::config::KvConfig;
 use mister_smith_persistence::kv::buckets::{
     KvBucketManager, AGENT_STATE, QUERY_CACHE, SESSION_DATA,
 };
+use mister_smith_persistence::kv::fingerprints::ProfileFingerprintStore;
 use mister_smith_persistence::kv::state::{ConflictStrategy, StateManager};
 
 fn nats_url() -> Option<String> {
@@ -250,6 +252,78 @@ async fn state_get_nonexistent_returns_none() {
     assert!(result.is_none());
 }
 
+#[tokio::test]
+#[ignore] // Requires NATS: NATS_URL=nats://localhost:4222
+async fn profile_fingerprint_round_trips_through_agent_state_bucket() {
+    let context = setup_jetstream().await;
+    let config = test_kv_config();
+
+    let mut manager = KvBucketManager::new(context, config);
+    manager.initialize_buckets().await.unwrap();
+
+    let store = ProfileFingerprintStore::new(manager.bucket(AGENT_STATE).unwrap().clone());
+    let fingerprint = ProfileFingerprint {
+        fingerprint_id: ProfileFingerprintId::new(),
+        target_kind: "branch".to_string(),
+        target_selector: "branch-a".to_string(),
+        source_refs: vec!["workflow:test".to_string()],
+        summary_payload: serde_json::json!({
+            "health_state": "degraded",
+            "signal_kinds": ["missing_context"],
+        }),
+        dominant_failure_modes: vec!["missing_context".to_string()],
+        preferred_interventions: vec![InterventionType::ContextRefresh],
+        confidence: 0.83,
+        updated_at: Utc::now(),
+        expires_at: Utc::now() + ChronoDuration::hours(6),
+    };
+
+    store.save(&fingerprint).await.unwrap();
+    let loaded = store.current("branch", "branch-a").await.unwrap().unwrap();
+
+    assert_eq!(loaded.fingerprint_id, fingerprint.fingerprint_id);
+    assert_eq!(loaded.target_kind, "branch");
+    assert_eq!(loaded.target_selector, "branch-a");
+    assert_eq!(loaded.dominant_failure_modes, vec!["missing_context"]);
+    assert_eq!(
+        loaded.preferred_interventions,
+        vec![InterventionType::ContextRefresh]
+    );
+}
+
+#[tokio::test]
+#[ignore] // Requires NATS: NATS_URL=nats://localhost:4222
+async fn profile_fingerprint_store_rejects_raw_transcript_summary_payloads() {
+    let context = setup_jetstream().await;
+    let config = test_kv_config();
+
+    let mut manager = KvBucketManager::new(context, config);
+    manager.initialize_buckets().await.unwrap();
+
+    let store = ProfileFingerprintStore::new(manager.bucket(AGENT_STATE).unwrap().clone());
+    let fingerprint = ProfileFingerprint {
+        fingerprint_id: ProfileFingerprintId::new(),
+        target_kind: "branch".to_string(),
+        target_selector: "branch-b".to_string(),
+        source_refs: vec!["workflow:test".to_string()],
+        summary_payload: serde_json::json!({
+            "health_state": "degraded",
+            "raw_transcript": "verbatim transcript should not be persisted",
+        }),
+        dominant_failure_modes: vec!["missing_context".to_string()],
+        preferred_interventions: vec![InterventionType::ContextRefresh],
+        confidence: 0.83,
+        updated_at: Utc::now(),
+        expires_at: Utc::now() + ChronoDuration::hours(6),
+    };
+
+    let error = store.save(&fingerprint).await.expect_err("should reject");
+    assert!(matches!(
+        error,
+        mister_smith_core::PersistenceError::SerializationFailed(_)
+    ));
+}
+
 // ---------------------------------------------------------------------------
 // TTL expiration test
 // ---------------------------------------------------------------------------
@@ -273,7 +347,7 @@ async fn state_ttl_expiration() {
 
     let key = "ttl_test_key";
     state_mgr
-        .save(&key, &serde_json::json!({"ephemeral": true}))
+        .save(key, &serde_json::json!({"ephemeral": true}))
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- add a typed JetStream KV helper for bounded profile fingerprints and export it from persistence
- let Guard and ProfileAssessment consume current fingerprints as advisory reinforcement only
- wire runtime supervision to load and refresh current fingerprints on the supported task path

## Validation
- cargo test -p mister-smith-core --test trait_compilation_tests
- cargo test -p mister-smith-persistence --test kv_tests
- cargo test -p mister-smith-agents --test guard_tests
- cargo test -p mister-smith-app
- cargo build --workspace
- cargo clippy -p mister-smith-core --test trait_compilation_tests -- -D warnings
- cargo clippy -p mister-smith-persistence --test kv_tests -- -D warnings
- cargo clippy -p mister-smith-agents --test guard_tests -- -D warnings
- cargo clippy -p mister-smith-app --lib --bin mister-smith -- -D warnings
- git diff --check
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync

## Notes
- env-gated cargo test -p mister-smith-persistence --test kv_tests -- --ignored was not run because NATS_URL was unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fingerprint-based decision reinforcement to supervision system, enabling profile assessments to leverage stored fingerprints for improved decision accuracy.
  * Implemented persistent storage for profile fingerprints, enabling fingerprint reuse across supervision cycles.

* **Tests**
  * Added fingerprint serialization and round-trip persistence test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->