### PR TITLE
docs(prompt-improver): add R9 research prompt suite

### DIFF
--- a/docs/prompt-improver-spec/final-prompts/mister-smith-ms-116-linear-initialization-handoff.md
+++ b/docs/prompt-improver-spec/final-prompts/mister-smith-ms-116-linear-initialization-handoff.md
@@ -1,0 +1,162 @@
+# Mister Smith MS-116 Fresh-Session Initialization Handoff
+
+You are Codex in a fresh session working in:
+
+- <repo_root>`/Users/macmain/MisterSmith`</repo_root>
+
+Your mission is to initialize the next honest packet-021 implementation issue in Linear without
+starting implementation work:
+
+- <linear_issue>`MS-116`</linear_issue>
+- Title: `T3: Add bounded profile fingerprints`
+- Parent packet: <linear_parent_issue>`MS-113`</linear_parent_issue>
+- Current known state at handoff:
+  - `MS-114` is landed on `main`
+  - `MS-115` is landed on `main`
+  - `MS-116` is currently `Backlog`
+  - `MS-117` is currently `Backlog`
+  - `MS-118` is still blocked by `MS-116` and `MS-117`
+  - `MS-116` does not yet have a `## Codex Workpad`
+- Issue URL:
+  <linear_issue_url>`https://linear.app/agentic-ops/issue/MS-116`</linear_issue_url>
+- Packet source:
+  <packet_source>`/Users/macmain/MisterSmith/specs/021-profile-aware-predictive-runtime-supervision/`</packet_source>
+
+This is an issue-initialization session, not an implementation session.
+
+## Objective
+
+By the end of this session, you must:
+
+1. verify that `MS-116` is still the next honest packet-021 child to initialize
+2. reconcile the current repo and Linear state before mutating anything
+3. create or update exactly one durable `## Codex Workpad` comment on `MS-116`
+4. leave `MS-116` in `Backlog`
+5. stop before code edits, branch creation, queue staging, or PR work
+
+## Start Sequence
+
+Before mutating Linear state, read these files in order:
+
+1. `/Users/macmain/MisterSmith/AGENTS.md`
+2. `/Users/macmain/MisterSmith/WORKFLOW.md`
+3. `/Users/macmain/MisterSmith/docs/linear/LINEAR.md`
+4. `/Users/macmain/MisterSmith/docs/current-state.md`
+5. `/Users/macmain/MisterSmith/specs/021-profile-aware-predictive-runtime-supervision/spec.md`
+6. `/Users/macmain/MisterSmith/specs/021-profile-aware-predictive-runtime-supervision/plan.md`
+7. `/Users/macmain/MisterSmith/specs/021-profile-aware-predictive-runtime-supervision/tasks.md`
+8. `/Users/macmain/MisterSmith/specs/021-profile-aware-predictive-runtime-supervision/contracts/supervision-evidence-contract.md`
+
+Then verify control-plane truth before taking any action:
+
+1. start with Smith MCP first-hop routing
+2. fetch the current snapshots for `MS-116`, `MS-117`, `MS-118`, and parent `MS-113`
+3. confirm `MS-118` is still blocked and should not be initialized first
+4. confirm the primary checkout is on clean synced `main`
+
+## Session Scope
+
+Initialize `MS-116` only.
+
+What that means:
+
+- confirm the issue is still the next honest packet-021 child to prepare
+- create or reconcile the single durable workpad comment
+- record scope, surfaces, constraints, validation plan, and next action for a later implementation
+  session
+- keep the issue resumable for a cold-start agent
+
+What that does not mean:
+
+- do not start implementation
+- do not create a branch
+- do not move the issue to `In Progress`
+- do not open a PR
+- do not initialize `MS-117` or `MS-118` in the same session unless the user explicitly asks
+- do not widen into packet-019 defaultization, operator-console work, or packet closure
+
+## MS-116 Scope To Capture In The Workpad
+
+Record the bounded packet tasks for `MS-116`:
+
+- `T013` add fingerprint serialization and guard-evidence tests
+- `T014` add JetStream KV fingerprint coverage
+- `T015` add fingerprint storage helpers
+- `T016` extend profile and Guard decision logic to consume fingerprints
+- `T017` wire fingerprint loading and save/update flow into runtime execution
+
+Record the primary surfaces:
+
+- `/Users/macmain/MisterSmith/crates/mister-smith-persistence/src/kv/`
+- `/Users/macmain/MisterSmith/crates/mister-smith-persistence/tests/kv_tests.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-agents/src/profile.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-agents/src/guard.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-app/src/execution.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-core/tests/trait_compilation_tests.rs`
+- `/Users/macmain/MisterSmith/crates/mister-smith-agents/tests/`
+
+Record the non-goals:
+
+- no `MS-117`
+- no `MS-118`
+- no operator-console rendering
+- no packet-019 defaultization
+- no broader learned control-plane work
+- no raw transcript duplication outside existing audit or replay surfaces
+
+## Workpad Requirements
+
+Create or update exactly one `## Codex Workpad` comment containing:
+
+- environment stamp as `host:cwd@sha`
+- issue title and URL
+- parent issue reference `MS-113`
+- current Linear state and whether the issue has a workpad yet
+- concise scope summary
+- milestone checklist for `T013` through `T017`
+- validation checklist for the future implementation lane
+- blockers
+- assumptions
+- explicit non-goals
+- exact next action for the future implementation session
+
+If an existing workpad is already present, update it instead of creating a second one.
+
+## Validation Plan To Record
+
+Capture the narrowest honest future validation set for this slice:
+
+- `cargo test -p mister-smith-core`
+- `cargo test -p mister-smith-persistence`
+- `cargo test -p mister-smith-agents`
+- `cargo test -p mister-smith-app`
+- `cargo clippy -p mister-smith-core -- -D warnings`
+- `cargo clippy -p mister-smith-persistence -- -D warnings`
+- `cargo clippy -p mister-smith-agents -- -D warnings`
+- `cargo clippy -p mister-smith-app -- -D warnings`
+- `cargo build --workspace`
+- `git diff --check`
+- `scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync`
+
+Do not run those commands unless you actually make repo changes during this session.
+
+## Decision Rules
+
+- If `MS-116` is still `Backlog` and uninitialized, initialize it and stop.
+- If `MS-116` already has a good workpad, reconcile and tighten it rather than replacing it.
+- If control-plane evidence shows `MS-117` must be prepared first, stop and report the exact
+  evidence instead of silently changing direction.
+- If the repo is not on clean synced `main`, report that before mutating Linear state.
+
+## Final Response Requirements
+
+At the end of the session, report only:
+
+- whether `MS-116` was confirmed as the next honest issue
+- whether the workpad was created or updated
+- the exact next implementation action recorded
+- blockers or risks, if any
+- whether any repo files were edited
+
+Do not claim implementation progress. This session is complete only when `MS-116` is cleanly
+initialized in Linear for a later implementation session.

--- a/docs/prompt-improver-spec/implementation_plan.md
+++ b/docs/prompt-improver-spec/implementation_plan.md
@@ -1,14 +1,18 @@
-# Implementation Plan — Mister Smith MS-114 Packet-021 Contract-Freeze Handoff Prompt
+# Implementation Plan — Mister Smith R9 Deep-Research Prompt Suite
 
 ## Step 1: Example Identification
 
 ### Source Prompt (normalized from user request)
 
-Create a fresh-session handoff prompt for the first implementation slice of packet `021` after
-the packet spec, tasks, and issue structure have been entered into Linear.
+Create a new additive `R9` suite of deep-research prompt documents for Mister Smith focused on
+recent advancements in workflow, orchestration, coordination, and real-time inter-agent
+communication that are not already covered by the existing research corpus under
+`docs/research-output/`.
 
-The prompt should initialize a new Codex session on the first runnable issue, grounded in the
-repo packet and Linear state, without pre-solving the implementation work.
+The suite must use the prompt-improver workflow as one batched campaign, keep shared workflow
+artifacts in `docs/prompt-improver-spec/`, create temporary drafts under
+`docs/prompt-improver-spec/final-prompts/`, and publish the final production prompts under
+`docs/research-prompts/R9/`.
 
 ### External Examples
 
@@ -16,188 +20,256 @@ repo packet and Linear state, without pre-solving the implementation work.
 
 ```text
 {
-  input: "Write a fresh-session handoff for a bounded packet child issue.",
-  ideal_output: "A direct implementation brief that names the issue, parent packet, reading
-  order, exact scope, validation floor, lifecycle expectations, and stop conditions without doing
-  the receiving agent's work."
+  input: "Refresh the dynamic orchestration research prompt without rediscovering what the repo
+  already knows.",
+  ideal_output: "A bounded deep-research prompt that names the baseline corpus, states the search
+  window, sharpens the open questions, and forces the receiving researcher to separate genuinely
+  new findings from already-landed conclusions."
 }
 ```
 
 Source:
-`docs/prompt-improver-spec/final-prompts/mister-smith-ms-106-orchestration-provenance-handoff.md`
+`docs/research-prompts/R8/04-dynamic-orchestration.md`
 
 #### Example 2
 
 ```text
 {
-  input: "Initialize implementation for a packet whose first milestone is a shared contract
-  freeze.",
-  ideal_output: "A handoff that keeps the session on the contract-freeze slice, points to the
-  contract artifact, blocks scope expansion into later slices, and requires shared-surface
-  validation before follow-on work."
+  input: "Create a new research prompt on coordination and verification for Mister Smith.",
+  ideal_output: "A prompt that uses the repo's consolidated findings and open gaps as the
+  baseline, names the specific coordination primitives already accepted, and asks only for new
+  work that materially changes the current implementation trajectory."
 }
 ```
 
 Source:
-`specs/015-complex-multi-agent-proof-and-unified-result-surfaces/contracts/result-surface-contract.md`
+`docs/research-prompts/R8/05-crdt-formal-verification.md`
 and
-`specs/021-profile-aware-predictive-runtime-supervision/contracts/supervision-evidence-contract.md`
+`docs/research-output/consolidated/05-coordination-and-state.md`
+
+#### Example 3
+
+```text
+{
+  input: "Create a recurring research task template for a new domain.",
+  ideal_output: "A prompt structure with clear standing orders, a compressed do-not-rediscover
+  baseline, scoped research dimensions, and explicit output criteria that avoid generic AI news."
+}
+```
+
+Source:
+`docs/prompt-improver-spec/final-prompts/pulse-task-template.md`
 
 ### What The Examples Demonstrate
 
-- the prompt should target one concrete Linear issue, not the whole packet parent
-- it should ground the receiving agent on current repo and tracker truth before edits
-- it should preserve the repo's Smith-first workflow and clean-closure expectations
-- it should point to the shared contract artifact explicitly when the slice is a contract freeze
-- it should prevent drift into later child slices or generic frontier strategy work
+- final prompts should be self-contained production briefings, not exploratory notes
+- the baseline must come from `docs/research-output/*`, not from prior prompt text alone
+- each prompt needs a firm scope boundary so adjacent research domains do not collapse together
+- the receiving researcher must be told what is already known, what counts as new, and how to
+  classify findings against Mister Smith's frontier mandate
+- reusable structure matters, but the "already known" sections must be rebuilt from repo truth
 
 ## Step 2: Planning Analysis
 
 ### Intent Summary
 
-**What**: produce a fresh-session handoff prompt for implementing `MS-114`, the first runnable
-packet-021 child issue.
+**What**: build a six-file `R9` deep-research prompt suite:
 
-**Who**: a fresh Codex session operating in `/Users/macmain/MisterSmith`.
+- `README.md`
+- `01-workflow-engines-compensation-and-resume.md`
+- `02-dynamic-orchestration-and-topology-control.md`
+- `03-coordination-protocols-shared-state-and-dynamic-verification.md`
+- `04-real-time-inter-agent-communication-and-transport.md`
+- `05-collaborative-communication-handoffs-and-cognitive-alignment.md`
 
-**Why**: packet `021` is now frozen and represented in Linear as parent `MS-113` plus bounded
-child slices. The next session should start at the first blocking slice rather than rediscovering
-scope or reopening packet framing.
+**Who**: a deep-research agent or analyst with live web access.
+
+**Why**: the existing research corpus and `R8` prompts already cover large parts of the landscape,
+but the repo still has documented gaps around workflow semantics, decentralized topology safety,
+dynamic protocol verification, real-time transport behavior, and collaborative communication
+policies. `R9` should convert those gaps into a sharper, additive prompt set.
 
 ### Deployment Summary
 
-- **Target environment**: fresh Codex session in `/Users/macmain/MisterSmith`
-- **Primary task**: execute `MS-114` end to end
-- **Expected outcome**:
-  - shared supervision contract published and aligned across `core`, `events`, and `orchestrator`
-  - validation run for the touched shared-surface crates and docs
-  - repo and Linear state closed cleanly at the end
+- **Working artifacts**:
+  - `docs/prompt-improver-spec/implementation_plan.md`
+  - `docs/prompt-improver-spec/task.md`
+  - `docs/prompt-improver-spec/walkthrough.md`
+- **Temporary drafts**:
+  - `docs/prompt-improver-spec/final-prompts/r9-*-draft.md`
+- **Production outputs**:
+  - `docs/research-prompts/R9/*.md`
+- **Baseline authority**:
+  - `docs/current-state.md`
+  - `docs/research-output/ROUTING_MANIFEST.md`
+  - relevant files under `docs/research-output/consolidated/`
 
 ### Task Flowchart
 
 ```mermaid
 graph TD
-    A["Start fresh Codex session"] --> B["Read repo authority and packet 021 docs"]
-    B --> C["Fetch Linear state for MS-113 and MS-114"]
-    C --> D["Reconcile workpad and move MS-114 to In Progress when implementation starts"]
-    D --> E["Freeze shared supervision contract and shared evidence fields"]
-    E --> F["Run narrow honest validation for touched crates and docs"]
-    F --> G["Update Linear/workpad state and return repo to clean synced main"]
+    A["Read repo research baseline and open gaps"] --> B["Define R9 prompt roster and scope boundaries"]
+    B --> C["Write suite-level prompt-improver plan and checklist"]
+    C --> D["Draft five temporary prompt files under prompt-improver-spec/final-prompts"]
+    D --> E["Critique the suite for overlap, stale baseline text, and weak frontier gating"]
+    E --> F["Finalize README plus five production prompts under docs/research-prompts/R9"]
+    F --> G["Delete temporary drafts and validate touched markdown files"]
 ```
 
 ### Lessons From Examples And Current Repo Truth
 
-- `MS-114` is the first blocking child slice under parent `MS-113`
-- the new packet includes a real contract artifact at
-  `specs/021-profile-aware-predictive-runtime-supervision/contracts/supervision-evidence-contract.md`
-- the receiving agent should implement only the contract-freeze slice, not `MS-115` through
-  `MS-118`
-- packet `020` repair lineage remains canonical and must stay coherent with the new contract
-- the prompt should preserve repo reading order, issue/workpad discipline, validation floor, and
-  clean-closure rules
+- `R8` already provides a deep-research family with a stable section backbone; `R9` should reuse
+  that shape for consistency
+- the authoritative boundary for "already discovered" is the research corpus under
+  `docs/research-output/`, especially the consolidated docs and routing manifest
+- [current-state](/Users/macmain/MisterSmith/docs/current-state.md) confirms the live runtime path
+  has moved through verifier-gated orchestration and packet `021` is now frozen, so the prompts
+  should assume phases `1-10` are landed and current frontier work is about sharpening next moves
+- the consolidated docs expose concrete open questions rather than broad unknowns:
+  decentralized DAG + OTP integration, workflow compensation semantics, dynamic MPST, production
+  evidence for meta-orchestration, provider-side backpressure, and communication policy design
+- the frontier mandate must stay visible in every prompt so future research does not drift into
+  market-following summaries
 
 ### Chain-of-Thought Approach
 
-Yes. The prompt should require the receiving agent to:
+Yes. The improved prompts should instruct the receiving researcher to:
 
-1. verify current repo and Linear truth
-2. read the packet and contract artifacts before editing
-3. ground on the shared code surfaces that define the contract freeze
-4. execute only the first bounded slice
-5. validate touched crates and docs honestly before closure
-6. leave repo and Linear state aligned
+1. anchor on the repo baseline before searching
+2. separate already-known findings from genuinely new work
+3. evaluate production evidence and contradictions, not just novelty
+4. map each finding to Mister Smith implementation surfaces
+5. rank outcomes by frontier leverage rather than popularity
 
 ### Output Format
 
 Markdown.
 
-The handoff prompt should provide:
+Each production prompt should remain a standalone research brief with the shared section order:
 
-- mission and current known state
-- required reading order
-- primary code surfaces
-- workflow expectations and lifecycle rules
-- exact scope and boundaries
-- validation floor
-- closure requirements
-- final response requirements
+`Context` → `Frontier-First Mandate` → `Research Objective` →
+`What Has Already Been Researched` → `Research Dimensions` →
+`Per-Dimension Output Structure` → `Synthesis` → `Research Methodology`
 
 ### Variable Plan
 
 | Variable | XML Tag | Description |
 | -------- | ------- | ----------- |
-| Repo root | `<repo_root>` | Absolute path to the Mister Smith repo |
-| Linear parent issue | `<linear_parent_issue>` | Packet parent issue identifier |
-| Linear issue | `<linear_issue>` | First runnable child issue identifier |
-| Linear doc | `<linear_doc>` | Packet doc attached to the parent issue |
-| Starting main SHA | `<starting_main_sha>` | Clean synced `main` commit at handoff |
-| Packet source | `<packet_source>` | Packet `021` directory |
-| Contract source | `<contract_source>` | Shared supervision contract artifact |
-| Branch name | `<branch_name>` | Suggested branch name if one is used |
+| Baseline boundary date | `<baseline_boundary>` | Fixed date after which the research should search for delta |
+| Repo state router | `<repo_state_router>` | Current repo-wide truth document |
+| Routing manifest | `<routing_manifest>` | Classification taxonomy and discovery-routing authority |
+| Baseline docs | `<baseline_docs>` | Relevant consolidated research files per prompt |
+| Search window | `<search_window>` | March 7, 2026 to present, with tightly scoped exceptions |
+| Frontier taxonomy | `<frontier_taxonomy>` | `EXTEND`, `TRANSFORM`, `NEW`, `FRONTIER`, `INCREMENTAL` |
+| Implementation vector | `<implementation_vector>` | Likely crates, runtime surfaces, or spec areas affected |
 
 ### Structural Notes
 
-- target the prompt at `MS-114`, not the packet parent
-- front-load the fact that this is the first contract-freeze slice
-- use current repo truth and the new Linear issue structure rather than stale packet-020 language
-- keep the prompt implementation-oriented, not spec-selection-oriented
-- explicitly forbid widening into `MS-115` through `MS-118`
+- `R9` is additive and should not replace or rewrite `R8`
+- each prompt must own one surface clearly:
+  - workflow semantics and compensation
+  - orchestration and topology control
+  - coordination and dynamic verification
+  - transport and real-time communication
+  - collaborative communication and alignment
+- prompts should cite exact baseline docs in the context rather than generic "existing corpus"
+- "already known" sections should be rebuilt from consolidated findings and open gaps, not copied
+  verbatim from `R8`
+- every prompt must explicitly ask for:
+  - frontier classification
+  - Mister Smith implementation vector
+  - production-validated vs research-only separation
+  - thin-results reporting
+  - contradictions to current assumptions
+
+### Overlap Boundaries
+
+- **Workflow vs orchestration**:
+  workflow prompt owns checkpointing, cancellation, compensation, reversible side effects, and
+  long-running execution semantics; orchestration prompt owns topology choice, team structure, and
+  adaptive control
+- **Orchestration vs coordination**:
+  orchestration prompt owns how teams are shaped; coordination prompt owns the shared-state and
+  protocol primitives those teams use once they exist
+- **Coordination vs transport**:
+  coordination prompt owns correctness and verification of interaction semantics; transport prompt
+  owns streaming, multiplexing, QoS, and wire-level delivery behavior
+- **Transport vs collaborative alignment**:
+  transport prompt owns the channel; collaborative alignment prompt owns the policy of what agents
+  say to each other, when they clarify, and how they avoid groupthink or trust drift
 
 ### Ambiguities & Questions
 
-None that block prompt creation.
+None that block execution.
 
-The first runnable slice and its repo/Linear anchors are now explicit.
+The user already resolved the two material choices:
 
-### Prompt Filename
+- build a full new `R9` round rather than a narrow gap patch
+- publish production prompts under `docs/research-prompts/R9/`
 
-`mister-smith-ms-114-packet-021-contract-freeze-handoff`
+### Prompt Filenames
+
+- `README.md`
+- `01-workflow-engines-compensation-and-resume.md`
+- `02-dynamic-orchestration-and-topology-control.md`
+- `03-coordination-protocols-shared-state-and-dynamic-verification.md`
+- `04-real-time-inter-agent-communication-and-transport.md`
+- `05-collaborative-communication-handoffs-and-cognitive-alignment.md`
 
 ### Constraint Preservation Checklist
 
-- [x] The output remains a handoff prompt, not execution of `MS-114`
-- [x] The prompt targets one bounded issue instead of the entire packet
-- [x] The prompt preserves repo authority, Linear, and clean-closure rules
-- [x] The prompt keeps later packet-021 slices explicitly out of scope
-- [x] The prompt grounds the receiving agent on the published contract artifact
+- [x] The work remains prompt creation only; it does not perform the research
+- [x] The baseline authority is `docs/research-output/*`, not `docs/pulse-tasks/*`
+- [x] `R9` is additive and does not replace `R8`
+- [x] Final production prompts live under `docs/research-prompts/R9/`
+- [x] Shared prompt-improver artifacts remain under `docs/prompt-improver-spec/`
+- [x] Each prompt preserves the frontier-first, anti-market-copying stance
+- [x] Each prompt includes frontier classification and implementation-vector requirements
+- [x] Each prompt forces honest reporting of thin results and contradictions
 
 ## Step 4: Critique & Revision Plan
 
 ### Issues Identified
 
-1. **"initialize this spec implementation"** → Problem: could imply the whole packet parent
-   instead of the first runnable slice → Revision: target `MS-114` explicitly.
-2. **"input the issues/tasks/spec into Linear"** → Problem: a handoff prompt could ignore the new
-   tracker state and fall back to repo-only grounding → Revision: include parent `MS-113`, child
-   `MS-114`, and the attached Linear doc in the prompt.
-3. **Generic implementation handoff structure** → Problem: it could miss that this slice is a
-   shared contract freeze → Revision: make the contract artifact a first-class required read and a
-   scope boundary.
-4. **Missing anti-scope-drift guard** → Problem: the receiving agent could widen into runtime
-   wiring, fingerprints, or operator-console work → Revision: add explicit out-of-scope language
-   for `MS-115` through `MS-118`.
-5. **Validation floor too vague** → Problem: shared-surface work can regress quietly across
-   multiple crates → Revision: name the narrowest honest test/clippy/build/doc checks for this
-   slice.
+1. **"workflow, orchestration, coordination, and real-time communication"** → Problem: the raw
+   scope language is broad enough that one prompt could collapse several domains together →
+   Revision: split the suite into five prompt owners with explicit overlap boundaries.
+2. **"using R8 as structure reference"** → Problem: if followed loosely, this encourages copying
+   stale baseline sections from the old prompt batch → Revision: require every "already known"
+   section to be rebuilt from `docs/research-output/*`.
+3. **"find recent advancements"** → Problem: a generic freshness requirement can devolve into
+   market-news summaries → Revision: enforce the routing-manifest taxonomy plus
+   `production-validated`, `research-only`, `thin-results`, and `contradictions` outputs.
+4. **"recent advancements in workflow"** → Problem: the repo baseline is strongest on topology,
+   supervision, and transport but thinner on compensation semantics and reversible tool taxonomy →
+   Revision: create a dedicated workflow-engine prompt anchored on compensation, resume, and
+   partial-failure recovery.
+5. **"real-time communication between the agents"** → Problem: that phrase spans transport,
+   multiplexing, protocol negotiation, and cognitive communication policy → Revision: separate
+   transport behavior from collaborative alignment and handoff policy.
 
 ### Areas Needing Expansion
 
-- stronger issue-state grounding from Linear
-- a clearer contract-first reading order
-- explicit closure requirements for repo and Linear state
-- sharper separation between `MS-114` and the later packet-021 child slices
+- a suite-level README explaining why `R9` exists and how to run it
+- exact baseline doc mapping for each production prompt
+- stronger instruction that older sources may be used only if absent from the baseline and
+  materially trajectory-changing
+- explicit implementation-surface mapping so research findings land closer to crates/specs/runtime
+- clearer distinctions between production evidence, frontier speculation, and thin-result areas
 
 ### Structural Improvements
 
-- add a **Current Known State** section with issue IDs and repo SHA
-- add a **Scope For MS-114 Only** section
-- add a **Boundaries** section that names later child issues explicitly
-- add a **Closure Requirements** section matching current repo workflow expectations
+- add a common "Fixed Inputs" subsection inside each prompt `Context` section
+- add a uniform "Baseline documents for this prompt" list in every prompt
+- add a shared per-dimension output contract with eight required fields
+- add run-order guidance in the `R9` README so the suite can be executed as a batch or as
+  individual prompts
 
 ### Constraint Preservation Check
 
-- [x] The prompt stays briefing-only and does not do the receiving agent's work
-- [x] The prompt preserves repo authority and tracker grounding
-- [x] The prompt keeps the packet slice bounded to contract freeze only
-- [x] The prompt keeps validation and closure requirements explicit
-- [x] The prompt avoids prescribing exact implementation details beyond necessary scope control
+- [x] All user-required files are represented in the suite
+- [x] The prompt backbone stays consistent across the five production prompts
+- [x] The baseline remains repo-authority-first
+- [x] The frontier mandate stays explicit and anti-imitative
+- [x] The production path and temporary-draft path remain distinct
+- [x] The work stays bounded to repo-local docs and prompt artifacts

--- a/docs/prompt-improver-spec/task.md
+++ b/docs/prompt-improver-spec/task.md
@@ -1,17 +1,24 @@
-# Task Checklist — Mister Smith MS-114 Packet-021 Contract-Freeze Handoff Prompt
+# Task Checklist — Mister Smith R9 Deep-Research Prompt Suite
 
 ## Steps 1-3: Planning and Initial Draft
 
-- [x] Step 1: normalized the user request into a first-runnable-slice handoff objective
-- [x] Step 2: identified the new Linear parent/child structure and the packet-021 contract-freeze
-  boundary
-- [x] Step 2a: added the contract artifact, issue IDs, and repo SHA as prompt anchors
-- [x] Step 3: drafted a fresh-session handoff prompt for `MS-114`
+- [x] Step 1: normalized the user request into an additive `R9` deep-research prompt suite
+- [x] Step 1a: identified existing prompt families and the relevant repo baseline under
+  `docs/research-output/`
+- [x] Step 2: mapped the five production prompts, README, baseline docs, and overlap boundaries
+- [x] Step 2a: locked the final production home to `docs/research-prompts/R9/`
+- [x] Step 3: created one temporary draft prompt per production prompt under
+  `docs/prompt-improver-spec/final-prompts/`
 
 ## Steps 4-6: Critique and Finalization
 
-- [x] Step 4: critiqued the draft for packet-parent drift, stale tracker context, and missing
-  contract-first framing
-- [x] Step 5: strengthened the prompt with explicit `MS-114` scope, Linear anchors, boundaries,
-  and validation rules
-- [x] Step 6: finalized the prompt and updated the prompt-improver artifacts for this session
+- [x] Step 4: critiqued the draft suite for overlap, stale baseline reuse, and weak frontier
+  gating
+- [x] Step 5: strengthened the prompts with explicit baseline-doc lists, frontier classification,
+  implementation vectors, and production-vs-research separation
+- [x] Step 6: finalized the production prompt set under `docs/research-prompts/R9/`
+- [x] Step 6a: removed all temporary `r9-*-draft.md` files from
+  `docs/prompt-improver-spec/final-prompts/`
+- [x] Validation: run targeted markdownlint on touched files
+- [x] Validation: run `git diff --check`
+- [x] Validation: verify no `r9-*-draft.md` files remain

--- a/docs/prompt-improver-spec/walkthrough.md
+++ b/docs/prompt-improver-spec/walkthrough.md
@@ -1,58 +1,71 @@
-# Walkthrough — Mister Smith MS-114 Packet-021 Contract-Freeze Handoff Prompt
+# Walkthrough — Mister Smith R9 Deep-Research Prompt Suite
 
 ## Original Prompt Summary
 
-The source request asked for two things:
+The source request asked for a fresh deep-research refresh in this repository, aimed at recent
+advancements in workflow, orchestration, coordination, and real-time inter-agent communication
+that are not already covered by the prior research corpus. The user explicitly wanted a series of
+markdown prompt documents, produced through the prompt-improver workflow and filtered through the
+Mister Smith frontier mandate.
 
-1. mirror packet `021` into Linear as issues/tasks/spec context
-2. create a new-session prompt, using the prompt-improver workflow, that initializes
-   implementation of the new packet
-
-The main prompt-design challenge was deciding what the receiving session should actually start on.
-Once the Linear packet structure existed, the honest answer was not the packet parent. It was the
-first runnable child issue: `MS-114`.
+The key design challenge was not whether to make more prompts. The repo already had substantial
+`R8` deep-research prompts. The real problem was to turn the documented corpus gaps into a new
+`R9` suite without duplicating the existing prompt batch or drifting into generic market scanning.
 
 ## Key Improvements Made
 
-- converted a broad "initialize this spec implementation" ask into a direct fresh-session handoff
-  for `MS-114`
-- grounded the prompt on the new tracker structure:
-  - parent packet `MS-113`
-  - first runnable slice `MS-114`
-  - attached Linear doc `Packet 021 spec packet`
-- made the contract artifact a first-class read instead of assuming the receiving agent would
-  infer it from `plan.md` or `tasks.md`
-- added explicit boundaries that keep the session out of `MS-115`, `MS-116`, `MS-117`, and
-  `MS-118`
-- kept the repo's Smith-first lifecycle, validation, and clean-closure requirements intact
+- converted a broad "catch me up" request into a concrete `R9` suite with five prompt owners and
+  one suite README
+- grounded every prompt in repo authority:
+  - `docs/current-state.md`
+  - `docs/research-output/ROUTING_MANIFEST.md`
+  - prompt-specific consolidated research docs
+- rebuilt the "already known" sections from `docs/research-output/*` instead of copying `R8`
+  baseline text
+- separated transport-level real-time communication from collaborative communication policy so
+  the suite does not collapse transport, protocol safety, and cognitive alignment into one prompt
+- added shared output requirements across the suite:
+  - frontier classification
+  - Mister Smith implementation vector
+  - production-validated vs research-only separation
+  - thin-results reporting
+  - contradictions to current assumptions
+- kept the frontier-first, anti-market-copying stance visible in each production prompt
 
 ## Before / After Comparison
 
-### Session target
+### Scope shape
 
-- Before: ambiguous between packet-parent initialization and first-slice implementation
-- After: explicitly targets `MS-114`, the first runnable contract-freeze slice
+- Before: one broad request that could have turned into a loose set of overlapping prompts
+- After: five production prompts with explicit overlap boundaries plus a README that explains the
+  run order
 
-### Contract grounding
+### Baseline authority
 
-- Before: could have treated the contract artifact as just one more packet file
-- After: the prompt requires the receiving agent to read and honor the published supervision
-  contract before editing code
+- Before: existing `R8` prompts could have been reused too literally
+- After: the suite treats `docs/research-output/*` as the hard "already discovered" boundary and
+  uses `R8` only as structural reference
 
-### Tracker integration
+### Output rigor
 
-- Before: "put it in Linear" did not yet give the next session actionable issue context
-- After: the prompt is anchored on the concrete Linear parent, child issue, attached packet doc,
-  and suggested branch name
+- Before: a research agent could return a generic update or a market-comparison memo
+- After: every prompt requires frontier taxonomy, implementation vectors, thin-results honesty,
+  and contradiction reporting
 
-## How To Use The Improved Prompt
+## How To Use The Improved Prompt Suite
 
-1. Start a fresh Codex session in `/Users/macmain/MisterSmith`.
-2. Paste the final prompt from the file below.
-3. Let the receiving agent execute `MS-114` end to end before moving to later packet-021 slices.
-4. Expect the receiving agent to keep repo and Linear state aligned and to stop at the contract
-   freeze boundary rather than widening into later packet work.
+1. Start with `docs/research-prompts/R9/README.md` to choose a run order.
+2. Run one prompt at a time with a deep-research agent that has live web access.
+3. Treat the prompt text as production-ready; the temporary drafts under
+   `docs/prompt-improver-spec/final-prompts/` are intentionally removed after finalization.
+4. Feed any resulting findings back into `docs/research-output/` rather than modifying the prompt
+   suite unless the baseline itself changes.
 
-## Final Prompt Location
+## Final Prompt Locations
 
-- `docs/prompt-improver-spec/final-prompts/mister-smith-ms-114-packet-021-contract-freeze-handoff.md`
+- `docs/research-prompts/R9/README.md`
+- `docs/research-prompts/R9/01-workflow-engines-compensation-and-resume.md`
+- `docs/research-prompts/R9/02-dynamic-orchestration-and-topology-control.md`
+- `docs/research-prompts/R9/03-coordination-protocols-shared-state-and-dynamic-verification.md`
+- `docs/research-prompts/R9/04-real-time-inter-agent-communication-and-transport.md`
+- `docs/research-prompts/R9/05-collaborative-communication-handoffs-and-cognitive-alignment.md`

--- a/docs/research-prompts/R9/01-workflow-engines-compensation-and-resume.md
+++ b/docs/research-prompts/R9/01-workflow-engines-compensation-and-resume.md
@@ -1,0 +1,187 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt
+tier: 1
+timeline: March 7, 2026 — present
+---
+
+# Deep Research Prompt: Workflow Engines, Compensation, and Resume Semantics
+
+## Context
+
+Mister Smith is a first-class multi-agent orchestration operating system in Rust, built on
+NATS/JetStream and Erlang OTP-inspired supervision trees. It is model-agnostic and designed to
+define the standard that the agent framework market will converge toward.
+
+Phases `1-10` are landed. The default runtime path now includes supervised planner and executor
+lifecycle management, ToolBus-backed execution boundaries, verifier-gated orchestration quality
+provenance, and bounded same-agent session handling. The current repo-wide state is routed through
+`docs/current-state.md`, and the research baseline is routed through the manifest and consolidated
+research corpus under `docs/research-output/`.
+
+**Fixed inputs**
+
+- `<baseline_boundary>`: March 7, 2026
+- `<search_window>`: March 7, 2026 to present
+- `<repo_state_router>`: `docs/current-state.md`
+- `<routing_manifest>`: `docs/research-output/ROUTING_MANIFEST.md`
+- `<baseline_docs>`:
+  - `docs/research-output/consolidated/00-MASTER-FINDINGS.md`
+  - `docs/research-output/consolidated/02-orchestration-and-self-organization.md`
+  - `docs/research-output/consolidated/03-supervision-and-resilience.md`
+  - `docs/research-output/consolidated/06-streaming-architecture.md`
+  - `docs/research-output/consolidated/08-competitive-landscape-and-ecosystem.md`
+
+Use the documents above as the authoritative baseline. `R8` is a structure reference only. Do not
+use prior prompt text as the source of truth for what is already known.
+
+## Frontier-First Mandate
+
+Do not choose an approach because it is popular, familiar, or already normalized by OpenAI Agents
+SDK, Google ADK, LangChain/LangGraph, CrewAI, AutoGen, Claude SDK, or similar systems. Benchmark
+them. Learn from them. Then exceed them.
+
+Pull from durable workflow engines, telecom transaction handling, distributed job control, payment
+reversal systems, exchange order lifecycles, operating systems, and actor-based recovery models
+when those fields offer stronger patterns for long-running workflow semantics.
+
+Reuse what is already correct. Do not reinvent primitives without benefit. But wherever the choice
+affects Mister Smith's execution, supervision, resumability, operator truth, or distributed
+behavior, prefer the architecture with the highest long-term leverage rather than the most
+conventional framework pattern.
+
+Incremental imitation is failure. Favor designs that create real advantage.
+
+## Research Objective
+
+Survey everything published from March 7, 2026 to the present on durable workflow execution,
+checkpoint/resume semantics, cancellation propagation, compensation patterns, reversible side
+effects, partial-failure recovery, workflow provenance, and long-running agent workflow state
+management.
+
+The goal is to discover what has changed since the current repo baseline and identify techniques
+that should influence how Mister Smith handles long-running execution beyond the current
+supervision, checkpoint, and streaming design.
+
+This is an open-ended research task. Go beyond the dimensions below if you discover strong leads.
+
+**Older-source rule**: include older sources only if they are absent from the current repo
+baseline and materially change the design direction.
+
+## What Has Already Been Researched (Baseline — Do Not Rediscover)
+
+The current research corpus already establishes a strong substrate but admits a workflow-semantics
+gap. Mister Smith's baseline already includes supervised actor lifecycles, per-workflow checkpoint
+streams, contextual rollback signals, circuit breakers, Saga-style compensation as a useful
+reference pattern, and a separation between transient, structural, streaming, and semantic failure
+classes. It already treats checkpoint streams, role-aware supervision, and stream finalization as
+foundational components for reliable runtime behavior.
+
+At the same time, the repo's consolidated findings explicitly say the field is stronger on
+topology selection and failure detection than on workflow semantics. The current orchestration
+synthesis admits there is still **no concrete taxonomy for LLM tool reversibility or compensation
+patterns** across common side-effect types. The supervision synthesis also leaves several workflow
+questions open: how partial streams are resumed per provider, how durable circuit-breaker state
+should be stored, and how restart semantics interact with partial progress and external side
+effects.
+
+The baseline already treats the following as known:
+
+- supervised actors plus durable checkpoints are the current foundation
+- restart alone is insufficient when side effects or semantic degradation are involved
+- Saga-like compensation is promising but incomplete as a full workflow model
+- contextual rollback and failure provenance matter for recovery honesty
+- the current literature leaves compensation, reversible tool taxonomies, and workflow transaction
+  semantics under-specified
+
+Do not rediscover those findings. Only surface new work that materially contradicts, sharpens, or
+extends them.
+
+## Research Dimensions
+
+### 1. Durable Workflow Engines for Agent Systems
+
+- What new workflow-engine architectures or execution models have appeared for long-running agent
+  workflows?
+- Are there new systems that combine durable execution with actor supervision instead of choosing
+  one model over the other?
+- What production reports exist for pause/resume, checkpoint, and crash recovery in agent
+  workflows?
+
+### 2. Compensation and Reversible Side-Effect Design
+
+- What new research or production patterns exist for compensation in tool-heavy agent workflows?
+- Has anyone published a practical taxonomy for reversible vs. irreversible tool actions?
+- Are there stronger compensation patterns from workflow engines, payments, trading, telecom, or
+  distributed transaction systems that transfer cleanly to agent systems?
+
+### 3. Checkpoint, Resume, and Partial Commit Semantics
+
+- What new checkpointing, rehydration, or partial-commit models exist for multi-agent workflows
+  with streaming state?
+- Are there better ways to resume from partially completed tool execution or partial model streams?
+- How do newer systems separate recoverable state from non-recoverable side effects?
+
+### 4. Cancellation, Timeouts, and Failure Propagation
+
+- What advances exist in cancellation propagation across multi-step or multi-agent workflows?
+- Are there new structured-concurrency or supervisory models for long-running AI workflows?
+- How do modern systems decide when to abort, retry, degrade, or compensate instead of
+  restarting?
+
+### 5. Workflow Provenance and Operator Truth
+
+- What new patterns exist for operator-visible workflow state, compensation history, and resume
+  provenance?
+- Are there better models for exposing partial completion, unresolved side effects, and degraded
+  recovery to operators?
+- What evidence exists that stronger workflow provenance changes reliability or operator trust?
+
+### 6. Adjacent-Field Transfer
+
+- What should Mister Smith learn from Temporal, Cadence, Erlang release handling, telecom call
+  flows, exchange order lifecycles, and payment reversals?
+- Which of those patterns remain underused in agent frameworks despite strong production evidence?
+
+## Per-Dimension Output Structure
+
+For each research dimension, provide:
+
+1. **Current state of the art** — what exists today, with specific citations
+2. **Key techniques** — the concrete workflow, resume, or compensation patterns discovered
+3. **Applicability to Rust + NATS + OTP** — how well the pattern transfers to Mister Smith
+4. **Delta from baseline** — what is genuinely new versus the repo's current research corpus
+5. **Frontier classification** — classify the finding as `EXTEND`, `TRANSFORM`, or `NEW`, and
+   also as `FRONTIER` or `INCREMENTAL`
+6. **Mister Smith implementation vector** — name the likely crates, runtime surfaces, or spec
+   areas affected; prefer concrete repo surfaces such as `mister-smith-supervision`,
+   `mister-smith-agents`, `mister-smith-llm`, `mister-smith-persistence`, `mister-smith-core`,
+   `mister-smith-events`, `mister-smith-app`, or `specs/021-*`
+7. **Evidence status** — classify the finding as `production-validated` or `research-only`
+8. **Implementation complexity** — rough effort, prerequisites, and operational risk
+
+## Synthesis
+
+After completing all dimensions, provide a synthesis that:
+
+- ranks the top 5 findings by strategic value for Mister Smith
+- identifies **contradictions to current assumptions** in the repo baseline
+- separates findings into:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+- recommends which findings should be prototyped, benchmarked, adopted, or only monitored
+- names the likely Mister Smith implementation vectors for the highest-value findings
+- clearly states where the literature remains weak instead of padding with speculative filler
+
+## Research Methodology
+
+1. Read the baseline docs named above before searching.
+2. Search broadly across March 7, 2026 to present. Include papers, releases, design docs,
+   postmortems, benchmarks, and production engineering reports.
+3. Look beyond agent frameworks into workflow engines, durable execution systems, telecom,
+   trading, and transactional distributed systems.
+4. Prefer evidence about real checkpointing, cancellation, resume, and compensation behavior over
+   generic framework marketing.
+5. If a topic yields thin results, say so directly rather than padding.

--- a/docs/research-prompts/R9/02-dynamic-orchestration-and-topology-control.md
+++ b/docs/research-prompts/R9/02-dynamic-orchestration-and-topology-control.md
@@ -1,0 +1,177 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt
+tier: 1
+timeline: March 7, 2026 — present
+---
+
+# Deep Research Prompt: Dynamic Orchestration and Topology Control
+
+## Context
+
+Mister Smith is a first-class multi-agent orchestration operating system in Rust, built on
+NATS/JetStream and Erlang OTP-inspired supervision trees. It is model-agnostic and designed to
+define the standard that the agent framework market will converge toward.
+
+Phases `1-10` are landed, and the current runtime path already includes verifier-gated
+orchestration-quality provenance, supervised planner/executor lifecycles, and a bounded
+profile-aware supervision packet frozen as `specs/021-profile-aware-predictive-runtime-supervision/`.
+The repo baseline already says topology selection, dynamic orchestration, and self-organization are
+major frontier surfaces. This prompt asks what has changed since the March 7, 2026 baseline.
+
+**Fixed inputs**
+
+- `<baseline_boundary>`: March 7, 2026
+- `<search_window>`: March 7, 2026 to present
+- `<repo_state_router>`: `docs/current-state.md`
+- `<routing_manifest>`: `docs/research-output/ROUTING_MANIFEST.md`
+- `<baseline_docs>`:
+  - `docs/research-output/consolidated/00-MASTER-FINDINGS.md`
+  - `docs/research-output/consolidated/01-model-routing-and-cost-optimization.md`
+  - `docs/research-output/consolidated/02-orchestration-and-self-organization.md`
+  - `docs/research-output/consolidated/03-supervision-and-resilience.md`
+  - `docs/research-output/consolidated/08-competitive-landscape-and-ecosystem.md`
+
+Use those documents as the authoritative baseline. `R8` is a structure reference only.
+
+## Frontier-First Mandate
+
+Do not choose an approach because it is popular, familiar, or already normalized by OpenAI Agents
+SDK, Google ADK, LangChain/LangGraph, CrewAI, AutoGen, Claude SDK, or similar systems. Benchmark
+them. Learn from them. Then exceed them.
+
+Pull from actor systems, adaptive control, distributed schedulers, swarm coordination, mechanism
+design, and network topology optimization when those fields offer stronger orchestration patterns.
+
+Reuse what is already correct. Do not reinvent primitives without benefit. But wherever the choice
+affects Mister Smith's coordination, execution, supervision, routing, or distributed behavior,
+prefer the architecture with the highest long-term leverage over the most conventional framework
+shape.
+
+Incremental imitation is failure. Favor designs that create real advantage.
+
+## Research Objective
+
+Survey everything published from March 7, 2026 to the present on dynamic orchestration, topology
+compilers, safe adaptive team shaping, decentralized DAG control, meta-orchestration, and
+resource-aware topology reshaping.
+
+The goal is to identify what has changed since the current baseline and discover which developments
+should affect Mister Smith's next orchestration iteration beyond the current findings on MaAS,
+AutoMaAS, MAS^2, AdaptOrch, AgentNet, FoA, DynTaskMAS, and RL puppeteers.
+
+This is an open-ended research task. Go beyond the dimensions below if you discover strong leads.
+
+**Older-source rule**: include older sources only if they are absent from the current repo
+baseline and materially change the design direction.
+
+## What Has Already Been Researched (Baseline — Do Not Rediscover)
+
+The current research corpus already concludes that static, centralized, fixed-topology
+orchestration is a dead end for serious multi-agent systems. The consolidated orchestration
+synthesis says topology is now a stronger performance lever than raw model capability, that
+decentralized coordination scales better than centralized schedulers once the agent count rises,
+and that meta-orchestration is the leading frontier. The baseline already covers MaAS, AutoMaAS,
+MAS^2, AdaptOrch, AgentNet, FoA, DynTaskMAS, RL puppeteers, and the rough centralized scaling
+ceiling around the mid-teens to low-twenties agent count.
+
+The baseline also already exposes the hardest unresolved orchestration seams:
+
+- no paper cleanly reconciles decentralized, agent-initiated DAG evolution with hierarchical OTP
+  supervision trees
+- production evidence for meta-orchestration remains thin relative to academic enthusiasm
+- adversarial robustness under decentralized coordination remains underdeveloped
+- trust calibration and runtime control policies are still weaker than the topology literature
+
+Treat the following as already known:
+
+- topology control is a first-class systems problem, not a cosmetic framework feature
+- learned or adaptive orchestration is more promising than fixed role graphs
+- decentralized DAG control is attractive but still under-verified in production
+- the interesting question is not whether MaAS-like ideas exist, but what has changed after them
+
+Only surface work that materially contradicts, sharpens, or extends that baseline.
+
+## Research Dimensions
+
+### 1. Safe Adaptive Topology Control
+
+- What new work exists on topology compilers or runtime topology reshaping that preserve safety,
+  budget, or latency constraints?
+- Are there stronger approaches for guaranteeing that adaptive orchestration stays within bounded
+  resource and policy envelopes?
+
+### 2. Decentralized DAGs and Hierarchical Supervision
+
+- Has any new research reconciled decentralized DAG evolution with hierarchical restart and
+  recovery models?
+- What patterns exist for restarting, reconfiguring, or isolating one part of an evolving DAG
+  without destabilizing the rest?
+
+### 3. Meta-Orchestration After MaAS and MAS^2
+
+- Have newer architecture-search or self-generating orchestration systems surpassed the current
+  MaAS, AutoMaAS, or MAS^2 baseline?
+- Are there newer search-space representations, controller designs, or safety constraints that
+  materially improve the frontier?
+
+### 4. Resource-Aware and Failure-Aware Topology Reshaping
+
+- What new evidence exists on changing topologies under budget pressure, provider degradation, or
+  partial failure?
+- Are there production systems that reshape teams dynamically in response to runtime conditions?
+
+### 5. Production Evidence and Scaling Law Updates
+
+- What new production reports, benchmarks, or postmortems exist for adaptive orchestration at
+  meaningful scale?
+- Has the prior centralized ceiling or the "more agents hurts sequential tasks" thesis been
+  replicated, refined, or contradicted?
+
+### 6. Adjacent-Field Transfer
+
+- What should Mister Smith borrow from telecom switching, distributed schedulers, autonomous
+  vehicle mission planners, or exchange routing systems for topology control?
+- Which strong adjacent-field patterns are still absent from agent frameworks?
+
+## Per-Dimension Output Structure
+
+For each research dimension, provide:
+
+1. **Current state of the art** — what exists today, with specific citations
+2. **Key techniques** — the concrete orchestration or topology-control mechanisms discovered
+3. **Applicability to Rust + NATS + OTP** — how well the pattern transfers to Mister Smith
+4. **Delta from baseline** — what is genuinely new versus the repo's current research corpus
+5. **Frontier classification** — classify the finding as `EXTEND`, `TRANSFORM`, or `NEW`, and
+   also as `FRONTIER` or `INCREMENTAL`
+6. **Mister Smith implementation vector** — name the likely crates, runtime surfaces, or spec
+   areas affected; prefer concrete repo surfaces such as `mister-smith-agents`,
+   `mister-smith-supervision`, `mister-smith-llm`, `mister-smith-core`,
+   `mister-smith-persistence`, `mister-smith-app`, or `specs/021-*`
+7. **Evidence status** — classify the finding as `production-validated` or `research-only`
+8. **Implementation complexity** — rough effort, prerequisites, and risk
+
+## Synthesis
+
+After completing all dimensions, provide a synthesis that:
+
+- ranks the top 5 findings by strategic value for Mister Smith's orchestration layer
+- identifies **contradictions to current assumptions** in the repo baseline
+- separates findings into:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+- recommends which findings should be prototyped, benchmarked, adopted, or only monitored
+- names the likely implementation vectors for the highest-value findings
+- clearly states where the literature remains weak instead of padding with speculation
+
+## Research Methodology
+
+1. Read the baseline docs named above before searching.
+2. Search broadly across March 7, 2026 to present. Include papers, releases, benchmarks,
+   production reports, and postmortems.
+3. Follow promising leads into control theory, telecom, distributed schedulers, and swarm
+   coordination research.
+4. Distinguish academic promise from production evidence.
+5. If a topic yields thin results, say so directly rather than padding.

--- a/docs/research-prompts/R9/03-coordination-protocols-shared-state-and-dynamic-verification.md
+++ b/docs/research-prompts/R9/03-coordination-protocols-shared-state-and-dynamic-verification.md
@@ -1,0 +1,170 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt
+tier: 1
+timeline: March 7, 2026 — present
+---
+
+# Deep Research Prompt: Coordination Protocols, Shared State, and Dynamic Verification
+
+## Context
+
+Mister Smith is a first-class multi-agent orchestration operating system in Rust, built on
+NATS/JetStream and Erlang OTP-inspired supervision trees. It is model-agnostic and designed to
+define the standard that the agent framework market will converge toward.
+
+The current coordination baseline already uses a three-tier substrate in the research corpus:
+delta-CRDTs for shared artifacts, JetStream KV CAS for strict invariants, and NATS request-reply
+for ephemeral routing. The repo also already identifies MPST and Rust session typing as a possible
+compile-time differentiator. This prompt asks what has changed since that March 7, 2026 baseline.
+
+**Fixed inputs**
+
+- `<baseline_boundary>`: March 7, 2026
+- `<search_window>`: March 7, 2026 to present
+- `<repo_state_router>`: `docs/current-state.md`
+- `<routing_manifest>`: `docs/research-output/ROUTING_MANIFEST.md`
+- `<baseline_docs>`:
+  - `docs/research-output/consolidated/00-MASTER-FINDINGS.md`
+  - `docs/research-output/consolidated/04-security-and-trust.md`
+  - `docs/research-output/consolidated/05-coordination-and-state.md`
+  - `docs/research-output/consolidated/08-competitive-landscape-and-ecosystem.md`
+
+Use those documents as the authoritative baseline. `R8` is a structure reference only.
+
+## Frontier-First Mandate
+
+Do not choose an approach because it is popular, familiar, or already normalized by OpenAI Agents
+SDK, Google ADK, LangChain/LangGraph, CrewAI, AutoGen, Claude SDK, or similar systems. Benchmark
+them. Learn from them. Then exceed them.
+
+Pull from distributed databases, process algebra, formal methods, programming-language theory,
+leaderless coordination, and safety-critical protocol design when those fields offer stronger
+coordination or verification primitives.
+
+Reuse what is already correct. Do not reinvent primitives without benefit. But wherever the choice
+affects Mister Smith's coordination, shared-state correctness, security, or distributed behavior,
+prefer the architecture with the highest long-term leverage rather than the most conventional
+agent-framework pattern.
+
+Incremental imitation is failure. Favor designs that create real advantage.
+
+## Research Objective
+
+Survey everything published from March 7, 2026 to the present on CRDT coordination, shared-state
+security, dynamic session typing, evolving protocol verification, event-triggered consensus,
+semantic conflict handling, and coordination correctness under dynamic topologies.
+
+The goal is to discover what has changed since the repo's coordination baseline and identify
+techniques that should influence Mister Smith's coordination and verification layers.
+
+This is an open-ended research task. Go beyond the dimensions below if you discover strong leads.
+
+**Older-source rule**: include older sources only if they are absent from the current repo
+baseline and materially change the direction.
+
+## What Has Already Been Researched (Baseline — Do Not Rediscover)
+
+The current corpus already accepts a hybrid coordination model. CRDTs are already treated as
+useful for shared artifacts but insufficient for invariants. CodeCRDT-style evidence already
+establishes syntactic convergence plus residual semantic conflicts. The baseline also already
+documents CRDT metadata growth, snapshot and rehydration uncertainty, event-triggered consensus as
+promising but under-tuned for LLM agents, and shared-state infection risk from adversarial inputs.
+
+On the verification side, the repo already knows that MPST and Rust session-type libraries are a
+unique potential differentiator for compile-time protocol safety, but also that dynamic topology,
+join/leave behavior, and evolving DAG verification remain unresolved. The security synthesis
+explicitly calls out **formal verification of dynamic agent topologies** as an open problem.
+
+Treat the following as already known:
+
+- CRDTs help with coordination but do not solve semantic correctness by themselves
+- MPST is strong for static protocols, weak for dynamic participation
+- event-triggered consensus is promising but under-characterized for stochastic LLM-agent state
+- shared-state coordination carries an explicit security cost and needs semantic firewalls
+
+Do not rediscover those findings. Only surface work that materially contradicts, sharpens, or
+extends them.
+
+## Research Dimensions
+
+### 1. Dynamic Session Types and Protocol Evolution
+
+- What new work exists on session typing or protocol verification for systems where participants
+  join, leave, or reshape protocols at runtime?
+- Are there stronger hybrid compile-time plus runtime techniques for dynamically evolving
+  multi-agent protocols?
+
+### 2. Shared-State Coordination Beyond the Current CRDT Baseline
+
+- Have new CRDT variants, dissemination methods, or semantic-conflict approaches appeared that are
+  relevant to agent coordination?
+- What has changed on garbage collection, snapshotting, and rehydration?
+
+### 3. Formal Verification of Evolving DAGs and Agent Choreographies
+
+- What new tools or methods exist for verifying dynamically changing agent workflows?
+- Are there new TLA+, Alloy, refinement-type, liquid-type, or runtime-verification approaches
+  suited to this problem?
+
+### 4. Event-Triggered and Leaderless Coordination
+
+- What new consensus-free or leaderless coordination primitives have emerged?
+- Are there better thresholding or signaling models for stochastic LLM-agent state than the older
+  event-triggered consensus work?
+
+### 5. Shared-State Infection Controls and Semantic Firewalls
+
+- What new techniques exist for securing shared coordination substrates against adversarial state
+  injection?
+- Are there new formal or runtime approaches for separating safe shared state from prompt-facing
+  state?
+
+### 6. Rust Ecosystem and Production Transfer
+
+- What new Rust libraries, implementation reports, or production systems affect dynamic
+  verification and coordination safety?
+- Has any production system demonstrated techniques that could transfer directly into Mister Smith?
+
+## Per-Dimension Output Structure
+
+For each research dimension, provide:
+
+1. **Current state of the art** — what exists today, with specific citations
+2. **Key techniques** — the concrete coordination or verification mechanisms discovered
+3. **Applicability to Rust + NATS + OTP** — how well the pattern transfers to Mister Smith
+4. **Delta from baseline** — what is genuinely new versus the repo's current research corpus
+5. **Frontier classification** — classify the finding as `EXTEND`, `TRANSFORM`, or `NEW`, and
+   also as `FRONTIER` or `INCREMENTAL`
+6. **Mister Smith implementation vector** — name the likely crates, runtime surfaces, or spec
+   areas affected; prefer concrete repo surfaces such as `mister-smith-nats`,
+   `mister-smith-supervision`, `mister-smith-core`, `mister-smith-events`,
+   `mister-smith-persistence`, `mister-smith-agents`, `mister-smith-mcp`, or `spec/`
+7. **Evidence status** — classify the finding as `production-validated` or `research-only`
+8. **Implementation complexity** — rough effort, prerequisites, and risk
+
+## Synthesis
+
+After completing all dimensions, provide a synthesis that:
+
+- ranks the top 5 findings by strategic value for Mister Smith's coordination and verification
+  layers
+- identifies **contradictions to current assumptions** in the repo baseline
+- separates findings into:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+- recommends which findings should be prototyped, benchmarked, adopted, or only monitored
+- names the likely implementation vectors for the strongest findings
+- clearly states where the literature remains weak instead of padding with speculation
+
+## Research Methodology
+
+1. Read the baseline docs named above before searching.
+2. Search broadly across March 7, 2026 to present. Include papers, releases, crate updates,
+   engineering reports, and standards work.
+3. Look beyond agent frameworks into distributed databases, PL theory, formal methods, and
+   process-algebra communities.
+4. Distinguish production-ready techniques from mathematically elegant but immature ones.
+5. If a topic yields thin results, say so directly rather than padding.

--- a/docs/research-prompts/R9/04-real-time-inter-agent-communication-and-transport.md
+++ b/docs/research-prompts/R9/04-real-time-inter-agent-communication-and-transport.md
@@ -1,0 +1,176 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt
+tier: 1
+timeline: March 7, 2026 — present
+---
+
+# Deep Research Prompt: Real-Time Inter-Agent Communication and Transport
+
+## Context
+
+Mister Smith is a first-class multi-agent orchestration operating system in Rust, built on
+NATS/JetStream and Erlang OTP-inspired supervision trees. It is model-agnostic and designed to
+define the standard that the agent framework market will converge toward.
+
+The current research corpus already concludes that streaming is not a presentation detail but a
+control-plane surface for coordination, failure detection, and routing. The repo already has strong
+baseline work on typed stream events, actor-per-stream supervision, JetStream pull consumers,
+backpressure, dual-stream designs, and external protocol awareness. This prompt asks what has
+changed since the March 7, 2026 baseline, especially for real-time inter-agent communication.
+
+**Fixed inputs**
+
+- `<baseline_boundary>`: March 7, 2026
+- `<search_window>`: March 7, 2026 to present
+- `<repo_state_router>`: `docs/current-state.md`
+- `<routing_manifest>`: `docs/research-output/ROUTING_MANIFEST.md`
+- `<baseline_docs>`:
+  - `docs/research-output/consolidated/00-MASTER-FINDINGS.md`
+  - `docs/research-output/consolidated/05-coordination-and-state.md`
+  - `docs/research-output/consolidated/06-streaming-architecture.md`
+  - `docs/research-output/consolidated/07-memory-and-context.md`
+  - `docs/research-output/consolidated/08-competitive-landscape-and-ecosystem.md`
+
+Use those documents as the authoritative baseline. `R8` is a structure reference only.
+
+## Frontier-First Mandate
+
+Do not choose an approach because it is popular, familiar, or already normalized by OpenAI Agents
+SDK, Google ADK, LangChain/LangGraph, CrewAI, AutoGen, Claude SDK, or similar systems. Benchmark
+them. Learn from them. Then exceed them.
+
+Pull from real-time messaging, telecom, high-frequency trading, RTC systems, multiplayer game
+networking, QUIC/HTTP3 transports, and distributed stream-processing systems when those fields
+offer stronger communication patterns.
+
+Reuse what is already correct. Do not reinvent primitives without benefit. But wherever the choice
+affects Mister Smith's streaming, routing, latency control, coordination, or distributed behavior,
+prefer the architecture with the highest long-term leverage rather than the most conventional
+framework transport.
+
+Incremental imitation is failure. Favor designs that create real advantage.
+
+## Research Objective
+
+Survey everything published from March 7, 2026 to the present on real-time inter-agent transport,
+bidirectional streaming, backpressure, stream multiplexing, QoS, session resumption, transport
+protocol evolution, and transport adapters bridging A2A, MCP, WebMCP, QUIC/HTTP3, WebSocket/SSE,
+and NATS-style messaging.
+
+The goal is to discover what has changed since the repo's streaming and protocol baseline and
+identify techniques that should influence Mister Smith's real-time communication architecture.
+
+This is an open-ended research task. Go beyond the dimensions below if you discover strong leads.
+
+**Older-source rule**: include older sources only if they are absent from the current repo
+baseline and materially change the direction.
+
+## What Has Already Been Researched (Baseline — Do Not Rediscover)
+
+The current research corpus already says Mister Smith should model streaming as typed event
+pipelines managed by supervised actors, not raw text chunking. It already covers actor-per-stream,
+stream finalizers, bounded in-process backpressure, JetStream pull consumers for distributed
+backpressure, dual-stream designs, fan-in via `StreamMap`, and the broad tradeoffs of SSE versus
+WebSocket. It also already treats A2A and MCP as important protocol standards and recognizes
+WebMCP, QUIC/HTTP3-adjacent surfaces, and shared KV cache routing as meaningful future areas.
+
+The baseline open questions are transport-specific and operational:
+
+- provider-side backpressure behavior remains unclear
+- numeric backpressure defaults are uncalibrated
+- JetStream flow-control stall modes still need empirical characterization
+- model-agnostic provider abstractions with streaming backpressure remain open
+- real-time communication semantics across heterogeneous protocols remain thinner than the stream
+  pipeline design itself
+
+Treat the following as already known:
+
+- typed supervised streaming is the correct baseline architecture
+- backpressure is a first-class systems problem
+- real-time agent communication is broader than parsing SSE chunks
+- protocol evolution matters because Mister Smith should speak external standards without copying
+  their internal architecture
+
+Do not rediscover those findings. Only surface work that materially contradicts, sharpens, or
+extends them.
+
+## Research Dimensions
+
+### 1. Bidirectional and Multiplexed Agent Communication
+
+- What new transport patterns exist for agent-to-agent bidirectional streaming and stream
+  multiplexing?
+- Are there newer approaches for merging or routing many live sub-agent streams with correctness
+  guarantees?
+
+### 2. Backpressure, Flow Control, and QoS
+
+- What new work exists on backpressure for long-running AI or agent streams?
+- Are there stronger QoS, fairness, or prioritization models for mixed-priority agent traffic?
+- Has anything changed on provider-side or transport-side handling when consumers slow down?
+
+### 3. Session Resumption, Recovery, and Transport-Level Resume
+
+- What new techniques exist for resuming interrupted real-time streams or live sessions?
+- Are there stronger transport-level recovery models for partially completed streams or tool calls?
+
+### 4. Protocol Evolution and Adapter Design
+
+- What has changed in A2A, MCP, WebMCP, QUIC/HTTP3, WebSocket, SSE, or related protocol work
+  that materially affects agent communication architecture?
+- Are there new adapter patterns for bridging heterogeneous protocols into one internal event
+  model?
+
+### 5. Adjacent-Field Transfer
+
+- What should Mister Smith borrow from telecom signaling, exchange routing, RTC, and multiplayer
+  networking for real-time agent communication?
+- Which proven communication patterns remain absent from mainstream agent frameworks?
+
+### 6. Production Evidence and Failure Modes
+
+- What new production reports or postmortems exist for real-time multi-agent communication?
+- What transport-level failure modes, congestion patterns, or coordination bugs have surfaced in
+  real deployments?
+
+## Per-Dimension Output Structure
+
+For each research dimension, provide:
+
+1. **Current state of the art** — what exists today, with specific citations
+2. **Key techniques** — the concrete transport or communication mechanisms discovered
+3. **Applicability to Rust + NATS + OTP** — how well the pattern transfers to Mister Smith
+4. **Delta from baseline** — what is genuinely new versus the repo's current research corpus
+5. **Frontier classification** — classify the finding as `EXTEND`, `TRANSFORM`, or `NEW`, and
+   also as `FRONTIER` or `INCREMENTAL`
+6. **Mister Smith implementation vector** — name the likely crates, runtime surfaces, or spec
+   areas affected; prefer concrete repo surfaces such as `mister-smith-nats`,
+   `mister-smith-llm`, `mister-smith-core`, `mister-smith-events`, `mister-smith-app`,
+   `mister-smith-mcp`, or `apps/operator-console/`
+7. **Evidence status** — classify the finding as `production-validated` or `research-only`
+8. **Implementation complexity** — rough effort, prerequisites, and risk
+
+## Synthesis
+
+After completing all dimensions, provide a synthesis that:
+
+- ranks the top 5 findings by strategic value for Mister Smith's transport and communication layer
+- identifies **contradictions to current assumptions** in the repo baseline
+- separates findings into:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+- recommends which findings should be prototyped, benchmarked, adopted, or only monitored
+- names the likely implementation vectors for the strongest findings
+- clearly states where the literature remains weak instead of padding with speculation
+
+## Research Methodology
+
+1. Read the baseline docs named above before searching.
+2. Search broadly across March 7, 2026 to present. Include papers, standards updates, releases,
+   postmortems, and engineering reports.
+3. Follow promising leads into telecom, RTC, trading, and real-time distributed systems.
+4. Distinguish protocol headlines from evidence that actually changes transport architecture.
+5. If a topic yields thin results, say so directly rather than padding.

--- a/docs/research-prompts/R9/05-collaborative-communication-handoffs-and-cognitive-alignment.md
+++ b/docs/research-prompts/R9/05-collaborative-communication-handoffs-and-cognitive-alignment.md
@@ -1,0 +1,176 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt
+tier: 1
+timeline: March 7, 2026 — present
+---
+
+# Deep Research Prompt: Collaborative Communication, Handoffs, and Cognitive Alignment
+
+## Context
+
+Mister Smith is a first-class multi-agent orchestration operating system in Rust, built on
+NATS/JetStream and Erlang OTP-inspired supervision trees. It is model-agnostic and designed to
+define the standard that the agent framework market will converge toward.
+
+The current research corpus already contains strong findings on predictive supervision, cognitive
+coordination, offline agent fingerprints, clarification modules, and anti-groupthink mechanisms.
+What remains less settled is the live policy layer: how agents should communicate with each other
+under uncertainty, how handoffs should be clarified, how trust should be calibrated, and how
+shared mental models should be maintained in real deployments. This prompt asks what has changed
+since the March 7, 2026 baseline.
+
+**Fixed inputs**
+
+- `<baseline_boundary>`: March 7, 2026
+- `<search_window>`: March 7, 2026 to present
+- `<repo_state_router>`: `docs/current-state.md`
+- `<routing_manifest>`: `docs/research-output/ROUTING_MANIFEST.md`
+- `<baseline_docs>`:
+  - `docs/research-output/consolidated/00-MASTER-FINDINGS.md`
+  - `docs/research-output/consolidated/02-orchestration-and-self-organization.md`
+  - `docs/research-output/consolidated/03-supervision-and-resilience.md`
+  - `docs/research-output/consolidated/07-memory-and-context.md`
+
+Use those documents as the authoritative baseline. `R8` is a structure reference only.
+
+## Frontier-First Mandate
+
+Do not choose an approach because it is popular, familiar, or already normalized by OpenAI Agents
+SDK, Google ADK, LangChain/LangGraph, CrewAI, AutoGen, Claude SDK, or similar systems. Benchmark
+them. Learn from them. Then exceed them.
+
+Pull from cognitive science, crew resource management, negotiation theory, organizational design,
+shared-mental-model research, collaborative robotics, and distributed cognition when those fields
+offer stronger communication patterns.
+
+Reuse what is already correct. Do not reinvent primitives without benefit. But wherever the choice
+affects Mister Smith's coordination, supervision, memory, communication quality, or distributed
+behavior, prefer the architecture with the highest long-term leverage rather than the most familiar
+agent-framework pattern.
+
+Incremental imitation is failure. Favor designs that create real advantage.
+
+## Research Objective
+
+Survey everything published from March 7, 2026 to the present on collaborative communication
+policies, handoff clarification, team formation negotiation, trust calibration, shared mental
+models, joint attention, anti-conformity mechanisms, and cognitive alignment in multi-agent
+systems.
+
+The goal is to discover what has changed since the current baseline on cognitive coordination and
+identify techniques that should influence Mister Smith's live communication policies between
+agents.
+
+This is an open-ended research task. Go beyond the dimensions below if you discover strong leads.
+
+**Older-source rule**: include older sources only if they are absent from the current repo
+baseline and materially change the direction.
+
+## What Has Already Been Researched (Baseline — Do Not Rediscover)
+
+The current research corpus already includes strong findings on predictive supervision and
+cognitive coordination. It already covers AWorld-style offline agent fingerprints, OSC
+Collaborator Knowledge Models, adaptive communication policies for cognitive gap analysis,
+anti-conformity mechanisms such as Bayesian Truth Serum and Peer Prediction, and AgentAsk-style
+clarification at inter-agent handoffs. The memory synthesis also already identifies joint
+attention, provenance, and collaborative memory as part of coordination quality rather than
+separate concerns.
+
+What remains unresolved is not whether communication quality matters, but how newer work changes
+the policy surface. The baseline still treats several important questions as open:
+
+- whether online cognitive modeling can be made practical
+- how trust calibration generalizes across heterogeneous agents, tools, and models
+- what production evidence exists for collaborative communication policies
+- whether stronger handoff or negotiation structures have appeared since the March baseline
+
+Treat the following as already known:
+
+- collaborative communication policy matters as much as raw transport
+- anti-groupthink and clarification mechanisms are necessary, not cosmetic
+- current evidence is stronger for offline or simulated settings than for live production
+  deployments
+- provenance and shared memory are part of communication quality
+
+Do not rediscover those findings. Only surface work that materially contradicts, sharpens, or
+extends them.
+
+## Research Dimensions
+
+### 1. Handoff Clarification and Ambiguity Arrest
+
+- What new work exists on detecting ambiguity at inter-agent handoffs?
+- Are there stronger clarification-loop policies than the current AgentAsk-style baseline?
+
+### 2. Shared Mental Models and Joint Attention
+
+- What has changed in collaborative cognition, shared mental-model maintenance, or joint attention
+  for multi-agent systems?
+- Are there more practical models than the current CKM-heavy approaches?
+
+### 3. Trust Calibration and Confidence Communication
+
+- What new techniques exist for calibrating trust across heterogeneous agents, models, or tools?
+- Are there better ways for agents to communicate uncertainty, competence, or confidence to peers?
+
+### 4. Anti-Conformity, Debate Quality, and Groupthink Prevention
+
+- What new evidence exists on preventing groupthink while preserving effective coordination?
+- Are there stronger mechanisms than the current anti-conformity and review-pipeline patterns?
+
+### 5. Team Formation, Negotiation, and Communication Policy
+
+- What new work exists on negotiation-based team formation, role negotiation, or live communication
+  contracts between agents?
+- Are there practical communication protocols that improve collaboration without heavy training
+  infrastructure?
+
+### 6. Production Evidence and Adjacent-Field Transfer
+
+- What production reports exist for collaborative communication policies in real multi-agent
+  systems?
+- What should Mister Smith borrow from aviation CRM, emergency response coordination, military
+  mission command, collaborative robotics, or organizational communication systems?
+
+## Per-Dimension Output Structure
+
+For each research dimension, provide:
+
+1. **Current state of the art** — what exists today, with specific citations
+2. **Key techniques** — the concrete communication or alignment mechanisms discovered
+3. **Applicability to Rust + NATS + OTP** — how well the pattern transfers to Mister Smith
+4. **Delta from baseline** — what is genuinely new versus the repo's current research corpus
+5. **Frontier classification** — classify the finding as `EXTEND`, `TRANSFORM`, or `NEW`, and
+   also as `FRONTIER` or `INCREMENTAL`
+6. **Mister Smith implementation vector** — name the likely crates, runtime surfaces, or spec
+   areas affected; prefer concrete repo surfaces such as `mister-smith-agents`,
+   `mister-smith-supervision`, `mister-smith-core`, `mister-smith-events`,
+   `mister-smith-persistence`, `mister-smith-app`, or `specs/021-*`
+7. **Evidence status** — classify the finding as `production-validated` or `research-only`
+8. **Implementation complexity** — rough effort, prerequisites, and risk
+
+## Synthesis
+
+After completing all dimensions, provide a synthesis that:
+
+- ranks the top 5 findings by strategic value for Mister Smith's collaborative communication layer
+- identifies **contradictions to current assumptions** in the repo baseline
+- separates findings into:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+- recommends which findings should be prototyped, benchmarked, adopted, or only monitored
+- names the likely implementation vectors for the strongest findings
+- clearly states where the literature remains weak instead of padding with speculation
+
+## Research Methodology
+
+1. Read the baseline docs named above before searching.
+2. Search broadly across March 7, 2026 to present. Include papers, production reports, releases,
+   and adjacent-field literature.
+3. Look beyond agent frameworks into organizational communication, aviation CRM, robotics, and
+   distributed cognition research.
+4. Distinguish promising lab results from production evidence.
+5. If a topic yields thin results, say so directly rather than padding.

--- a/docs/research-prompts/R9/README.md
+++ b/docs/research-prompts/R9/README.md
@@ -1,0 +1,113 @@
+---
+version: R9
+created: 2026-03-28
+type: prompt-suite
+---
+
+# Mister Smith R9 Deep-Research Prompt Suite
+
+## Purpose
+
+This directory contains the `R9` additive deep-research prompt round for Mister Smith.
+
+Use this suite when you want a new research pass grounded in the current repo baseline rather than
+the older `R8` prompt text. The authoritative "already discovered" boundary is:
+
+- `docs/current-state.md`
+- `docs/research-output/ROUTING_MANIFEST.md`
+- the relevant files under `docs/research-output/consolidated/`
+
+Do **not** treat `docs/pulse-tasks/` or the unexecuted `R8` prompts as the source of truth for
+what is already known.
+
+## Baseline Boundary
+
+- **Baseline date**: March 7, 2026
+- **Search window**: March 7, 2026 to present
+- **Older-source rule**: include older material only if it is missing from the repo baseline and
+  materially changes the design direction
+
+## Suite Design
+
+The `R9` suite exists because the repo already has strong prior coverage of routing, orchestration,
+streaming, supervision, coordination, security, memory, and competitive landscape. The remaining
+value is in a sharper set of prompts that:
+
+- refresh the corpus against the latest developments
+- target the documented open gaps in the consolidated research
+- force honest separation between frontier findings and thin or hype-driven results
+- map findings back to Mister Smith implementation surfaces
+
+Every prompt in this suite uses the same backbone:
+
+`Context` → `Frontier-First Mandate` → `Research Objective` →
+`What Has Already Been Researched` → `Research Dimensions` →
+`Per-Dimension Output Structure` → `Synthesis` → `Research Methodology`
+
+Every prompt also requires:
+
+- `Frontier classification` using the routing-manifest taxonomy:
+  `EXTEND`, `TRANSFORM`, `NEW`, plus `FRONTIER` vs `INCREMENTAL`
+- `Mister Smith implementation vector` naming likely crates, runtime surfaces, or spec areas
+- explicit separation of:
+  - `production-validated`
+  - `research-only`
+  - `thin-results`
+  - `contradictions to current assumptions`
+
+## Prompt Map
+
+- `01-workflow-engines-compensation-and-resume.md`
+  Scope: durable execution, resume, cancellation, compensation, reversible tools
+  Primary baseline docs:
+  `00-MASTER-FINDINGS`, `02-orchestration-and-self-organization`,
+  `03-supervision-and-resilience`, `06-streaming-architecture`,
+  `08-competitive-landscape-and-ecosystem`
+- `02-dynamic-orchestration-and-topology-control.md`
+  Scope: topology compilers, adaptive orchestration, decentralized DAG plus OTP reconciliation
+  Primary baseline docs:
+  `00-MASTER-FINDINGS`, `01-model-routing-and-cost-optimization`,
+  `02-orchestration-and-self-organization`, `03-supervision-and-resilience`,
+  `08-competitive-landscape-and-ecosystem`
+- `03-coordination-protocols-shared-state-and-dynamic-verification.md`
+  Scope: CRDTs, dynamic session typing, evolving DAG verification, shared-state infection controls
+  Primary baseline docs:
+  `00-MASTER-FINDINGS`, `04-security-and-trust`, `05-coordination-and-state`,
+  `08-competitive-landscape-and-ecosystem`
+- `04-real-time-inter-agent-communication-and-transport.md`
+  Scope: real-time transport, bidirectional streams, QoS, resumption, protocol adapters
+  Primary baseline docs:
+  `00-MASTER-FINDINGS`, `05-coordination-and-state`, `06-streaming-architecture`,
+  `07-memory-and-context`, `08-competitive-landscape-and-ecosystem`
+- `05-collaborative-communication-handoffs-and-cognitive-alignment.md`
+  Scope: clarification loops, trust calibration, negotiation, anti-groupthink communication policy
+  Primary baseline docs:
+  `00-MASTER-FINDINGS`, `02-orchestration-and-self-organization`,
+  `03-supervision-and-resilience`, `07-memory-and-context`
+
+## Recommended Run Order
+
+1. `02-dynamic-orchestration-and-topology-control.md`
+   Use first if you want the broadest update to Mister Smith's next orchestration direction.
+2. `03-coordination-protocols-shared-state-and-dynamic-verification.md`
+   Use next to test whether the coordination and safety primitives have shifted.
+3. `04-real-time-inter-agent-communication-and-transport.md`
+   Use third to refresh the wire-level and transport assumptions that support orchestration.
+4. `05-collaborative-communication-handoffs-and-cognitive-alignment.md`
+   Use fourth to refresh policy-level agent communication beyond transport.
+5. `01-workflow-engines-compensation-and-resume.md`
+   Use when you want the strongest update on durable workflow semantics, resumability, and
+   compensation once the other layers are refreshed.
+
+Alternative: run any prompt independently if you only need that surface.
+
+## Scope Boundaries
+
+- `01` owns workflow semantics, cancellation, compensation, and resume behavior
+- `02` owns topology shaping and orchestration control
+- `03` owns shared-state correctness and protocol verification
+- `04` owns transport, multiplexing, backpressure, and protocol adapters
+- `05` owns communication policy, handoffs, and cognitive alignment
+
+If a finding spans multiple prompts, keep it in the prompt whose boundary is most directly affected
+and cross-reference the others in the synthesis rather than duplicating full treatment.


### PR DESCRIPTION
## Summary
- refresh the prompt-improver planning artifacts for the R9 deep-research round
- add the production prompt suite under docs/research-prompts/R9
- preserve the standalone MS-116 initialization handoff prompt as a landed prompt artifact

## Validation
- npx markdownlint-cli2 "docs/prompt-improver-spec/implementation_plan.md" "docs/prompt-improver-spec/task.md" "docs/prompt-improver-spec/walkthrough.md" "docs/prompt-improver-spec/final-prompts/mister-smith-ms-116-linear-initialization-handoff.md" "docs/research-prompts/R9/*.md" --config .markdownlint.json
- git diff --check
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync
- verified no r9 draft prompts remain under docs/prompt-improver-spec/final-prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive R9 deep-research documentation suite investigating agent system architecture across five domains: workflow engines and compensation, dynamic orchestration and topology control, coordination protocols and verification, real-time communication and transport, and collaborative communication handoffs.
  * Updated development specifications and planning documentation for internal research and issue initialization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->