### PR TITLE
docs(packet-023): scaffold runtime truth spec

### DIFF
--- a/specs/023-runtime-truth-and-run-trace/analyze.md
+++ b/specs/023-runtime-truth-and-run-trace/analyze.md
@@ -1,0 +1,67 @@
+# Specification Analysis Report
+
+This report reflects the scaffold pass across `spec.md`, `plan.md`, `contracts/`, and `tasks.md`
+for packet `023`.
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| -- | -------- | -------- | ----------- | ------- | -------------- |
+| A1 | Inconsistency | MEDIUM | `spec.md`, `research.md`, repo notes | Both `supported task path` and `supported task path only` still appear. | Normalize to one phrase during revalidation. |
+| A2 | Deferred dependency | LOW | `spec.md`, `plan.md`, `tasks.md` | Packet `023` still depends on packet `022` ownership wording. | Keep T001-T004 blocking until packet `022` is rechecked. |
+
+No critical or high-severity cross-artifact conflicts were detected. The scaffold is internally
+consistent and honest about its revision-required posture.
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| run-trace-root-per-workflow | Yes | T005, T006, T016, T018 | Shared contract, core taxonomy, and transport inputs are covered. |
+| substrate-vs-grounded-proof-boundary | Yes | T005, T008, T011, T012, T021 | Contract freeze and projection tasks cover the core truth split. |
+| preserve-019-020-live-vs-021-deterministic-split | Yes | T001, T002, T003, T013, T030 | Revalidation and proof-note sync tasks preserve the current split. |
+| explicit-placeholder-step-limit | Yes | T009, T010, T011, T012 | Test and projection tasks cover the placeholder boundary honesty rule. |
+| exact-conservative-wording | Yes | T011, T013, T021, T022 | Surface projection and doc sync tasks cover wording reuse. |
+| trace-taxonomy-full-relationship-set | Yes | T005, T006, T007, T008, T014, T015, T016, T017, T018 | Foundational contract and taxonomy tasks cover the full relationship set. |
+| consistent-task-session-autonomy-operator-projection | Yes | T019, T020, T021, T022 | Task, session, autonomy, and operator projection work is covered. |
+| external-tracing-guidance-only | Yes | T005, T016, T018 | Contract and taxonomy tasks are the right place to enforce this boundary. |
+| packet-022-ownership-preserved | Yes | T001, T002, T005 | Revalidation and contract freeze tasks keep packet `022` ownership explicit. |
+| blocking-revalidation-gate | Yes | T001, T002, T003, T004 | The opening phase enforces the gate before any implementation work. |
+| bounded-scope-no-ui-polish-no-platform-widening | Yes | T005, T023 | Contract and narrow doc-sync tasks preserve scope limits. |
+| scaffold-stays-revision-required | Yes | T001, T002, T003, T004, T030 | The scaffold posture is preserved from revalidation through final evidence. |
+
+## Contract Alignment
+
+- `contracts/run-trace-proof-boundary-contract.md` correctly keeps packet `023` focused on
+  naming, taxonomy, and proof-boundary projection.
+- `plan.md` and `tasks.md` both preserve packet `022` as the owner of lifecycle and
+  durable-history semantics.
+- `quickstart.md` correctly blocks later implementation until current repo truth is reread.
+
+## Constitution Alignment Issues
+
+None detected. The scaffold remains spec-first, packet-bounded, dependency-explicit, and honest
+about deterministic versus live proof.
+
+## Unmapped Tasks
+
+None. Every task maps to either the revalidation gate, the shared truth contract, or one of the
+three user stories.
+
+## Metrics
+
+- Total Requirements: 12
+- Total Tasks: 30
+- Coverage: 12/12 requirements mapped to one or more tasks (100%)
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- This scaffold is ready to use as a future packet accelerator, not as an immediate implementation
+  freeze.
+- Before any later coding, complete T001-T004 and refresh this analysis if repo truth moved.
+- If you want one extra hardening pass now, the highest-value improvement would be to pre-decide
+  the canonical proof-boundary string normalization during the future revalidation step rather than
+  during code changes.

--- a/specs/023-runtime-truth-and-run-trace/checklists/requirements.md
+++ b/specs/023-runtime-truth-and-run-trace/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Runtime Truth And Run Trace
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This checklist validates a scaffold packet spec, not an implementation-ready freeze.
+- The spec intentionally includes a blocking revalidation gate before any future implementation.
+- Upstream packet completion may require later spec revision before `/speckit.implement`.

--- a/specs/023-runtime-truth-and-run-trace/checklists/runtime-truth-proof-boundary.md
+++ b/specs/023-runtime-truth-and-run-trace/checklists/runtime-truth-proof-boundary.md
@@ -1,0 +1,70 @@
+# Runtime Truth Proof Boundary Checklist: Runtime Truth And Run Trace
+
+**Purpose**: Validate that packet `023` requirements clearly define truthful run-trace scope,
+proof boundaries, placeholder-step limits, and revision gates before later implementation work
+**Created**: 2026-04-01
+**Feature**: [spec.md](../spec.md)
+
+## Requirement Completeness
+
+- [ ] CHK001 Are all proof-bearing surfaces named explicitly for packet `023` coverage: task,
+  session, autonomy, and operator run detail? [Completeness, Spec §Functional Requirements]
+- [ ] CHK002 Does the spec define the full trace-taxonomy scope for graph, branch, node, tool,
+  handoff, repair, retry, fan-out, join, and supervision relationships? [Completeness, Spec
+  §FR-006]
+- [ ] CHK003 Does the spec clearly define what packet `023` owns versus what packet `022` still
+  owns? [Completeness, Spec §Current Truth & Scope; Spec §FR-009]
+- [ ] CHK004 Are deferred revision points documented for upstream packet completion and repo-truth
+  drift? [Completeness, Spec §Deferred Revision Points]
+
+## Requirement Clarity
+
+- [ ] CHK005 Is the difference between substrate completion and grounded task proof defined in
+  direct, testable language rather than implied wording? [Clarity, Spec §FR-002]
+- [ ] CHK006 Is the placeholder-step limit stated plainly enough that a future implementer cannot
+  mistake `workflow.execute_step` completion for grounded task proof? [Clarity, Spec §FR-004]
+- [ ] CHK007 Are the conservative phrases frozen exactly and presented as current truth wording
+  rather than optional examples? [Clarity, Spec §FR-005]
+- [ ] CHK008 Is the OpenTelemetry and W3C role stated as taxonomy guidance only, without blurred
+  claims about existing emitted spans? [Clarity, Spec §FR-008]
+
+## Requirement Consistency
+
+- [ ] CHK009 Do the user stories, functional requirements, and success criteria all preserve the
+  same packet `019` and `020` live-proof versus packet `021` deterministic-only split?
+  [Consistency, Spec §User Story 1; Spec §FR-003; Spec §SC-003]
+- [ ] CHK010 Do the scope and non-goal statements consistently exclude UI polish, generic
+  observability-platform work, and coordinator-runtime scope? [Consistency, Spec §Current Truth &
+  Scope; Spec §FR-011]
+- [ ] CHK011 Do the key entities use one stable naming scheme for run trace, trace events, trace
+  links, and proof-boundary views without synonym drift? [Consistency, Spec §Key Entities]
+
+## Scenario Coverage
+
+- [ ] CHK012 Does the spec define what should be said when a graph completes but no grounded work
+  occurred below the placeholder step boundary? [Coverage, Spec §User Story 1]
+- [ ] CHK013 Does the spec define how fan-out, join, repair, and retry relationships should be
+  represented without claiming a full emitted span hierarchy? [Coverage, Spec §User Story 2]
+- [ ] CHK014 Does the spec address cross-surface wording drift as a scenario instead of assuming
+  all projections already agree? [Coverage, Spec §User Story 3; Spec §Edge Cases]
+
+## Edge Case Coverage
+
+- [ ] CHK015 Are mismatch cases between proof-boundary wording and actual runtime evidence
+  explicitly called out? [Edge Case, Spec §Edge Cases]
+- [ ] CHK016 Does the spec address the case where upstream packet work changes the preferred
+  ownership or wording before implementation starts? [Edge Case, Spec §Deferred Revision Points]
+
+## Revalidation Gate Quality
+
+- [ ] CHK017 Is the before-implementation revalidation gate explicit, blocking, and tied to named
+  source documents? [Acceptance Criteria, Spec §Before Implementation Revalidation Gate]
+- [ ] CHK018 Does the revalidation gate require rerunning downstream SpecKit steps if repo truth
+  moved? [Acceptance Criteria, Spec §Before Implementation Revalidation Gate]
+- [ ] CHK019 Is the scaffold status clearly separated from an implementation-ready freeze?
+  [Acceptance Criteria, Spec §Scaffold Status]
+
+## Notes
+
+- Check items off as later revision work confirms the scaffold is still accurate.
+- This checklist validates requirement quality and readiness posture, not implementation behavior.

--- a/specs/023-runtime-truth-and-run-trace/contracts/run-trace-proof-boundary-contract.md
+++ b/specs/023-runtime-truth-and-run-trace/contracts/run-trace-proof-boundary-contract.md
@@ -1,0 +1,106 @@
+# Contract: Run Trace And Proof Boundary Surface
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Scaffold note
+
+This contract is a scaffold freeze for later revision.
+
+- It is meant to preserve packet `023` naming and proof-boundary rules now.
+- It is not implementation-ready without a later revalidation pass.
+- It must be revised once upstream packet work, especially packet `022`, is complete enough to
+  depend on safely.
+
+## Design goal
+
+Freeze one shared contract for honest runtime truth and run traces so current and future result
+surfaces can say exactly what a run proved and what it did not prove.
+
+This packet does **not** define durable lifecycle or event-history semantics. Packet `022`
+remains the owner of those surfaces.
+
+## Canonical mapping
+
+The contract for packet `023` is:
+
+- one run trace root per `workflow_id`
+- one trace taxonomy covering graph, branch, node, tool, handoff, repair, retry, fan-out, join,
+  and supervision relationships
+- one proof-boundary view that distinguishes:
+  - orchestration-substrate completion
+  - placeholder or simulated step completion
+  - grounded tool execution
+  - grounded task proof
+- one consistent projection story for task, session, autonomy, and operator run-detail surfaces
+
+No other packet in this sequence should redefine these naming and proof-boundary rules once packet
+`023` is revised and implemented.
+
+## Canonical wording for current placeholder-boundary runs
+
+When a run completes through the current placeholder step boundary, the rendered truth story should
+be able to say:
+
+- `workflow graph executed successfully`
+- `semantic completion not yet proven`
+- `grounded tool execution: none/minimal`
+- `result is orchestration proof, not substantive task proof`
+
+These phrases are frozen as current conservative wording for this packet scaffold.
+
+## Placeholder-step limit
+
+The current `WorkflowStepTool` behavior is a contract constraint for this scaffold:
+
+- it echoes the incoming payload
+- it marks `status=completed`
+- it marks `execution_boundary=tool_bus`
+- it sets `tool_name=workflow.execute_step`
+
+Until that runtime behavior changes and is revalidated, a result that passes through this boundary
+must not be described as grounded task proof.
+
+## Proof-status contract
+
+Current proof-status mapping for this packet is:
+
+- packet `019`: bounded supported-path live proof exists
+- packet `020`: bounded supported-path live proof exists
+- packet `021`: newer supervision-evidence surface is landed and deterministically validated, but
+  this scaffold must not treat that as a fresh default-path live proof claim by itself
+
+The contract must preserve this split until newer repo truth explicitly changes it.
+
+## External tracing guidance
+
+OpenTelemetry traces, context propagation, and W3C Trace Context may guide:
+
+- trace-root naming
+- relationship vocabulary
+- propagation concepts
+
+They may not be used to claim that Mister Smith already emits a complete span tree, complete span
+links, or a production-grade tracing export surface today.
+
+## Surface expectations
+
+The same bounded truth story should be renderable from:
+
+- task result and inspect surfaces
+- session-result or session-summary surfaces
+- autonomy status surfaces
+- operator run-detail surfaces
+
+This scaffold does not require a new dashboard or a UI redesign. It only requires one consistent
+truth contract for existing and future projections.
+
+## Revalidation gate
+
+Before implementing this contract later:
+
+1. reread `docs/direction.md`
+2. reread `docs/current-state.md`
+3. reread `docs/packet-prep/023-runtime-truth-and-run-trace.md`
+4. confirm packet `022` is complete enough to anchor lifecycle and history ownership
+5. rerun `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.analyze` if repo
+   truth moved

--- a/specs/023-runtime-truth-and-run-trace/data-model.md
+++ b/specs/023-runtime-truth-and-run-trace/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Runtime Truth And Run Trace
+
+## Core trace entities
+
+### `RunTraceRecord`
+
+- `workflow_id`: canonical workflow identifier and primary run anchor
+- `trace_root_id`: canonical trace-root identifier for the run
+- `proof_boundary`: latest bounded proof statement for the run
+- `evidence_class`: current class of execution evidence for the run
+- `surface_projection_targets`: task, session, autonomy, and operator run-detail surfaces that
+  should render the same truth story
+- `source_refs`: packet notes, artifact bundles, or future runtime references used to justify the
+  rendered truth story
+
+### `TraceRoot`
+
+- represents the top-level trace identity for one workflow run
+- may reuse packet `022` durable identifiers later, but does not define packet `022` ownership
+- remains distinct from any external tracing vendor or export identifier
+
+### `TraceEvent`
+
+- typed event in the run trace
+- expected event classes include:
+  - graph formation
+  - branch execution
+  - node execution
+  - tool-boundary crossing
+  - handoff
+  - repair
+  - retry
+  - supervision
+  - join or reconvergence
+- may point to grounded evidence references when such evidence actually exists
+
+### `TraceLink`
+
+- explicit relationship between two trace events
+- supported relationship types include:
+  - parent-child execution flow
+  - fan-out
+  - join or reconvergence
+  - retry of prior work
+  - repair of prior work
+  - supervision attached to an execution edge
+
+## Proof-boundary entities
+
+### `ProofBoundaryView`
+
+- operator-facing summary of what the run proved and what it did not prove
+- should preserve the packet-owned conservative phrases when the placeholder step boundary is still
+  active
+- should carry current proof status without collapsing packet `019`, `020`, and `021` into one
+  vague label
+
+### `ExecutionEvidenceClass`
+
+- classifies the strongest evidence the run actually produced
+- expected classes for this packet:
+  - `substrate_completion`
+  - `placeholder_or_simulated_step_completion`
+  - `grounded_tool_execution`
+  - `grounded_task_proof`
+- packet `023` defines the naming and semantics of these classes, not the later implementation
+  mechanics
+
+### `GroundedEvidenceReference`
+
+- stable reference to real files, endpoints, artifacts, or other grounded work touched during the
+  run
+- may be absent when the run only proved orchestration-substrate completion
+- absence is meaningful and must not be silently backfilled with optimistic language
+
+## Invariants
+
+- packet `022` remains the owner of durable lifecycle, event-history, compaction, and effect
+  boundary semantics
+- placeholder `workflow.execute_step` completion is not enough to classify a run as grounded task
+  proof
+- packet `019` and `020` live-proof notes remain distinct from packet `021` deterministic-only
+  proof for newer supervision-evidence claims
+- external tracing docs may shape names and link concepts, but they do not prove a full emitted
+  span model exists in the repo today
+- all rendered proof-boundary views should tell the same bounded truth story across task, session,
+  autonomy, and operator surfaces

--- a/specs/023-runtime-truth-and-run-trace/plan.md
+++ b/specs/023-runtime-truth-and-run-trace/plan.md
@@ -1,0 +1,180 @@
+# Implementation Plan: Runtime Truth And Run Trace
+
+**Branch**: `023-runtime-truth-and-run-trace` | **Date**: 2026-04-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from
+`/Users/macmain/MisterSmith/specs/023-runtime-truth-and-run-trace/spec.md`
+
+## Scaffold Status
+
+This is a scaffold plan written ahead of upstream packet completion.
+
+- It is meant to speed later packet work.
+- It does not authorize immediate implementation.
+- It must be revised against then-current repo truth before any future `/speckit.implement`.
+
+## Summary
+
+Packet `023` freezes one bounded contract for honest runtime truth and run traces: one trace root
+per workflow run, one shared proof-boundary model, one placeholder-step honesty rule, and one
+consistent projection story across task, session, autonomy, and operator surfaces. It does not
+reopen packet `022` lifecycle ownership, and it does not widen into UI polish, generic
+observability-platform work, or coordinator-runtime scope.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88.0 plus repo-owned packet docs
+**Primary Dependencies**: `mister-smith-core`, `mister-smith-events`, `mister-smith-app`,
+`mister-smith-transport`, current result and autonomy surfaces, and current proof notes under
+`docs/plans/`
+**Storage**: Existing task/autonomy metadata and packet-owned docs only for this scaffold; future
+implementation may consume packet `022` durable-history surfaces once they are frozen
+**Testing**: Packet-writing checks now, then targeted Rust and smoke-harness checks later once
+implementation is revalidated
+**Target Platform**: Current Mister Smith runtime-backed task path and its existing operator
+inspection surfaces
+**Project Type**: Rust workspace packet with state-bearing docs and future projection-contract work
+**Performance Goals**: Honest operator understanding in one inspection pass; no broadened runtime
+claim surface without corresponding proof
+**Constraints**: Keep packet `022` as lifecycle/history owner; preserve packet `019` and `020`
+live-proof split versus packet `021` deterministic-only proof; treat OpenTelemetry and W3C docs as
+taxonomy guidance only; do not widen scope
+**Scale/Scope**: One scaffold packet focused on naming, taxonomy, proof boundaries, and revision
+gates
+
+## Constitution Check
+
+*GATE: Must pass before any future implementation begins. Re-check after upstream packet work lands.*
+
+| Principle | Status | Evidence |
+| --------- | ------ | -------- |
+| I. Canonical Single Source | PASS | Grounded in `docs/direction.md`, `docs/current-state.md`, the packet `023` dossier, and current runtime seams. |
+| II. Spec-First Design | PASS | This scaffold exists to define the packet before any code work. |
+| III. Phase-And-Packet-Gated Delivery | PASS | Packet `023` stays bounded and explicitly depends on packet `022` ownership instead of reopening it. |
+| IV. Model-Agnostic Architecture | PASS | The packet describes proof boundaries and trace taxonomy, not provider-specific behavior. |
+| V. Erlang/OTP-Style Fault Tolerance | PASS | No fault-tolerance guarantees are widened here; current runtime boundaries stay explicit. |
+| VI. Evidence-Based Validation | PASS | The scaffold preserves live-proof versus deterministic-only boundaries and requires later revalidation. |
+| VII. Explicit Dependency Management | PASS | Upstream dependency on packet `022` and existing packet `019` / `020` / `021` proof notes is explicit. |
+| VIII. Clean Closure And Resumability | PASS | The artifact set is designed for later cold-start reuse and revision. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-runtime-truth-and-run-trace/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── run-trace-proof-boundary-contract.md
+├── checklists/
+│   ├── requirements.md
+│   └── runtime-truth-proof-boundary.md
+├── tasks.md
+└── analyze.md
+```
+
+### Source Code (future implementation targets only)
+
+```text
+crates/mister-smith-transport/
+└── src/envelope.rs
+
+crates/mister-smith-core/
+└── src/autonomy.rs
+
+crates/mister-smith-events/
+└── src/bus.rs
+
+crates/mister-smith-app/
+├── src/execution.rs
+├── src/autonomy.rs
+└── src/conversation.rs
+
+apps/operator-console/
+└── src/views/
+```
+
+**Structure Decision**: This scaffold writes only packet artifacts now. The runtime and projection
+paths above are listed as future implementation targets so a later session does not need to
+rediscover the likely write set, including the existing session-facing conversation surface.
+
+## Design Decisions
+
+### D1: Packet `023` owns naming and proof-boundary projection, not lifecycle semantics
+
+**Decision**: Packet `023` freezes truthful naming, trace taxonomy, and proof-boundary projection
+only. Packet `022` remains the owner of durable lifecycle, event-history, compaction, and effect
+boundaries.
+
+**Rationale**: The dossier and packet dependency map explicitly place packet `023` after packet
+`022` and keep it narrower than durable-workflow semantics.
+
+### D2: Placeholder step completion is a first-class non-proof state
+
+**Decision**: The scaffold treats the current `workflow.execute_step` payload-echo behavior as a
+placeholder completion boundary that can prove orchestration-substrate flow but not grounded task
+work.
+
+**Rationale**: Current runtime code marks `workflow.execute_step` payloads `completed` at the
+`tool_bus` boundary without proving grounded execution. The packet must freeze this honesty rule.
+
+### D3: Packet `019` and `020` live proof remain separate from packet `021` deterministic proof
+
+**Decision**: The scaffold preserves the current proof split instead of collapsing all runtime
+evidence into one broad “live” label.
+
+**Rationale**: `docs/current-state.md` and the packet `021` closure and live-evaluation notes make
+that split explicit and current.
+
+### D4: External tracing standards are taxonomy references, not current emitted-truth claims
+
+**Decision**: Use OpenTelemetry traces, context propagation, and W3C Trace Context to shape the
+taxonomy, but do not claim the repo already emits a complete span model.
+
+**Rationale**: The dossier makes this a hard boundary and prevents fake observability claims.
+
+## Minimal Scaffold Slice
+
+### Milestone 1: Freeze the scaffold contract
+
+**Scope**: Write `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/run-trace-proof-boundary-contract.md`, and both checklists.
+
+**Validation**:
+
+- packet `023` artifact set exists under `specs/023-runtime-truth-and-run-trace/`
+- every artifact repeats the scaffold-only and revalidation-required posture
+
+### Milestone 2: Freeze the future implementation posture
+
+**Scope**: Write `tasks.md` as a future-only scaffold and create one durable analysis artifact that
+highlights top gaps before later implementation.
+
+**Validation**:
+
+- `tasks.md` starts with a blocking revalidation task before any code work
+- analysis output is preserved in a reusable artifact
+
+## Parallel Staging Posture
+
+- Blocking first: spec contract, revalidation gate, and proof-boundary wording
+- Allowed later as separate future lanes once the packet is revised for implementation:
+  - transport and core taxonomy lane
+  - events and app projection lane
+  - operator projection lane
+- Shared-write choke points for future implementation:
+  - `crates/mister-smith-app/src/execution.rs`
+  - `crates/mister-smith-core/src/autonomy.rs`
+  - `crates/mister-smith-events/src/bus.rs`
+  - `docs/current-state.md`
+
+## Deferred Until Revalidation
+
+- any code changes in runtime or operator surfaces
+- any attempt to rewrite repo router docs as if packet `023` were already the active
+  implementation-ready post-packet-021 packet
+- any decision that depends on the final packet `022` lifecycle and history contract language
+- any broader observability, tracing export, or runtime-coordinator work

--- a/specs/023-runtime-truth-and-run-trace/quickstart.md
+++ b/specs/023-runtime-truth-and-run-trace/quickstart.md
@@ -1,0 +1,72 @@
+# Quickstart: Runtime Truth And Run Trace
+
+## Scaffold note
+
+This is a scaffold quickstart for later packet work.
+
+- It is meant to save time later.
+- It is not a signal to implement immediately.
+- It must be revised once upstream packet work is complete enough to revalidate packet `023`.
+
+## Before implementation
+
+Before any later implementation starts:
+
+```bash
+sed -n '1,220p' docs/direction.md
+sed -n '1,260p' docs/current-state.md
+sed -n '1,260p' docs/packet-prep/023-runtime-truth-and-run-trace.md
+```
+
+Then confirm:
+
+- packet `022` is complete enough to rely on for lifecycle and history ownership
+- the packet `019` / `020` live-proof baseline versus packet `021` deterministic-only split is
+  still current
+- the placeholder `workflow.execute_step` truth gap is still described correctly by this scaffold
+
+If any of that changed, rerun:
+
+```bash
+./.specify/scripts/bash/check-prerequisites.sh --json --paths-only
+./.specify/scripts/bash/setup-plan.sh --json
+```
+
+Then refresh the packet by rerunning `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, and
+`/speckit.analyze`.
+
+## Future deterministic validation
+
+When packet `023` is later revised for implementation, start with the narrowest honest checks for
+the touched truth and projection seams:
+
+```bash
+cargo test -p mister-smith-core
+cargo test -p mister-smith-events --test autonomy_event_tests
+cargo test -p mister-smith-app --test autonomy_status_tests
+cargo test -p mister-smith-app workflow_step_tool_marks_payload_as_tool_bus_completed
+python3 -m unittest scripts.tests.test_live_runtime_proof_smoke
+git diff --check
+```
+
+## Proof expectation
+
+Later implementation work for packet `023` should earn proof by making it easy to tell, in one
+inspection pass:
+
+- whether the run only proved orchestration-substrate completion
+- whether the current step boundary remained placeholder or simulated
+- whether grounded tool execution exists and what evidence anchors it
+- whether packet `019` and `020` live-proof claims stay separate from packet `021`
+  deterministic-only proof for newer surfaces
+
+## Live-proof boundary
+
+This scaffold does not create a new live-proof claim.
+
+If packet `023` later earns a live runtime proof, that proof must stay bounded to the exact
+provider path and artifact set that were actually exercised and must not imply that:
+
+- packet `022` semantics were already finalized if they were not
+- the repo already emits a complete span model
+- placeholder step completion became grounded task proof without the runtime actually changing

--- a/specs/023-runtime-truth-and-run-trace/research.md
+++ b/specs/023-runtime-truth-and-run-trace/research.md
@@ -1,0 +1,96 @@
+# Research Notes: Runtime Truth And Run Trace
+
+## Current repo truth
+
+- packet `019` provides the last bounded live-proof note for budget-aware runtime routing on the
+  supported path
+- packet `020` provides the last bounded live-proof note for orchestration-quality and repair
+  lineage on the supported path
+- packet `021` provides landed supervision-evidence projection with deterministic validation and
+  explicit proof-boundary language, but it does not by itself create a new supported-path live
+  proof claim
+- the March 19 live run-trace evaluation and March 28 session context report both document the
+  same honesty gap: graph completion and tool-bus step completion can appear semantically richer
+  than they really are
+- `WorkflowStepTool` currently echoes the incoming payload, adds `status=completed`,
+  `execution_boundary=tool_bus`, and `tool_name=workflow.execute_step`, and returns that payload
+  without grounded task execution proof
+
+## Primary decisions
+
+### Decision: packet `023` should freeze proof-boundary and trace taxonomy, not durable lifecycle
+
+**Rationale**: The packet-prep README and packet `023` dossier place packet `023` after packet
+`022`, with packet `022` still owning durable workflow semantics, history, compaction, and effect
+boundaries.
+
+**Alternatives considered**:
+
+- Let packet `023` also freeze lifecycle semantics: rejected because it would steal packet `022`
+  ownership and widen scope.
+- Delay packet `023` entirely until packet `022` is done: rejected for this scaffold because the
+  user wants speed later, not immediate implementation.
+
+### Decision: the scaffold must preserve the current proof split exactly
+
+**Rationale**: `docs/current-state.md`, the packet `021` closure note, and the packet `021` live
+evaluation note all show that packet `019` and `020` remain the last fresh live-proof baseline,
+while packet `021` is landed and deterministically validated for its newer claim surface.
+
+**Alternatives considered**:
+
+- Call all three packets “live enough”: rejected because it overstates current proof.
+- Collapse the distinction into “partial”: rejected because it hides the real boundary.
+
+### Decision: external tracing docs are taxonomy references only
+
+**Rationale**: OpenTelemetry traces, context propagation, and W3C Trace Context provide the best
+shape for naming roots, links, and propagation, but the dossier explicitly forbids treating those
+docs as proof that the repo already emits a complete span model.
+
+**Alternatives considered**:
+
+- Import external tracing vocabulary as if it already matched repo behavior: rejected because it
+  would create fake observability claims.
+- Ignore external tracing docs entirely: rejected because the packet still needs a coherent
+  taxonomy baseline.
+
+### Decision: placeholder completion must remain a first-class non-grounded evidence class
+
+**Rationale**: The March 28 session report and current `WorkflowStepTool` implementation make the
+truth gap explicit. This packet must freeze language that can say a run completed at the workflow
+graph layer while still saying semantic completion is unproven.
+
+**Alternatives considered**:
+
+- Treat placeholder tool-bus completion as semantic task proof: rejected because current code does
+  not support that claim.
+- Hide the placeholder boundary behind generic “success” wording: rejected because it misleads the
+  operator.
+
+## Guidance from current proof notes
+
+- Use `docs/plans/2026-03-19-live-run-trace-evaluation.md` as the main live-gap anchor for why
+  graph success is not enough.
+- Use `docs/2026-03-28-session-context-report.md` for the conservative wording that packet `023`
+  should freeze.
+- Use `docs/plans/2026-03-29-packet-021-supervision-evidence-proof-boundary.md` for deterministic
+  proof-boundary language.
+- Use `docs/plans/2026-03-29-packet-021-live-evaluation.md` for the explicit “deterministic yes,
+  fresh live default-path proof no” split.
+
+## External taxonomy guidance
+
+- OpenTelemetry traces are the best reference for span-like causal structure, events, and links.
+- OpenTelemetry context propagation is the best reference for how trace identity moves across
+  boundaries.
+- W3C Trace Context is the best reference for wire-level trace correlation semantics.
+
+These sources guide naming and relationship shape only. They do not upgrade current repo proof.
+
+## Bounded conclusion
+
+Packet `023` is a truth-contract packet. Its honest job is to say what a run proved, what it did
+not prove, and how that story should be named consistently across existing result and operator
+surfaces. It should not become a packet about new runtime behavior, durable lifecycle semantics,
+UI redesign, or generic observability tooling.

--- a/specs/023-runtime-truth-and-run-trace/spec.md
+++ b/specs/023-runtime-truth-and-run-trace/spec.md
@@ -1,0 +1,254 @@
+# Feature Specification: Runtime Truth And Run Trace
+
+**Feature Branch**: `023-runtime-truth-and-run-trace`
+**Created**: 2026-04-01
+**Status**: Draft
+**Input**: `docs/direction.md`, `docs/current-state.md`, `docs/packet-prep/README.md`,
+`docs/packet-prep/023-runtime-truth-and-run-trace.md`,
+`docs/2026-03-28-session-context-report.md`,
+`docs/plans/2026-03-29-packet-021-supervision-evidence-proof-boundary.md`,
+`docs/plans/2026-03-29-packet-021-live-evaluation.md`,
+`docs/plans/2026-03-19-live-run-trace-evaluation.md`, and the current runtime surfaces in
+`crates/mister-smith-app/src/execution.rs`, `crates/mister-smith-core/src/autonomy.rs`,
+`crates/mister-smith-events/src/bus.rs`, and `crates/mister-smith-transport/src/envelope.rs`
+
+## Scaffold Status
+
+This is a scaffold spec written ahead of upstream packet completion to speed later packet work.
+
+- It freezes packet `023` scope, naming, proof-boundary language, and revalidation gates now.
+- It does not claim packet `023` is implementation-ready or already validated for execution.
+- It must be revised against then-current repo truth before any future `/speckit.implement`.
+
+## Current Truth & Scope
+
+Current repo truth already includes:
+
+- packet `019` bounded live proof for the supported path under the documented
+  `openai_chatgpt` / `gpt-5.4` baseline
+- packet `020` live-proof-backed orchestration-quality and repair-lineage surfaces on the
+  supported path
+- packet `021` landed supervision-evidence projection with deterministic validation and explicit
+  proof-boundary notes
+- stable runtime identifiers such as `workflow_id`, `session_id`, and `coordinator_agent_id`
+- transport-level trace and correlation fields on `MessageEnvelope`
+
+The remaining gap is narrower than a broad observability or runtime-expansion packet:
+
+- the runtime still allows a run to look successful at the orchestration-substrate layer while
+  leaving semantic task completion unproven
+- the current `workflow.execute_step` boundary still marks payloads as `completed` on the
+  `tool_bus` path without proving grounded task work
+- the repo does not yet have one frozen run-trace taxonomy spanning graph, branch, node, tool,
+  repair, retry, fan-out, join, and supervision relationships
+- proof-boundary wording is present in several places, but not yet frozen as one shared packet
+  contract
+
+This scaffold packet therefore freezes one bounded slice:
+
+1. define one honest run-trace taxonomy rooted at `workflow_id` and one trace root per workflow
+   run
+2. define one explicit proof-boundary contract that separates substrate completion from grounded
+   task proof
+3. define how current task, session, autonomy, and operator surfaces should project truthful
+   execution status without overclaiming grounded work
+
+This is not:
+
+- packet `022` durable lifecycle, event-history, compaction, or effect-boundary work
+- UI polish, dashboard redesign, or generic observability-platform work
+- coordinator-runtime, real subagent-runtime, or interoperability work
+- proof that the repo already emits a complete OpenTelemetry-style span model
+
+## Before Implementation Revalidation Gate
+
+Before any future implementation starts, the next session must:
+
+1. reread `docs/direction.md`
+2. reread `docs/current-state.md`
+3. reread `docs/packet-prep/023-runtime-truth-and-run-trace.md`
+4. confirm packet `022` and any reused upstream packet work are complete enough to depend on
+5. rerun `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, and `/speckit.analyze` if repo
+   truth moved
+
+If those checks fail, this scaffold must be revised before code work begins.
+
+## Deferred Revision Points
+
+- finalize packet `022` lifecycle and durable-history ownership wording before packet `023`
+  implementation starts
+- re-check whether current proof-boundary wording across task, autonomy, session, and operator
+  surfaces has drifted since this scaffold was written
+- re-check whether newer live-proof or deterministic-only evidence changed the packet `019`,
+  `020`, or `021` proof split before this packet is implemented
+
+## User Scenarios & Testing
+
+### User Story 1 - Report honest proof boundaries for one completed run (Priority: P1)
+
+An operator inspects a completed run and can immediately tell whether the system proved only
+workflow-graph execution or also proved grounded task work.
+
+**Why this priority**: This is the core honesty gap the packet exists to close. If this stays
+blurry, later runtime and operator claims stay misleading.
+
+**Independent Test**: A task, session, or autonomy result that shows graph completion through the
+current placeholder step boundary can be inspected and still clearly states that semantic
+completion is not yet proven.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run completed through `workflow.execute_step` with `execution_boundary=tool_bus`,
+   **When** an operator inspects the result surface, **Then** it can say `workflow graph executed
+   successfully` while also stating `semantic completion not yet proven`.
+2. **Given** the run produced no grounded external action beyond the placeholder step boundary,
+   **When** the proof-boundary block is rendered, **Then** it states `grounded tool execution:
+   none/minimal`.
+3. **Given** packet `019` and packet `020` remain the last fresh live-proof baseline while packet
+   `021` remains deterministic-only for its newer supervision surface, **When** the packet
+   describes current proof status, **Then** it preserves that split explicitly instead of merging
+   them into one vague live-claim.
+
+---
+
+### User Story 2 - Freeze one canonical run-trace taxonomy (Priority: P1)
+
+A future implementation team can use one packet-owned taxonomy for run traces and proof
+boundaries instead of re-inventing names and relationships per surface.
+
+**Why this priority**: Later packets depend on clear truth and trace language. If packet `023`
+does not own this now, later packets will drift.
+
+**Independent Test**: One written contract can classify graph, branch, node, tool, handoff,
+repair, retry, fan-out, join, and supervision relationships without redefining packet `022`
+lifecycle semantics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow run fans out into branches and later joins, **When** the packet describes
+   trace relationships, **Then** it distinguishes parent-child flow from linked reconvergence
+   without claiming the repo already emits a full span graph.
+2. **Given** a run includes repair or retry behavior, **When** the trace taxonomy is applied,
+   **Then** repair and retry edges are represented as explicit trace relationships rather than
+   hidden status noise.
+3. **Given** packet `022` still owns durable lifecycle and event-history semantics, **When**
+   packet `023` names trace records and proof boundaries, **Then** it reuses those identifiers and
+   ownership boundaries instead of redefining lifecycle behavior.
+
+---
+
+### User Story 3 - Keep operator surfaces consistent without widening packet scope (Priority: P2)
+
+An operator or future packet author can compare task, session, autonomy, and operator views and
+see the same proof-boundary story without turning packet `023` into a UI or platform packet.
+
+**Why this priority**: The packet is about truthful projection, not a redesign. The value is
+consistency across existing surfaces.
+
+**Independent Test**: One written contract describes the same proof-boundary fields and wording
+for task, session, autonomy, and operator run-detail views.
+
+**Acceptance Scenarios**:
+
+1. **Given** task, session, autonomy, and operator surfaces all show run results, **When** the
+   packet defines proof-boundary projection, **Then** each surface uses the same bounded truth
+   story rather than drifted wording.
+2. **Given** OpenTelemetry and W3C tracing docs are used as guidance, **When** the packet defines
+   surface language, **Then** it borrows taxonomy carefully without claiming the repo already has a
+   complete emitted span model.
+3. **Given** future implementation packets need this contract later, **When** this scaffold is
+   handed off, **Then** it is clear what must be revised before code work starts and what can be
+   reused as-is.
+
+## Edge Cases
+
+- a graph completes successfully while every step still uses the placeholder `workflow.execute_step`
+  boundary
+- task and autonomy surfaces use slightly different proof-boundary text for the same run
+- a repair or retry edge exists, but the surface only shows final completion state
+- a fan-out or join path is visible in runtime metadata, but no grounded work occurred below the
+  step boundary
+- a surface tries to treat OpenTelemetry terms as proof that the repo already emits a complete
+  span hierarchy
+- packet `022` later freezes lifecycle or history semantics that change the preferred wording or
+  ownership boundary for packet `023`
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System documentation for packet `023` MUST define one run-trace taxonomy rooted at
+  `workflow_id` with one trace root per workflow run.
+- **FR-002**: Packet `023` MUST define one proof-boundary contract that keeps substrate
+  completion separate from grounded task proof.
+- **FR-003**: Packet `023` MUST preserve the current proof split in its written contract: packet
+  `019` and packet `020` remain the last fresh live-proof baseline on the supported path, while
+  packet `021` supervision evidence is landed and deterministically validated but does not create a
+  new default-path live claim by itself.
+- **FR-004**: Packet `023` MUST state the current placeholder-step limit explicitly: while
+  `WorkflowStepTool` only echoes payload and marks `workflow.execute_step` as `completed` on the
+  `tool_bus` boundary, that boundary does not prove grounded task work.
+- **FR-005**: Packet `023` MUST preserve the exact conservative language below for current
+  placeholder-boundary runs:
+  `workflow graph executed successfully`,
+  `semantic completion not yet proven`,
+  `grounded tool execution: none/minimal`, and
+  `result is orchestration proof, not substantive task proof`.
+- **FR-006**: Packet `023` MUST define trace-taxonomy coverage for graph, branch, node, tool,
+  handoff, repair, retry, fan-out, join, and supervision relationships.
+- **FR-007**: Packet `023` MUST describe consistent proof-boundary projection expectations for
+  task, session, autonomy, and operator run-detail surfaces.
+- **FR-008**: Packet `023` MUST treat OpenTelemetry and W3C Trace Context as taxonomy guidance
+  only and MUST NOT claim the repo already emits a complete span model.
+- **FR-009**: Packet `023` MUST keep packet `022` as owner of durable lifecycle, event-history,
+  compaction, and effect-boundary semantics.
+- **FR-010**: Packet `023` MUST include a blocking revalidation gate before any future
+  implementation begins.
+- **FR-011**: Packet `023` MUST remain scoped to truthful naming, trace taxonomy, and
+  proof-boundary projection and MUST NOT widen into UI polish, generic observability-platform
+  work, or coordinator-runtime scope.
+- **FR-012**: Packet `023` MUST stay explicitly revision-required until upstream packet work it
+  depends on is complete enough to revalidate the scaffold against then-current repo truth.
+
+### Key Entities
+
+- **Run Trace Record**: the packet-owned description of one workflow run’s trace root,
+  relationships, and proof-boundary story anchored to `workflow_id`
+- **Trace Root**: the canonical top-level identifier for one workflow run’s trace view
+- **Trace Event**: a typed traceable event such as graph formation, branch execution, tool
+  boundary crossing, repair, retry, or supervision
+- **Trace Link**: the relationship record used to describe parent-child execution, fan-out,
+  reconvergence, repair, or retry connections between trace events
+- **Proof Boundary View**: the bounded summary that states what was proven and what was not proven
+  for one run
+- **Grounded Evidence Reference**: the stable reference to files, endpoints, artifacts, or other
+  grounded evidence actually touched during a run when such evidence exists
+- **Execution Evidence Class**: the packet-owned classification that distinguishes substrate
+  completion, placeholder or simulated completion, grounded tool execution, and grounded task proof
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A future reviewer can inspect the packet `023` scaffold and determine in one pass
+  whether a run proves only orchestration-substrate completion or also proves grounded task work.
+- **SC-002**: The packet provides one shared taxonomy that covers all required run-trace
+  relationship types without widening into lifecycle ownership or platform scope.
+- **SC-003**: The packet states the packet `019` and packet `020` live-proof baseline separately
+  from packet `021` deterministic-only supervision proof with no contradictory wording.
+- **SC-004**: The packet gives future implementation work one explicit revalidation gate so no
+  session can honestly treat the scaffold as implementation-ready without rereading current repo
+  truth first.
+- **SC-005**: The packet leaves later implementers with enough contract language to begin a later
+  revision pass without rediscovering the placeholder-step truth gap from scratch.
+
+## Assumptions
+
+- Packet `022` is still the owner of durable workflow semantics and will be completed or clarified
+  before packet `023` implementation starts.
+- Upstream packet work may still move repo truth before packet `023` is implemented, so this
+  scaffold will need a revision pass.
+- Existing task, session, autonomy, and operator run-detail surfaces remain the intended
+  projection targets; this scaffold does not assume a new surface will be added first.
+- OpenTelemetry and W3C Trace Context remain the right external taxonomy references for naming and
+  structure, even if the final repo contract later narrows or renames parts of that taxonomy.

--- a/specs/023-runtime-truth-and-run-trace/tasks.md
+++ b/specs/023-runtime-truth-and-run-trace/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: Runtime Truth And Run Trace
+
+**Input**: Design documents from `/Users/macmain/MisterSmith/specs/023-runtime-truth-and-run-trace/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/`
+
+**Tests**: Included. Future implementation should use targeted truth-surface and smoke-harness
+checks rather than broad workspace validation first.
+
+**Organization**: Tasks are grouped by bounded checkpoints so packet `023` is revalidated before
+any later code work starts.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel only when every blocking checkpoint in the current section is
+  complete and the write set is disjoint
+- **[Story]**: Which user story the task advances (`US1` through `US3`)
+- Include exact file paths in every task description
+
+## Phase 1: Revalidation Gate (Blocking)
+
+**Purpose**: No implementation may start until this scaffold is revised against current repo truth.
+
+**CRITICAL**: No later task may begin until this phase is complete.
+
+- [ ] T001 Reread `docs/direction.md`, `docs/current-state.md`, and
+      `docs/packet-prep/023-runtime-truth-and-run-trace.md` and record any truth drift in
+      `specs/023-runtime-truth-and-run-trace/spec.md`
+- [ ] T002 Confirm packet `022` and any reused upstream packet work are complete enough to rely on
+      before code work begins, then update `specs/023-runtime-truth-and-run-trace/spec.md`,
+      `specs/023-runtime-truth-and-run-trace/plan.md`, and
+      `specs/023-runtime-truth-and-run-trace/quickstart.md`
+- [ ] T003 Rerun scaffold refinement for `specs/023-runtime-truth-and-run-trace/spec.md`,
+      `specs/023-runtime-truth-and-run-trace/plan.md`, and
+      `specs/023-runtime-truth-and-run-trace/tasks.md` if repo truth moved
+- [ ] T004 Refresh `specs/023-runtime-truth-and-run-trace/analyze.md` from a fresh
+      `/speckit.analyze`-style pass before any implementation begins
+
+**Checkpoint**: Packet `023` is revalidated and safe to implement against.
+
+---
+
+## Phase 2: Foundational Contract Freeze (Blocking Prerequisites)
+
+**Purpose**: Freeze the shared truth and taxonomy contract before any surface-specific work.
+
+**CRITICAL**: No user story work may begin until this phase is complete.
+
+- [ ] T005 Freeze the shared run-trace and proof-boundary contract in
+      `specs/023-runtime-truth-and-run-trace/contracts/run-trace-proof-boundary-contract.md`
+- [ ] T006 Add or update shared value objects for packet `023` truth and trace taxonomy in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T007 [P] Extend transport-level trace record inputs in
+      `crates/mister-smith-transport/src/envelope.rs` only as needed to support the packet `023`
+      contract
+- [ ] T008 Extend event-bus truth synthesis to project the frozen contract in
+      `crates/mister-smith-events/src/bus.rs`
+
+**Checkpoint**: One shared packet `023` contract exists before projection or surface work starts.
+
+---
+
+## Phase 3: User Story 1 - Honest Proof Boundaries (Priority: P1) 🎯 MVP
+
+**Goal**: Make current placeholder-boundary runs clearly non-grounded on result surfaces.
+
+**Independent Test**: A run that completes through the current `workflow.execute_step` path still
+states graph success without claiming grounded task proof.
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Add truth-boundary regression coverage in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+- [ ] T010 [P] [US1] Extend smoke-harness proof-boundary assertions in
+      `scripts/tests/test_live_runtime_proof_smoke.py`
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Freeze the placeholder-step boundary wording and projection rules in
+      `crates/mister-smith-app/src/execution.rs` and
+      `crates/mister-smith-app/src/autonomy.rs`
+- [ ] T012 [US1] Ensure task and autonomy projections distinguish substrate completion from
+      grounded task proof in `crates/mister-smith-core/src/autonomy.rs` and
+      `crates/mister-smith-events/src/bus.rs`
+- [ ] T013 [US1] Sync packet-owned proof-boundary wording with durable packet notes under `docs/plans/`
+      if implementation changes current rendered truth
+
+**Checkpoint**: Placeholder-boundary runs are clearly non-grounded across supported result views.
+
+---
+
+## Phase 4: User Story 2 - Canonical Run-Trace Taxonomy (Priority: P1)
+
+**Goal**: Freeze one shared taxonomy for run-trace relationships without widening packet scope.
+
+**Independent Test**: Graph, branch, node, tool, repair, retry, fan-out, join, and supervision
+relationships can all be represented through one packet-owned taxonomy.
+
+### Tests for User Story 2
+
+- [ ] T014 [P] [US2] Add typed contract coverage for new run-trace entities in
+      `crates/mister-smith-core/tests/trait_compilation_tests.rs`
+- [ ] T015 [P] [US2] Add event projection coverage for trace relationships in
+      `crates/mister-smith-events/tests/autonomy_event_tests.rs`
+
+### Implementation for User Story 2
+
+- [ ] T016 [P] [US2] Add or refine trace-taxonomy value objects in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T017 [P] [US2] Extend event-bus synthesis for fan-out, join, repair, retry, and supervision
+      trace relationships in `crates/mister-smith-events/src/bus.rs`
+- [ ] T018 [US2] Reconcile transport trace-root inputs with the packet `023` taxonomy in
+      `crates/mister-smith-transport/src/envelope.rs`
+
+**Checkpoint**: Packet `023` taxonomy is shared, bounded, and ready for projection use.
+
+---
+
+## Phase 5: User Story 3 - Consistent Surface Projection (Priority: P2)
+
+**Goal**: Keep task, session, autonomy, and operator run-detail surfaces aligned without turning
+the packet into a UI redesign.
+
+**Independent Test**: The same run tells the same bounded truth story across task, session,
+autonomy, and operator surfaces.
+
+### Tests for User Story 3
+
+- [ ] T019 [P] [US3] Extend task, session, and autonomy projection tests in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs` and create
+      `crates/mister-smith-app/tests/conversation_status_tests.rs` if session-specific coverage
+      needs a separate file
+- [ ] T020 [P] [US3] Add operator-console view coverage in
+      `apps/operator-console/src/views/`
+
+### Implementation for User Story 3
+
+- [ ] T021 [P] [US3] Project the packet `023` truth contract through task, session, and autonomy
+      surfaces in `crates/mister-smith-app/src/autonomy.rs`,
+      `crates/mister-smith-app/src/conversation.rs`, and
+      `crates/mister-smith-events/src/bus.rs`
+- [ ] T022 [P] [US3] Render the same bounded truth story in
+      `apps/operator-console/src/views/` without widening into new dashboard scope
+- [ ] T023 [US3] Update any state-bearing packet notes or router docs only as needed to reflect
+      implemented packet `023` truth, without presenting the packet as broader than it is
+
+**Checkpoint**: Supported surfaces tell one bounded truth story for the same run.
+
+---
+
+## Final Validation And Evidence
+
+- [ ] T024 Run `cargo test -p mister-smith-core`
+- [ ] T025 Run `cargo test -p mister-smith-events --test autonomy_event_tests`
+- [ ] T026 Run `cargo test -p mister-smith-app --test autonomy_status_tests`
+- [ ] T027 Run `cargo test -p mister-smith-app workflow_step_tool_marks_payload_as_tool_bus_completed`
+- [ ] T028 Run `python3 -m unittest scripts.tests.test_live_runtime_proof_smoke`
+- [ ] T029 Run `git diff --check`
+- [ ] T030 Capture or refresh the packet-owned analysis and proof-boundary note in
+      `specs/023-runtime-truth-and-run-trace/analyze.md` and any required `docs/plans/` note
+
+## Parallel Staging Directive
+
+`[P]` means the task may run in parallel only when its write set is disjoint from every other
+active lane and all blocking checkpoint tasks in the current section are already complete.
+
+Shared-write choke points for packet `023` implementation:
+
+- `crates/mister-smith-core/src/autonomy.rs`
+- `crates/mister-smith-events/src/bus.rs`
+- `crates/mister-smith-app/src/execution.rs`
+- `crates/mister-smith-app/src/autonomy.rs`
+- active truth-state notes under `docs/plans/`
+
+Only one active lane may own a choke-point file at a time.
+
+## Explicitly Out Of Scope For This Packet
+
+- packet `022` durable lifecycle, event-history, compaction, or effect-boundary implementation
+- generic observability-platform work or export-pipeline work
+- UI polish or dashboard redesign
+- coordinator-runtime or real subagent-runtime implementation
+- pretending that placeholder step completion is grounded task proof


### PR DESCRIPTION
## Summary
- add the full packet 023 scaffold artifact set under `specs/023-runtime-truth-and-run-trace`
- freeze the run-trace taxonomy, proof-boundary wording, and revalidation gate
- keep this packet scaffold-only and revision-required before any later implementation

## Notes
- packet `022` remains the owner of lifecycle, history, compaction, and effect-boundary semantics
- packets `019` and `020` remain the last fresh live-proof baseline
- packet `021` remains deterministic-only supervision evidence, not a new live default-path proof claim
- this PR does not claim packet `023` is implementation-ready

## Validation
- `./.specify/scripts/bash/check-prerequisites.sh --json --paths-only`
- `./.specify/scripts/bash/setup-plan.sh --json`
- `./.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`
- `git diff --check -- /Users/macmain/MisterSmith/specs/023-runtime-truth-and-run-trace`
- `npx markdownlint-cli2 "/Users/macmain/MisterSmith/specs/023-runtime-truth-and-run-trace/**/*.md" --config /Users/macmain/MisterSmith/.markdownlint.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification documentation for runtime truth and run trace system, including requirements checklists, contract definitions, data models, implementation plans, and analysis reports to guide future development phases.

* **Chores**
  * Established revalidation gates and prerequisite checks for upcoming implementation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->