### PR TITLE
docs: scaffold packet 024 boundary hardening

### DIFF
--- a/specs/024-agent-boundary-security-hardening/analyze.md
+++ b/specs/024-agent-boundary-security-hardening/analyze.md
@@ -1,0 +1,73 @@
+# Specification Analysis Report
+
+This report reflects the draft-scaffolding pass across `spec.md`, `plan.md`, `contracts/`, and
+`tasks.md` for packet `024`.
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| -- | -------- | -------- | ----------- | ------- | -------------- |
+| A1 | Ambiguity | LOW | packet docs | Earlier packet work may change reused contracts before `024` implementation starts. | Refresh before code starts. |
+
+No critical or high-severity cross-artifact conflicts were detected in this draft scaffold.
+The one intentional low-severity risk is already captured by the packet's revision gate.
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| discover-execute-separation | Yes | T006, T007, T008, T009, T010 | ToolBus and MCP both preserve separate discover and execute actions. |
+| descriptor-and-action-binding | Yes | T006, T007, T008, T009, T010, T019, T022 | Exact delegated action matching and revocation stay covered. |
+| mcp-2025-11-25-baseline | Yes | T001, T002, T003 | The refresh gate and contract refresh preserve the version-pinned protocol rule. |
+| packet-016-continuity-no-live-reject | Yes | T001, T002, T018, T019, T022, T023 | Continuity remains preserved without inventing a new live reject surface. |
+| jwt-auth-callout-delegation-baseline | Yes | T018, T019, T021, T022 | Identity work stays on the current least-privilege baseline. |
+| persistent-ephemeral-boundary-rule | Yes | T012, T016, T020, T021 | Sandbox and lifecycle isolation remain explicit. |
+| required-quarantine-for-protected-crossings | Yes | T012, T014, T016 | Required quarantine paths and failures stay covered. |
+| size-schema-pattern-validation | Yes | T011, T013, T015, T017 | Validation and shared-state mediation both remain explicit. |
+| explicit-pass-sanitize-reject-quarantine-outcomes | Yes | T011, T012, T014, T015 | Outcome mapping and audit reasons are part of the packet. |
+| revocation-audit-no-fabrication | Yes | T018, T019, T021, T022, T023 | Boundary evidence and continuity stay tied to real runtime facts. |
+| bounded-packet-scope | Yes | T001, T002, T003, T004, T005 | Refresh and contract freeze keep scope tight. |
+| no-generic-iam-compliance-interop-expansion | Yes | T001, T002, T003, T004, T005 | Deferred scope is explicit across all packet artifacts. |
+| pre-implementation-refresh-gate | Yes | T001, T002 | The packet blocks implementation on a revision pass. |
+| exact-repo-anchor-fidelity | Yes | T001, T002, T003, T004, T005 | Refresh and contract tasks enforce anchor-based packet wording. |
+| deny-wins-and-quarantined-fallback | Yes | T018, T021 | Auth-callout and identity tasks preserve current fallback posture. |
+
+## Contract Alignment
+
+- `contracts/capability-boundary-contract.md` freezes the discover-versus-execute split and
+  descriptor-and-action matching across ToolBus and MCP.
+- `contracts/quarantine-and-schema-enforcement.md` freezes the validation pipeline and explicit
+  boundary outcomes before agent consumption.
+- `contracts/identity-and-sandbox-boundary.md` freezes the current JWT/auth-callout/delegation
+  baseline plus persistent-versus-ephemeral sandbox rules and packet `016` continuity.
+
+## Constitution Alignment Issues
+
+None detected.
+
+- the packet is spec-first
+- the packet is bounded
+- the packet is explicit about provisional status and later refresh
+- the packet keeps deterministic validation and live-proof claims separate
+
+## Unmapped Tasks
+
+None. The refresh gate and contract-refresh tasks map to the packet's provisional-authority and
+bounded-scope requirements.
+
+## Metrics
+
+- Total Requirements: 15
+- Total Tasks: 31
+- Coverage: 15/15 requirements mapped to one or more tasks (100%)
+- Ambiguity Count: 1
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Packet `024` is ready as a draft scaffold and does not need another clarify pass right now.
+- Before any implementation starts, run the refresh gate and revise the packet against newly landed
+  earlier packet work.
+- If implementation begins later, keep Phase 0 and Phase 1 serial until the reused contracts stop
+  moving.

--- a/specs/024-agent-boundary-security-hardening/checklists/requirements.md
+++ b/specs/024-agent-boundary-security-hardening/checklists/requirements.md
@@ -1,0 +1,71 @@
+# Packet Quality Checklist: Agent-Boundary Security Hardening
+
+**Purpose**: Validate the quality, clarity, and boundedness of the packet `024` requirements before
+implementation planning moves forward
+**Created**: 2026-04-01
+**Feature**: `/Users/macmain/MisterSmith/specs/024-agent-boundary-security-hardening/spec.md`
+
+**Note**: This checklist tests packet requirements and packet-authoring quality. It does not test
+implementation behavior.
+
+## Repo Anchor Accuracy
+
+- [ ] CHK001 Are all major claims tied to exact repo seams rather than broad crate summaries?
+      [Completeness, Spec §Current Truth & Scope]
+- [ ] CHK002 Are packet `016`, `MS-77`, and Phase 9.1 contract references aligned with the
+      current packet wording? [Consistency, Spec §Input]
+
+## Boundary Separation
+
+- [ ] CHK003 Are discover and execute permissions described as separate boundary actions everywhere
+      they appear? [Clarity, Spec §FR-001]
+- [ ] CHK004 Is descriptor-only matching explicitly rejected in favor of descriptor-and-action
+      matching? [Clarity, Spec §FR-002]
+
+## Protocol Baseline
+
+- [ ] CHK005 Does the packet clearly pin MCP protocol references to the `2025-11-25` versioned
+      pages? [Completeness, Spec §Clarifications, Spec §FR-003]
+- [ ] CHK006 Does the packet clearly keep MCP security best-practices docs in a guidance role
+      instead of a frozen protocol role? [Clarity, Research §Official docs and why they matter]
+
+## Quarantine And Schema Enforcement
+
+- [ ] CHK007 Are size, schema, malicious-pattern, and quarantine stages all explicitly covered in
+      the requirements? [Coverage, Spec §FR-007 through Spec §FR-009]
+- [ ] CHK008 Are pass, sanitize, reject, and quarantine outcomes defined clearly enough for future
+      tests and contract writing? [Measurability, Spec §FR-009]
+
+## Packet 016 Continuity
+
+- [ ] CHK009 Does the packet preserve accepted delegated task-ingress continuity without reopening
+      the rejected-path proof question? [Consistency, Spec §FR-004]
+- [ ] CHK010 Does the packet avoid fabricating a workflow-backed live reject surface? [Clarity,
+      Spec §Clarifications]
+
+## Draft Scaffold Integrity
+
+- [ ] CHK011 Is the provisional scaffold note present in `spec.md`, `plan.md`, and `tasks.md`?
+      [Completeness]
+- [ ] CHK012 Is the revision-before-implementation gate explicit and easy to find? [Clarity,
+      Spec §Draft Status And Revision Gate]
+
+## Scope Discipline
+
+- [ ] CHK013 Are generic IAM, compliance, and broader interop design clearly kept out of scope?
+      [Coverage, Spec §Current Truth & Scope, Spec §FR-012]
+- [ ] CHK014 Is persistent-versus-ephemeral separation framed as a boundary rule rather than a
+      broader redesign? [Clarity, Spec §Clarifications, Spec §FR-006]
+
+## Future Implementation Readiness
+
+- [ ] CHK015 Do the packet contracts and tasks preserve the current JWT/auth-callout/delegation
+      baseline without silently upgrading to SPIFFE? [Consistency]
+- [ ] CHK016 Does every functional requirement have at least one future task path in `tasks.md`?
+      [Traceability]
+
+## Notes
+
+- Use this checklist before future implementation work starts.
+- If earlier packets land with changed contracts, refresh this packet before checking off these
+  items.

--- a/specs/024-agent-boundary-security-hardening/contracts/capability-boundary-contract.md
+++ b/specs/024-agent-boundary-security-hardening/contracts/capability-boundary-contract.md
@@ -1,0 +1,110 @@
+# Contract: Capability Boundary Surface
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Design Goal
+
+Freeze one least-privilege capability contract across ToolBus and MCP so discovery stays bounded,
+execution stays action-bound, and delegated authority is checked before handler execution.
+
+This contract is part of draft packet scaffolding and must be refreshed before implementation if
+earlier packet work changes reused capability or delegation seams.
+
+## Canonical Mapping
+
+The contract for packet `024` is:
+
+- every capability surface publishes one stable descriptor
+- discovery and execution are separate actions on that descriptor
+- descriptor match alone is not enough for execution
+- execution requires the exact action binding, required scope, and revocation key
+- bounded discovery may expose the descriptor and action requirements without granting execute
+  authority
+
+No packet `024` surface may collapse discover and execute into one ambient permission.
+
+## Canonical Capability Shape
+
+Example authoritative shape:
+
+```json
+{
+  "descriptor_id": "tool:smith.describe_external_capabilities",
+  "boundary_family": "mcp.tool",
+  "discover_action": {
+    "action_id": "tool:describe_external_capabilities#discover",
+    "kind": "discover",
+    "required_scope": null,
+    "revocation_key": "tool:describe_external_capabilities#discover"
+  },
+  "execute_action": {
+    "action_id": "tool:describe_external_capabilities#execute",
+    "kind": "execute",
+    "required_scope": "InvokeTool",
+    "revocation_key": "tool:describe_external_capabilities#execute"
+  }
+}
+```
+
+Behavior:
+
+- `discover_action` is for capability inspection only
+- `execute_action` is for invocation only
+- if a caller presents only discover authority and attempts execution, the boundary rejects it
+- if descriptor identifiers match but action identifiers or revocation keys do not, the boundary
+  rejects the call before dispatch
+
+## ToolBus Contract
+
+The ToolBus contract remains grounded in:
+
+- `crates/mister-smith-agents/src/tool_bus.rs`
+
+Expected behavior:
+
+- `CapabilityDescriptor` continues to publish separate discover and execute actions
+- the live enforcement path continues to require the exact delegated action needed by the boundary
+- local and remote tool surfaces use the same least-privilege posture
+
+## MCP Contract
+
+The MCP contract remains grounded in:
+
+- `crates/mister-smith-mcp/src/server.rs`
+- `crates/mister-smith-mcp/src/compatibility.rs`
+
+Expected behavior:
+
+- `tools/list` and `describe_external_capabilities` stay on discover authority
+- `tools/call` stays on execute authority
+- `handle_tools_call` validates the exact expected boundary action before handler execution
+- `describe_external_capabilities` continues to expose descriptor and action metadata without
+  widening into ambient execute permission
+
+## Protocol Source Rule
+
+Packet `024` uses:
+
+- MCP versioning pages
+- MCP `2025-11-25` authorization pages
+
+Packet `024` does **not** use latest or mixed MCP protocol pages as its frozen contract.
+MCP security best-practices docs may inform hardening guidance, but they do not replace the
+version-pinned protocol baseline.
+
+## Relationship To Packet 016
+
+Packet `024` preserves packet `016` continuity rules:
+
+- accepted delegated task ingress remains baseline truth
+- no new workflow-backed live rejection surface is invented here
+- capability-boundary hardening must compose with that continuity rather than reopening it
+
+## Deferred
+
+This contract does not freeze:
+
+- generic interop protocol design
+- broader A2A mapping
+- a new identity program
+- compliance or operator-dashboard work beyond the named capability boundary

--- a/specs/024-agent-boundary-security-hardening/contracts/identity-and-sandbox-boundary.md
+++ b/specs/024-agent-boundary-security-hardening/contracts/identity-and-sandbox-boundary.md
@@ -1,0 +1,103 @@
+# Contract: Identity And Sandbox Boundary
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Design Goal
+
+Freeze one least-privilege identity and sandbox contract across delegation, auth callout, and
+persistent-versus-ephemeral sandbox boundaries without widening into a new IAM program.
+
+This contract is part of draft packet scaffolding and must be refreshed before implementation if
+earlier packet work changes reused identity or continuity seams.
+
+## Identity Baseline
+
+Packet `024` keeps this current identity baseline:
+
+- JWT-backed principal claims
+- auth-callout-issued least-privilege NATS credentials
+- bounded delegation capabilities and provenance chains
+- external delegation envelopes for boundary crossings
+
+This packet does **not** adopt a new SPIFFE-based identity rollout.
+SPIFFE remains comparator guidance only for later work.
+
+## Auth Callout Contract
+
+Expected behavior from `crates/mister-smith-security/src/auth_callout.rs`:
+
+- permission tiers remain `full`, `standard`, `restricted`, and `quarantined`
+- fallback stays on the minimal quarantined posture
+- `$SYS.>` and `$JS.>` remain denied for narrowed credentials
+- TTL remains bounded by current tier rules
+- delegation references, when present, remain tied to the current validated authority chain
+
+## Delegation Contract
+
+Expected behavior from `crates/mister-smith-security/src/delegation.rs`:
+
+- delegated authority stays bound to exact action requirements
+- revocation and expiry remain first-class enforcement paths
+- external envelopes remain bounded wrappers around current capability and provenance data
+- provenance depth and chain validation remain deterministic
+
+## Sandbox Contract
+
+Expected behavior from:
+
+- `crates/mister-smith-security/src/sandbox.rs`
+- `crates/mister-smith-agents/src/sandbox.rs`
+
+The packet freezes:
+
+- persistent and ephemeral agent classes as a boundary rule
+- least-privilege subject reach by class
+- explicit crossing rules for cross-account movement
+- required cleanup of ephemeral credentials
+- shared-state mediation rather than direct unrestricted access
+
+Persistent-versus-ephemeral separation is a boundary-hardening rule here, not a broader redesign of
+all runtime roles.
+
+## Packet 016 Continuity Rule
+
+Packet `024` preserves packet `016` truth:
+
+- accepted delegated `POST /api/v1/tasks` continuity remains the landed baseline
+- rejected delegated requests still do not imply a workflow-backed live reject surface unless the
+  runtime actually grows one
+- packet `024` may harden identity and delegation checks, but it may not invent a new continuity
+  story from metadata alone
+
+## Canonical Evidence Shape
+
+Example authoritative shape:
+
+```json
+{
+  "principal_id": "agent-123",
+  "permission_tier": "restricted",
+  "delegation_ref": {
+    "descriptor_id": "tool:smith.resolve_issue_lifecycle",
+    "action_id": "tool:smith.resolve_issue_lifecycle#execute"
+  },
+  "agent_class": "ephemeral",
+  "fallback_applied": false,
+  "continuity_ref": "packet-016-accepted-ingress"
+}
+```
+
+Behavior:
+
+- identity evidence must remain least-privilege
+- fallback posture must be explicit
+- continuity references must not fabricate a missing live reject surface
+
+## Deferred
+
+This contract does not freeze:
+
+- enterprise IAM rollout
+- SPIFFE implementation
+- a broader trust-scoring program beyond the current auth-callout seam
+- generic operator-facing identity dashboards

--- a/specs/024-agent-boundary-security-hardening/contracts/quarantine-and-schema-enforcement.md
+++ b/specs/024-agent-boundary-security-hardening/contracts/quarantine-and-schema-enforcement.md
@@ -1,0 +1,109 @@
+# Contract: Quarantine And Schema Enforcement
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Design Goal
+
+Freeze one deterministic mediation contract for cross-boundary payloads and shared-state reads so
+content is validated before agent consumption and boundary outcomes are explicit.
+
+This contract is part of draft packet scaffolding and must be refreshed before implementation if
+earlier packet work changes the reused validator, quarantine, or sandbox seams.
+
+## Validation Pipeline
+
+Packet `024` keeps the current validation pipeline as the canonical baseline:
+
+1. size check
+2. sanitization of disallowed control content
+3. schema validation
+4. malicious-pattern inspection
+5. taint-label classification
+6. quarantine action mapping
+
+This contract remains grounded in:
+
+- `crates/mister-smith-security/src/state_validator.rs`
+- `crates/mister-smith-security/src/quarantine.rs`
+- `crates/mister-smith-security/src/sandbox.rs`
+- `crates/mister-smith-agents/src/sandbox.rs`
+- `crates/mister-smith-persistence/src/repository/agent.rs`
+
+## Canonical Outcomes
+
+The packet freezes these canonical outcomes:
+
+- `Pass`
+  - clean payload, forward unchanged
+- `Sanitize`
+  - payload forwarded after deterministic sanitization
+- `Reject`
+  - boundary blocks the payload and returns an error
+- `Quarantine`
+  - boundary isolates the payload for investigation and blocks it
+
+The packet also preserves the existing taint labels:
+
+- `Clean`
+- `Sanitized`
+- `Suspicious`
+- `Rejected`
+
+`Suspicious` remains a monitored state, not silent success.
+
+## Shared-State Contract
+
+Expected behavior:
+
+- shared-state reads and writes that cross a protected boundary remain mediated through the same
+  validation and quarantine rules
+- no shared-state payload is passed directly into agent context without deterministic mediation
+- validated state returned to an agent includes enough classification data for downstream audit or
+  monitoring
+
+## Cross-Boundary Contract
+
+Expected behavior:
+
+- when a crossing rule says quarantine is required, the boundary must route through a quarantine
+  actor
+- if quarantine is required and no quarantine actor is attached, the crossing fails explicitly
+- same-account traffic may pass only when the current sandbox rules allow it
+
+## Canonical Evidence Shape
+
+Example authoritative shape:
+
+```json
+{
+  "boundary": "shared_state",
+  "source": "shared_state",
+  "target": "agent",
+  "resource": "read:memory.snapshot",
+  "action": "sanitize",
+  "taint_label": "sanitized",
+  "reason": "control characters removed during sanitization",
+  "detected_pattern": null,
+  "monitored": true
+}
+```
+
+Behavior:
+
+- the action and taint label must stay coherent
+- non-pass outcomes always carry a reason
+- suspicious or sanitized content remains visible to audit and monitoring
+
+## Source Rule
+
+Packet `024` uses JSON Schema as the structural-validation reference.
+It does not widen into a generic semantic-policy engine or a model-enforced safety layer.
+
+## Deferred
+
+This contract does not freeze:
+
+- a new classifier service
+- ML-based semantic filtering
+- a broader content moderation program
+- UI work beyond boundary evidence already justified by existing runtime seams

--- a/specs/024-agent-boundary-security-hardening/data-model.md
+++ b/specs/024-agent-boundary-security-hardening/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: Agent-Boundary Security Hardening
+
+## Boundary capability entities
+
+### `BoundaryCapabilityDescriptor`
+
+- `descriptor_id`: stable surface identifier such as `tool:namespace.name`
+- `boundary_family`: boundary class such as `tool_bus`, `mcp_tool`, or future adapter family
+- `title`: human-readable surface title
+- `description`: short operator-facing description
+- `discover_action`: action binding for bounded discovery
+- `execute_action`: action binding for execution
+- `required_scope`: execution scope required for the bound surface
+
+### `BoundaryActionBinding`
+
+- `descriptor_id`: capability descriptor the action belongs to
+- `action_id`: exact delegated action identifier
+- `kind`: discover or execute
+- `scope`: delegated scope required, if any
+- `resource`: policy resource family
+- `resource_id`: exact resource name
+- `revocation_key`: revocation handle bound to the action
+
+## Identity and credential entities
+
+### `BoundaryCredentialLease`
+
+- `principal_id`: current boundary principal identifier
+- `permission_tier`: full, standard, restricted, or quarantined
+- `ttl_secs`: effective credential lifetime
+- `publish_allow`: allowed publish subjects
+- `subscribe_allow`: allowed subscribe subjects
+- `fallback_applied`: whether minimal fallback posture was used
+- `delegation_ref`: optional active delegated capability reference
+
+### `SandboxBoundaryClass`
+
+- `agent_class`: persistent or ephemeral
+- `account_name`: logical account used for the credential
+- `subject_reach`: allowed same-account or crossing-rule reach
+- `cleanup_rule`: how credentials and temporary state are cleaned up
+
+## Quarantine and validation entities
+
+### `ValidatedSharedState`
+
+- `state_type`: validator schema reference
+- `schema_version`: schema identifier used for validation
+- `taint_label`: clean, sanitized, suspicious, or rejected
+- `forwardable`: whether the payload may continue toward agent context
+- `monitored`: whether the payload should remain under heightened monitoring
+
+### `QuarantineInspectionRecord`
+
+- `boundary`: boundary class such as `cross_boundary` or `shared_state`
+- `source`: source side of the transfer
+- `target`: target side of the transfer
+- `resource`: crossed subject or state key
+- `action`: pass, sanitize, reject, or quarantine
+- `taint_label`: final validation label
+- `reason`: human-readable explanation for non-pass outcomes
+- `detected_pattern`: optional malicious pattern marker
+
+## Boundary evidence entity
+
+### `BoundaryEvidenceSummary`
+
+- `surface`: boundary surface such as `tool_bus`, `mcp`, `task_ingress`, or `shared_state`
+- `descriptor_id`: exact capability descriptor when applicable
+- `action_id`: exact action identifier when applicable
+- `outcome`: allowed, sanitized, rejected, quarantined, revoked, or missing
+- `continuity_ref`: optional packet `016` continuity reference when the decision is task-ingress
+- `audit_ref`: audit or event reference for later operator inspection
+- `fabricated`: must stay false for metadata-only projections
+
+## Invariants
+
+- discover and execute are separate action bindings even when they share one descriptor
+- descriptor match alone is not enough; action binding must match too
+- auth-callout fallback never grants more than quarantined access
+- persistent and ephemeral separation remains a boundary rule for credentials and shared-state
+  mediation
+- shared-state reads and cross-boundary payloads are validated before agent consumption
+- suspicious content may be monitored but still requires explicit labeling
+- packet `016` continuity may be preserved, but a live rejection surface must not be fabricated
+- this draft data model is provisional until the pre-implementation refresh gate confirms reused
+  contracts still match landed truth

--- a/specs/024-agent-boundary-security-hardening/plan.md
+++ b/specs/024-agent-boundary-security-hardening/plan.md
@@ -1,0 +1,220 @@
+# Implementation Plan: Agent-Boundary Security Hardening
+
+**Branch**: `024-agent-boundary-security-hardening` | **Date**: 2026-04-01 |
+**Spec**: [spec.md](spec.md)
+**Input**: Feature specification from
+`/specs/024-agent-boundary-security-hardening/spec.md`
+
+## Draft Status And Revision Gate
+
+This is draft scaffolding, not final implementation authority.
+
+- packet `024` is being scaffolded before earlier packets are fully complete
+- claims are based on current repo truth and current dossiers
+- before implementation, this plan MUST be revised against the then-current
+  `docs/current-state.md`, `docs/direction.md`, and any newly landed earlier packet artifacts
+- if earlier packet work changes reused contracts, packet `024` wins no authority over those
+  contracts until revised
+
+## Summary
+
+Current repo truth already includes the major security building blocks needed for packet `024`:
+ToolBus discover-versus-execute separation, MCP descriptor-and-action-bound enforcement, bounded
+delegation validation, auth callout, quarantine inspection, state validation, sandbox isolation,
+and packet `016` accepted-ingress continuity. This packet freezes those seams into one bounded
+least-privilege contract before later packets widen delegation or interoperability surfaces.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88.0 plus repo-owned markdown artifacts
+**Primary Dependencies**: `mister-smith-security`, `mister-smith-agents`,
+`mister-smith-mcp`, `mister-smith-persistence`, packet `016` continuity notes, and the Phase 9.1
+security-hardening contracts
+**Storage**: existing delegation metadata, audit streams, and shared-state storage through current
+PostgreSQL and JetStream-backed seams; no new storage technology is introduced by this packet
+**Testing**: targeted Rust tests in `mister-smith-security`, `mister-smith-agents`,
+`mister-smith-mcp`, and `mister-smith-persistence`, plus markdown and diff hygiene
+**Target Platform**: local macOS development and Linux runtime parity for the shipped Rust
+workspace
+**Project Type**: Rust workspace packet plus bounded packet documentation
+**Performance Goals**: keep least-privilege checks on the current runtime path, keep quarantine and
+validation deterministic, and avoid widening current hot paths into a generic policy engine
+**Constraints**: no generic IAM rollout, no broader interop design, no new live reject surface, no
+compliance expansion, and no silent drift away from MCP `2025-11-25` protocol pages
+**Scale/Scope**: one bounded packet that freezes boundary rules and defers implementation until a
+later refresh pass
+
+## Constitution Check
+
+| Principle | Status | Evidence |
+| --------- | ------ | -------- |
+| I. Canonical Single Source | PASS | Grounded in `docs/direction.md`, `docs/current-state.md`, packet `016`, `MS-77`, and current code seams. |
+| II. Spec-First Design | PASS | This packet is being scaffolded entirely through spec artifacts before implementation. |
+| III. Phase-And-Packet-Gated Delivery | PASS | Packet `024` is bounded and includes a mandatory pre-implementation refresh gate because earlier packets are still moving. |
+| IV. Model-Agnostic Architecture | PASS | The packet hardens boundaries and identity posture without introducing provider-specific logic. |
+| V. Erlang/OTP-Style Fault Tolerance | PASS | The packet builds on existing sandbox, quarantine, and auth-callout isolation rather than weakening them. |
+| VI. Evidence-Based Validation | PASS | Validation remains deterministic and explicitly avoids inventing live rejection proof. |
+| VII. Explicit Dependency Management | PASS | The write set and contract reuse are explicit and tied to named repo anchors. |
+| VIII. Clean Closure And Resumability | PASS | The scaffold includes draft-status notes, a refresh gate, and an analysis report for cold-start reuse. |
+
+## Project Structure
+
+```text
+specs/024-agent-boundary-security-hardening/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── capability-boundary-contract.md
+│   ├── quarantine-and-schema-enforcement.md
+│   └── identity-and-sandbox-boundary.md
+├── checklists/
+│   └── requirements.md
+├── tasks.md
+└── analyze.md
+
+crates/mister-smith-security/
+├── src/delegation.rs
+├── src/auth_callout.rs
+├── src/quarantine.rs
+├── src/state_validator.rs
+├── src/sandbox.rs
+└── tests/
+
+crates/mister-smith-agents/
+├── src/tool_bus.rs
+├── src/sandbox.rs
+└── tests/
+
+crates/mister-smith-mcp/
+├── src/server.rs
+├── src/compatibility.rs
+└── tests/
+
+crates/mister-smith-persistence/
+├── src/repository/agent.rs
+└── tests/
+```
+
+## Design Decisions
+
+### D1: This scaffold is real packet prep, but not final implementation authority
+
+**Decision**: packet `024` is authored now for speed, but implementation is blocked on a later
+refresh pass against newly landed earlier packet work.
+
+**Rationale**: this gives the repo a reusable packet shape now without pretending that moving
+upstream truth is already final.
+
+### D2: Discover and execute remain separate everywhere
+
+**Decision**: the packet freezes discover and execute as separate permissions and separate action
+bindings across ToolBus, MCP discovery, and MCP invocation.
+
+**Rationale**: MS-77 and the current ToolBus/MCP seams already prove this split is the safest
+baseline to preserve.
+
+### D3: Quarantine and schema enforcement happen before agent consumption
+
+**Decision**: cross-boundary content and shared-state reads remain mediated by size checks, schema
+validation, malicious-pattern inspection, and quarantine outcomes before agent context sees them.
+
+**Rationale**: the research and the Phase 9.1 contracts both point to deterministic mediation, not
+prompt-only handling, as the boundary rule to freeze.
+
+### D4: Current JWT/auth-callout/delegation posture stays the identity baseline
+
+**Decision**: packet `024` keeps the current JWT, auth-callout, and delegation-envelope posture as
+the implementation baseline and leaves SPIFFE as comparator guidance only.
+
+**Rationale**: this packet hardens the existing shipped seams rather than opening a second identity
+program.
+
+### D5: Persistent and ephemeral separation is a boundary rule, not a broader redesign
+
+**Decision**: packet `024` freezes persistent-versus-ephemeral separation for credentials, subject
+reach, and shared-state mediation without widening into a larger IAM or role-system rewrite.
+
+**Rationale**: the repo already has the right sandbox direction; the missing piece is one coherent
+boundary contract.
+
+### D6: Packet `016` continuity and no-fabrication stay intact
+
+**Decision**: packet `024` must compose with packet `016` accepted-ingress truth and must not
+invent a workflow-backed live reject surface.
+
+**Rationale**: packet `016` already closed that scope honestly, and this packet is not allowed to
+reopen it casually.
+
+## Minimal Implementation Slice
+
+### Milestone 0: Mandatory refresh gate before implementation
+
+**Scope**: re-read `docs/current-state.md`, `docs/direction.md`,
+`docs/packet-prep/024-agent-boundary-security-hardening.md`, and any earlier packet artifacts that
+land before packet `024` code starts.
+
+**Validation**:
+
+- packet `024` spec, plan, contracts, and tasks are revised if reused contracts drifted
+- no implementation begins until the refresh note is complete
+
+### Milestone 1: Freeze the capability-boundary contract
+
+**Scope**: preserve discover-versus-execute separation, exact descriptor/action binding, and
+bounded MCP capability discovery without widening authority.
+
+**Validation**:
+
+- targeted ToolBus and MCP tests prove the action-bound boundary still holds
+- packet contracts and tasks keep discover separate from execute everywhere
+
+### Milestone 2: Freeze quarantine and schema-enforcement behavior
+
+**Scope**: preserve deterministic size, schema, malicious-pattern, and quarantine behavior across
+cross-boundary payloads and shared-state reads.
+
+**Validation**:
+
+- targeted validator, quarantine, sandbox, and persistence tests cover clean, sanitized,
+  suspicious, rejected, and quarantined outcomes
+
+### Milestone 3: Freeze identity, sandbox, and continuity behavior
+
+**Scope**: preserve least-privilege auth-callout and sandbox credential posture, revocation,
+packet `016` continuity, and boundary evidence without widening into general IAM.
+
+**Validation**:
+
+- auth-callout, delegation, sandbox, and continuity tests remain green
+- packet `016` no-fabrication and no-live-reject rules remain intact
+
+## Parallel Staging Posture
+
+- blocking refresh checkpoint before any implementation lane begins:
+  - packet refresh and contract reconciliation
+- allowed disjoint lanes after the refresh checkpoint:
+  - ToolBus and MCP boundary lane
+  - quarantine and validator lane
+  - auth-callout and sandbox lane
+- single-owner choke points:
+  - `crates/mister-smith-agents/src/tool_bus.rs`
+  - `crates/mister-smith-mcp/src/server.rs`
+  - `crates/mister-smith-mcp/src/compatibility.rs`
+  - `crates/mister-smith-security/src/delegation.rs`
+  - `crates/mister-smith-security/src/auth_callout.rs`
+  - `crates/mister-smith-security/src/quarantine.rs`
+  - `crates/mister-smith-security/src/state_validator.rs`
+  - `crates/mister-smith-security/src/sandbox.rs`
+  - `crates/mister-smith-persistence/src/repository/agent.rs`
+
+## Explicitly Deferred
+
+- generic IAM or enterprise identity policy work
+- SPIFFE rollout work
+- broader interoperability protocol design
+- compliance, legal, or audit-program expansion beyond current runtime evidence
+- new live rejection proof for delegated HTTP task ingress
+- broader operator-console or observability redesign work

--- a/specs/024-agent-boundary-security-hardening/quickstart.md
+++ b/specs/024-agent-boundary-security-hardening/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart: Agent-Boundary Security Hardening
+
+## Draft Status
+
+This quickstart is part of draft packet scaffolding.
+
+- packet `024` is being scaffolded before earlier packets are fully complete
+- before implementation, refresh the packet against the then-current `docs/current-state.md`,
+  `docs/direction.md`, and newly landed earlier packet artifacts
+
+## Targeted deterministic validation
+
+Run the narrowest honest checks for a future packet `024` implementation:
+
+```bash
+cargo test -p mister-smith-security
+cargo test -p mister-smith-agents --test tool_bus_tests
+cargo test -p mister-smith-agents --test quarantine_tests
+cargo test -p mister-smith-mcp
+cargo test -p mister-smith-persistence
+cargo build --workspace
+git diff --check
+npx markdownlint-cli2 "specs/024-agent-boundary-security-hardening/**/*.md" --config .markdownlint.json
+```
+
+## Proof expectation
+
+Packet `024` earns proof by showing:
+
+- discover and execute remain separate across ToolBus and MCP boundaries
+- delegated action mismatch, missing delegation, and revocation are rejected before handler
+  execution
+- cross-boundary and shared-state payloads are deterministically validated before agent
+  consumption
+- auth-callout fallback stays on the current minimal quarantined posture
+- packet `016` continuity remains intact without inventing a workflow-backed live reject surface
+
+## Live-proof boundary
+
+This scaffolding pass does not create a new live runtime proof claim.
+
+If a later implementation captures live proof, it must stay bounded to the actual runtime surface
+used and must not imply:
+
+- a new generic IAM program
+- a new interoperability protocol claim
+- a broader compliance or observability claim
+- a new workflow-backed live reject surface unless the runtime actually grows one

--- a/specs/024-agent-boundary-security-hardening/research.md
+++ b/specs/024-agent-boundary-security-hardening/research.md
@@ -1,0 +1,91 @@
+# Research Notes: Agent-Boundary Security Hardening
+
+## Current repo truth
+
+- ToolBus already models `CapabilityDescriptor` with separate discover and execute actions in
+  `crates/mister-smith-agents/src/tool_bus.rs`
+- MCP already publishes descriptor and action metadata, and `handle_tools_call` validates the
+  exact delegated boundary action before handler execution in
+  `crates/mister-smith-mcp/src/server.rs`
+- `describe_external_capabilities` already keeps capability discovery bounded to a discover action
+  on the MCP side in `crates/mister-smith-mcp/src/compatibility.rs`
+- `DelegationService` already validates exact `DelegatedAction` bindings, revocation, and bounded
+  external envelopes in `crates/mister-smith-security/src/delegation.rs`
+- auth callout already narrows permissions by trust tier and falls back to quarantined permissions
+  in `crates/mister-smith-security/src/auth_callout.rs`
+- the validator and quarantine seams already define size, schema, malicious-pattern, sanitize,
+  reject, and quarantine behavior in `crates/mister-smith-security/src/state_validator.rs` and
+  `crates/mister-smith-security/src/quarantine.rs`
+- sandbox and persistence seams already freeze persistent-versus-ephemeral separation plus
+  mediated shared-state access in `crates/mister-smith-security/src/sandbox.rs`,
+  `crates/mister-smith-agents/src/sandbox.rs`, and
+  `crates/mister-smith-persistence/src/repository/agent.rs`
+- packet `016` already closed the accepted delegated task-ingress continuity slice and explicitly
+  kept live rejection proof out of scope
+
+## Official docs and why they matter
+
+### MCP protocol baseline
+
+- MCP versioning page
+  - keep the packet on one versioned protocol baseline instead of drifting between latest and
+    versioned pages
+- MCP `2025-11-25` authorization page
+  - keep authorization expectations tied to the same pinned revision the packet prep dossier names
+
+### Operational guidance, not frozen protocol
+
+- MCP security best practices
+  - use as operational advice about trust boundaries, consent, and hardening
+  - do not treat it as the canonical protocol contract for packet `024`
+
+### Transport and validation
+
+- NATS authorization
+  - subject-level least privilege remains the first hard boundary for current transport posture
+- NATS auth callout
+  - dynamic per-connection credentials remain the cleanest official fit for the current auth
+    posture
+- JSON Schema specification
+  - primary source for structural validation at the boundary
+
+### Comparator only
+
+- SPIFFE overview
+  - useful comparator for future workload identity work
+  - not part of the implementation baseline for packet `024`
+
+## Research signals that matter here
+
+### Deterministic enforcement beats prompt-only defenses
+
+- the consolidated security research is explicit that LLMs are unreliable policy enforcers
+- packet `024` therefore needs to freeze infrastructure-level boundary rules, not stronger prompt
+  instructions
+
+### Persistent and ephemeral separation is the strongest architectural defense already pointed to
+
+- the research and Phase 9.1 contracts converge on persistent-versus-ephemeral separation, I/O
+  firewall rules, and quarantine mediation as the most useful boundary pattern to preserve
+
+### Cross-boundary memory and shared-state reads must be mediated
+
+- infectious jailbreak, MINJA, and memory-injection findings all support the current repo move:
+  do not pass shared-state content straight into agent context
+
+### Discover-versus-execute separation is already the cleanest current boundary posture
+
+- MS-77 and the MCP server/client seams already prove the repo has the right shape for bounded
+  discovery without ambient execute authority
+- packet `024` should freeze and generalize that posture rather than reopening it
+
+## Bounded conclusion
+
+Packet `024` should not invent a new identity system, a broader interop contract, or a larger
+compliance program. The honest next packet is a boundary-hardening freeze over what the repo
+already has: least-privilege capability scoping, exact descriptor/action binding, quarantine and
+schema enforcement, persistent-versus-ephemeral sandbox rules, auth-callout narrowing, and packet
+`016` continuity.
+
+Because earlier packets are still moving, this packet stays explicitly provisional until a refresh
+pass confirms that its reused contracts still match landed repo truth.

--- a/specs/024-agent-boundary-security-hardening/spec.md
+++ b/specs/024-agent-boundary-security-hardening/spec.md
@@ -1,0 +1,263 @@
+# Feature Specification: Agent-Boundary Security Hardening
+
+**Feature Branch**: `024-agent-boundary-security-hardening`
+**Created**: 2026-04-01
+**Status**: Draft
+**Input**: `docs/direction.md`, `docs/current-state.md`, `docs/packet-prep/README.md`,
+`docs/packet-prep/024-agent-boundary-security-hardening.md`,
+`docs/research-output/consolidated/04-security-and-trust.md`,
+`docs/plans/2026-03-19-ms-77-bounded-external-agent-surface.md`,
+`docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md`,
+`specs/011-phase9.1-security-hardening/contracts/auth-callout.md`,
+`specs/011-phase9.1-security-hardening/contracts/agent-sandbox.md`,
+`specs/011-phase9.1-security-hardening/contracts/state-validator.md`, and the current runtime
+seams in `crates/mister-smith-agents/src/tool_bus.rs`,
+`crates/mister-smith-mcp/src/server.rs`,
+`crates/mister-smith-mcp/src/compatibility.rs`,
+`crates/mister-smith-security/src/delegation.rs`,
+`crates/mister-smith-security/src/auth_callout.rs`,
+`crates/mister-smith-security/src/quarantine.rs`,
+`crates/mister-smith-security/src/state_validator.rs`,
+`crates/mister-smith-security/src/sandbox.rs`,
+`crates/mister-smith-agents/src/sandbox.rs`, and
+`crates/mister-smith-persistence/src/repository/agent.rs`
+
+## Draft Status And Revision Gate
+
+This packet is draft scaffolding for future work.
+
+- packet `024` is being scaffolded before earlier packets are fully complete
+- claims are based on current repo truth and current dossiers
+- before implementation, this packet MUST be revised against the then-current
+  `docs/current-state.md`, `docs/direction.md`, and any newly landed earlier packet artifacts
+- if earlier packet work changes reused contracts, packet `024` wins no authority over those
+  contracts until revised
+
+## Current Truth & Scope
+
+Current repo truth already includes baseline behavior that this packet must reuse instead of
+reopening:
+
+- ToolBus capability descriptors already separate discover from execute actions and can require
+  delegated authority per action
+- the MCP boundary already has bounded discovery through `describe_external_capabilities`, plus
+  descriptor-and-action-bound delegated invocation checks
+- the current delegation layer already validates exact `DelegatedAction` bindings, revocation, and
+  bounded external envelopes
+- Phase 9.1 already landed auth callout, quarantine, sandbox, and state-validator contracts
+- packet `016` already proved accepted delegated HTTP task-ingress continuity and explicitly kept
+  live rejection proof out of scope because the current runtime does not create a workflow-backed
+  reject surface
+
+The remaining gap is narrower than generic security or interoperability work:
+
+- the repo does not yet freeze one coherent least-privilege runtime contract across ToolBus, MCP,
+  quarantine, schema enforcement, and identity boundaries
+- the current boundary hardening posture is spread across multiple crates, tests, and closure notes
+  instead of one bounded packet
+- later packets will widen delegation, runtime coordination, or interop reach, so boundary rules
+  should be frozen before that widening happens
+
+This packet therefore freezes one bounded security-hardening packet with three stories:
+
+1. least-privilege capability boundaries across ToolBus and MCP
+2. quarantine and schema enforcement before agent consumption
+3. identity, auth-callout, delegation continuity, and boundary evidence
+
+This is not:
+
+- a general IAM redesign
+- a compliance or policy program
+- a wider interoperability packet
+- a new live rejection proof packet
+- a broader runtime-truth, observability, or operator-console redesign packet
+
+## Clarifications
+
+### Session 2026-04-01
+
+- Q: What identity posture is in scope for this draft packet? → A: Keep the current JWT,
+  auth-callout, and delegation-envelope posture as the implementation baseline.
+- Q: Is SPIFFE part of packet `024`? → A: No. SPIFFE stays comparator guidance only and is out of
+  scope for this packet.
+- Q: How far does persistent versus ephemeral separation go here? → A: It is frozen as a boundary
+  rule for credentials, subject reach, and shared-state mediation, not widened into a broader IAM
+  redesign.
+- Q: Does packet `024` reopen packet `016` rejection proof? → A: No. Packet `016` keeps the
+  current rule that live rejection proof stays out of scope unless a workflow-backed reject surface
+  actually exists.
+- Q: Which MCP sources are authoritative for this packet? → A: Use the MCP `2025-11-25`
+  versioned pages as the protocol baseline and treat MCP security best-practices pages as
+  operational guidance only.
+
+## User Scenarios & Testing
+
+### User Story 1 - Keep capability boundaries least-privilege and action-bound (Priority: P1)
+
+An operator or framework maintainer needs ToolBus and MCP boundaries to keep discover permission
+separate from execute permission and reject delegated authority that does not match the exact
+descriptor and action being used.
+
+**Why this priority**: later packets will widen delegation and external capability reach, so the
+descriptor-and-action boundary needs to be frozen first.
+
+**Independent Test**: targeted ToolBus and MCP tests prove that discover and execute stay separate,
+that mismatched or revoked delegated actions are rejected, and that bounded discovery still works
+without widening execution authority.
+
+**Acceptance Scenarios**:
+
+1. **Given** a caller lists or inspects capabilities, **When** it uses a discover path,
+   **Then** the packet keeps discover permission separate from execute permission.
+2. **Given** a caller invokes a ToolBus or MCP action with a mismatched descriptor, action, or
+   revoked authority, **When** the boundary validates the request, **Then** the request is rejected
+   before handler execution.
+3. **Given** a caller uses the bounded MCP discovery surface, **When** it inspects the catalog,
+   **Then** it sees the exact descriptor and action requirements without gaining execute authority.
+
+---
+
+### User Story 2 - Quarantine and validate cross-boundary content before agent use (Priority: P1)
+
+An operator or framework maintainer needs all cross-boundary payloads and shared-state reads to
+pass through deterministic quarantine and schema enforcement before they enter agent working
+context.
+
+**Why this priority**: the security research and current repo seams both show that agents cannot be
+trusted to enforce this boundary for themselves.
+
+**Independent Test**: targeted quarantine, validator, sandbox, and persistence tests prove that
+clean payloads pass, sanitized payloads are marked, suspicious payloads are monitored, and rejected
+or quarantined payloads do not reach agent context.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cross-boundary payload that matches allowed structure and patterns, **When** it
+   crosses the boundary, **Then** it is forwarded with the correct validation outcome.
+2. **Given** a payload that violates size, schema, or malicious-pattern checks, **When** the
+   validator inspects it, **Then** the packet defines whether the result is sanitize, reject, or
+   quarantine and preserves the audit reason.
+3. **Given** a shared-state read from persistence, **When** the state is returned to an agent,
+   **Then** the read passes through the same validation and quarantine mediation before agent
+   consumption.
+
+---
+
+### User Story 3 - Keep identity, auth-callout, and delegation continuity bounded (Priority: P2)
+
+An operator or framework maintainer needs least-privilege identity and delegation rules to stay
+bounded across auth callout, sandbox credentials, and the already-landed packet `016` continuity
+surface.
+
+**Why this priority**: packet `024` should harden the existing identity boundary without widening
+into a new identity program or breaking packet `016` truth.
+
+**Independent Test**: targeted auth-callout, delegation, sandbox, and packet `016` continuity
+checks prove that least-privilege credentials stay narrow, quarantined fallback remains minimal,
+and packet `016` continuity rules remain intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated boundary principal with current delegated authority, **When** auth
+   callout or sandbox credentials are issued, **Then** permissions stay least-privilege and
+   revocation remains enforceable.
+2. **Given** a low-trust, missing-profile, or unavailable-auth-callout path, **When** fallback
+   applies, **Then** the result stays on the current minimal quarantined posture rather than a
+   broader default.
+3. **Given** the packet `016` accepted task-ingress path, **When** packet `024` tightens identity
+   and delegation rules, **Then** it preserves accepted-ingress continuity and does not invent a
+   workflow-backed live reject surface.
+
+## Edge Cases
+
+- a caller has discover delegation for a capability but tries to execute it
+- descriptor identifiers match while the action identifier or revocation key does not
+- a payload is schema-valid but still contains known malicious markers
+- sanitization changes object keys or payload shape in a way that creates conflicts
+- a cross-boundary payload requires quarantine, but no quarantine actor is attached
+- a shared-state read returns structurally valid but stale or suspicious content
+- auth callout is unavailable and fallback permissions must remain minimal
+- persistent and ephemeral agents need to communicate across an allowed rule, but only through
+  quarantine
+- earlier packet work changes a reused contract before packet `024` implementation begins
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST keep discover and execute permissions separate across ToolBus, MCP
+  `tools/list`, MCP `tools/call`, and the future adapter contracts frozen by this packet.
+- **FR-002**: System MUST bind delegated authority to the exact descriptor and action required at
+  the ToolBus and MCP call boundary rather than descriptor-only matching.
+- **FR-003**: System MUST treat MCP `2025-11-25` versioned pages as the protocol baseline for this
+  packet and MUST treat MCP security best-practices pages as operational guidance only.
+- **FR-004**: System MUST preserve packet `016` accepted delegated HTTP task-ingress continuity as
+  existing repo truth and MUST NOT invent a workflow-backed live rejection surface.
+- **FR-005**: System MUST keep the current JWT, auth-callout, and delegation-envelope posture as
+  the identity baseline for this packet and MUST NOT widen into a new SPIFFE rollout or generic
+  IAM program.
+- **FR-006**: System MUST freeze persistent-versus-ephemeral agent separation as a boundary rule
+  for credentials, subject reach, and shared-state mediation.
+- **FR-007**: System MUST route cross-boundary payloads through quarantine inspection whenever the
+  crossing rule requires quarantine.
+- **FR-008**: System MUST apply deterministic size, schema, and malicious-pattern validation before
+  shared-state or cross-boundary payloads enter agent working context.
+- **FR-009**: System MUST define explicit pass, sanitize, reject, and quarantine outcomes, plus
+  the audit reason and monitoring posture for each non-pass case.
+- **FR-010**: System MUST preserve revocation, audit, and no-fabrication rules as first-class
+  runtime facts rather than optional logs.
+- **FR-011**: System MUST keep packet scope bounded to ToolBus, MCP, delegation, quarantine, auth
+  callout, schema enforcement, and identity boundaries.
+- **FR-012**: System MUST NOT widen into generic IAM, compliance, broader interop design,
+  operator-console redesign, or unrelated observability work.
+- **FR-013**: System MUST carry a pre-implementation refresh gate that requires re-reading
+  `docs/current-state.md`, `docs/direction.md`, the packet dossier, and any newly landed earlier
+  packet artifacts before implementation starts.
+- **FR-014**: System MUST tie major packet claims to the exact repo anchors named in this packet,
+  its contracts, and its future implementation tasks.
+- **FR-015**: System MUST preserve the current deny-wins, least-privilege, and quarantined fallback
+  posture already present in the current authorization and auth-callout seams.
+
+### Key Entities
+
+- **BoundaryCapabilityDescriptor**: stable capability surface description for ToolBus or MCP that
+  distinguishes discover and execute actions.
+- **BoundaryActionBinding**: the exact descriptor, action, scope, and revocation key tuple required
+  to authorize one boundary crossing or tool invocation.
+- **BoundaryCredentialLease**: current least-privilege identity material issued through auth
+  callout or sandbox credentials, including TTL, subject reach, and fallback posture.
+- **QuarantineInspectionRecord**: deterministic inspection result carrying the action, taint label,
+  monitoring flag, reason, and any detected malicious pattern.
+- **ValidatedSharedState**: shared-state payload that has passed size, schema, and malicious-pattern
+  checks before agent consumption.
+- **BoundaryEvidenceSummary**: operator-facing and audit-facing summary of boundary decisions,
+  revocation, and continuity facts that must not fabricate state from raw metadata alone.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The packet remains bounded to ToolBus, MCP, delegation, quarantine, auth callout,
+  schema enforcement, and identity boundaries, with no broader IAM or interop work pulled in.
+- **SC-002**: Discover-versus-execute separation is explicit in the packet spec, contracts, and
+  tasks for every relevant boundary surface.
+- **SC-003**: The packet carries a visible draft-status note and revision-before-implementation gate
+  in `spec.md`, `plan.md`, and `tasks.md`.
+- **SC-004**: Every major packet claim maps to one or more exact repo anchors already named in the
+  dossier and frozen in the packet artifacts.
+- **SC-005**: The packet preserves packet `016` continuity and does not claim a new workflow-backed
+  live rejection surface.
+- **SC-006**: The packet defines deterministic quarantine and schema-enforcement outcomes for clean,
+  sanitized, suspicious, rejected, and quarantined boundary content.
+- **SC-007**: The packet `024` task plan maps every functional requirement to at least one future
+  implementation task and the packet analysis reports no critical internal contradictions.
+
+## Assumptions
+
+- earlier packets may still change reused contracts or truth-status details before packet `024`
+  implementation begins
+- current security, delegation, and MCP boundary seams remain the authoritative baseline until a
+  later landed packet explicitly changes them
+- packet `024` is being authored now to reduce future startup time, not because it is immediately
+  implementation-ready
+- no new live runtime proof claim is created by this scaffolding pass

--- a/specs/024-agent-boundary-security-hardening/tasks.md
+++ b/specs/024-agent-boundary-security-hardening/tasks.md
@@ -1,0 +1,206 @@
+# Tasks: Agent-Boundary Security Hardening
+
+**Input**: Design documents from `/specs/024-agent-boundary-security-hardening/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/`
+
+**Draft Status**: This task list is scaffolding only.
+
+- packet `024` is being scaffolded before earlier packets are fully complete
+- claims are based on current repo truth and current dossiers
+- before implementation, this task list MUST be revised against the then-current
+  `docs/current-state.md`, `docs/direction.md`, and any newly landed earlier packet artifacts
+- if earlier packet work changes reused contracts, packet `024` wins no authority over those
+  contracts until revised
+
+**Tests**: Included. Future implementation should use targeted Rust tests for capability-boundary,
+quarantine, validator, sandbox, delegation, and auth-callout seams, plus bounded doc hygiene.
+
+**Organization**: Tasks are grouped by a blocking refresh gate first, then by the three bounded
+stories frozen in the packet.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel only after all blocking tasks in the current section are complete
+  and the write set is disjoint
+- **[Story]**: Which user story the task advances (`US1` through `US3`)
+- Every task includes exact file paths
+
+---
+
+## Phase 0: Mandatory Refresh Gate (Blocking)
+
+**Purpose**: Reconcile packet `024` against landed truth before any implementation work starts.
+
+- [ ] T001 Re-read `docs/current-state.md`, `docs/direction.md`,
+      `docs/packet-prep/024-agent-boundary-security-hardening.md`, and newly landed earlier packet
+      artifacts, then record any contract drift in
+      `specs/024-agent-boundary-security-hardening/spec.md`
+- [ ] T002 Refresh draft packet artifacts in
+      `specs/024-agent-boundary-security-hardening/plan.md`,
+      `specs/024-agent-boundary-security-hardening/research.md`,
+      `specs/024-agent-boundary-security-hardening/data-model.md`,
+      `specs/024-agent-boundary-security-hardening/contracts/`, and
+      `specs/024-agent-boundary-security-hardening/tasks.md` if upstream packet work changed reused
+      seams
+
+**Checkpoint**: Packet `024` is refreshed against current truth and safe to implement.
+
+---
+
+## Phase 1: Shared Boundary Contract Freeze (Blocking Prerequisites)
+
+**Purpose**: Keep the packet contracts authoritative before code changes start.
+
+- [ ] T003 Refresh the capability boundary contract in
+      `specs/024-agent-boundary-security-hardening/contracts/capability-boundary-contract.md`
+- [ ] T004 Refresh the quarantine and schema enforcement contract in
+      `specs/024-agent-boundary-security-hardening/contracts/quarantine-and-schema-enforcement.md`
+- [ ] T005 Refresh the identity and sandbox boundary contract in
+      `specs/024-agent-boundary-security-hardening/contracts/identity-and-sandbox-boundary.md`
+
+**Checkpoint**: The shared contracts match the current repo seams and block scope drift.
+
+---
+
+## User Story 1 - Least-Privilege Capability Boundaries (Priority: P1)
+
+**Goal**: Keep ToolBus and MCP capability boundaries least-privilege, action-bound, and explicit
+about discover-versus-execute separation.
+
+**Independent Test**: prove discovery remains bounded and execution rejects mismatched or revoked
+delegated action bindings before handler execution.
+
+### Tests For User Story 1
+
+- [ ] T006 [P] [US1] Extend ToolBus capability-boundary coverage in
+      `crates/mister-smith-agents/tests/tool_bus_tests.rs`
+- [ ] T007 [P] [US1] Extend MCP discovery and action-bound invocation coverage in
+      `crates/mister-smith-mcp/src/server.rs` and
+      `crates/mister-smith-mcp/src/compatibility.rs`
+
+### Implementation For User Story 1
+
+- [ ] T008 [P] [US1] Reconcile shared capability descriptor and delegated-action use in
+      `crates/mister-smith-agents/src/tool_bus.rs`
+- [ ] T009 [P] [US1] Tighten MCP boundary action generation and tool metadata publication in
+      `crates/mister-smith-mcp/src/server.rs`
+- [ ] T010 [US1] Preserve bounded discovery and exact action enforcement in
+      `crates/mister-smith-mcp/src/compatibility.rs`
+
+**Checkpoint**: Discovery and execution remain separate across ToolBus and MCP.
+
+---
+
+## User Story 2 - Quarantine And Schema Enforcement (Priority: P1)
+
+**Goal**: Keep cross-boundary payloads and shared-state reads deterministically validated before
+agent consumption.
+
+**Independent Test**: prove clean payloads pass, sanitized payloads are marked, suspicious payloads
+stay monitored, and rejected or quarantined payloads do not reach agent context.
+
+### Tests For User Story 2
+
+- [ ] T011 [P] [US2] Extend validator pipeline coverage in
+      `crates/mister-smith-security/tests/validator_tests.rs`
+- [ ] T012 [P] [US2] Extend quarantine and sandbox crossing coverage in
+      `crates/mister-smith-security/tests/quarantine_tests.rs`,
+      `crates/mister-smith-security/tests/sandbox_tests.rs`,
+      `crates/mister-smith-agents/tests/quarantine_tests.rs`, and
+      `crates/mister-smith-agents/tests/sandbox_tests.rs`
+- [ ] T013 [P] [US2] Extend shared-state mediation coverage in
+      `crates/mister-smith-persistence/tests/repository_tests.rs`
+
+### Implementation For User Story 2
+
+- [ ] T014 [P] [US2] Reconcile quarantine decision mapping and audit reasons in
+      `crates/mister-smith-security/src/quarantine.rs`
+- [ ] T015 [P] [US2] Tighten state validation, taint labels, and malicious-pattern handling in
+      `crates/mister-smith-security/src/state_validator.rs`
+- [ ] T016 [P] [US2] Preserve required quarantine enforcement for protected crossings in
+      `crates/mister-smith-security/src/sandbox.rs` and
+      `crates/mister-smith-agents/src/sandbox.rs`
+- [ ] T017 [US2] Reconcile validated shared-state mediation in
+      `crates/mister-smith-persistence/src/repository/agent.rs`
+
+**Checkpoint**: Cross-boundary content and shared-state reads are deterministically mediated before
+agent use.
+
+---
+
+## User Story 3 - Identity, Auth Callout, And Delegation Continuity (Priority: P2)
+
+**Goal**: Keep least-privilege identity and delegation rules bounded without widening into a new
+IAM program or breaking packet `016` continuity truth.
+
+**Independent Test**: prove auth-callout fallback stays minimal, delegated authority remains
+action-bound, sandbox classes stay isolated, and packet `016` continuity assumptions still hold.
+
+### Tests For User Story 3
+
+- [ ] T018 [P] [US3] Extend auth-callout permission-tier and fallback coverage in
+      `crates/mister-smith-security/tests/auth_callout_tests.rs`
+- [ ] T019 [P] [US3] Extend delegated-action binding, expiry, and revocation coverage in
+      `crates/mister-smith-security/tests/delegation_tests.rs`
+- [ ] T020 [P] [US3] Extend identity and sandbox lifecycle isolation coverage in
+      `crates/mister-smith-security/tests/sandbox_tests.rs` and
+      `crates/mister-smith-agents/tests/sandbox_tests.rs`
+
+### Implementation For User Story 3
+
+- [ ] T021 [P] [US3] Tighten least-privilege auth-callout issuance and quarantined fallback in
+      `crates/mister-smith-security/src/auth_callout.rs`
+- [ ] T022 [P] [US3] Tighten external envelope, action binding, and revocation continuity in
+      `crates/mister-smith-security/src/delegation.rs`
+- [ ] T023 [US3] Reconcile packet `016` continuity assumptions in
+      `specs/024-agent-boundary-security-hardening/spec.md`,
+      `specs/024-agent-boundary-security-hardening/contracts/identity-and-sandbox-boundary.md`,
+      and `specs/024-agent-boundary-security-hardening/analyze.md` before landing code changes
+
+**Checkpoint**: Least-privilege identity posture stays bounded and packet `016` continuity remains
+honest.
+
+---
+
+## Final Validation And Evidence
+
+- [ ] T024 Run `cargo test -p mister-smith-security`
+- [ ] T025 Run `cargo test -p mister-smith-agents --test tool_bus_tests`
+- [ ] T026 Run `cargo test -p mister-smith-agents --test quarantine_tests`
+- [ ] T027 Run `cargo test -p mister-smith-mcp`
+- [ ] T028 Run `cargo test -p mister-smith-persistence`
+- [ ] T029 Run `cargo build --workspace`
+- [ ] T030 Run `git diff --check`
+- [ ] T031 Run `npx markdownlint-cli2 "specs/024-agent-boundary-security-hardening/**/*.md" --config .markdownlint.json`
+
+## Parallel Staging Directive
+
+`[P]` means a task may run in parallel only when:
+
+- every blocking checkpoint task in the current section is complete
+- its write set is disjoint from every other active lane
+
+Shared-write choke points for this packet:
+
+- `crates/mister-smith-agents/src/tool_bus.rs`
+- `crates/mister-smith-mcp/src/server.rs`
+- `crates/mister-smith-mcp/src/compatibility.rs`
+- `crates/mister-smith-security/src/delegation.rs`
+- `crates/mister-smith-security/src/auth_callout.rs`
+- `crates/mister-smith-security/src/quarantine.rs`
+- `crates/mister-smith-security/src/state_validator.rs`
+- `crates/mister-smith-security/src/sandbox.rs`
+- `crates/mister-smith-persistence/src/repository/agent.rs`
+- `specs/024-agent-boundary-security-hardening/contracts/`
+
+Only one active lane may own a choke-point path at a time.
+
+## Explicitly Out Of Scope For This Packet
+
+- generic IAM rollout
+- SPIFFE implementation
+- broader interoperability design
+- compliance expansion
+- new live rejection proof for delegated HTTP task ingress
+- broader runtime-truth or operator-console redesign work


### PR DESCRIPTION
## Problem

Packet `024-agent-boundary-security-hardening` needed a full SpecKit artifact set so later work can move quickly, but earlier packets are still landing and the packet cannot pretend to be final implementation authority yet.

## Solution

- add the full packet `024` scaffold under `specs/024-agent-boundary-security-hardening/`
- freeze the draft packet around ToolBus and MCP least-privilege boundaries, quarantine, schema enforcement, delegation, auth callout, and identity boundaries
- add explicit draft-status and revision-gate notes so the packet must be refreshed before any implementation starts

## Validation

- `./.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`
- `npx markdownlint-cli2 "specs/024-agent-boundary-security-hardening/**/*.md" --config .markdownlint.json`
- `rg -n "NEEDS CLARIFICATION|TODO|TBD|FIXME|TKTK|<placeholder>|\?\?\?" specs/024-agent-boundary-security-hardening`
- `git diff --check`
- `git diff --cached --check`
- `scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync`
