### PR TITLE
docs(specs): scaffold packet 025 step intelligence

### DIFF
--- a/specs/025-step-level-intelligence-v2/analyze.md
+++ b/specs/025-step-level-intelligence-v2/analyze.md
@@ -1,0 +1,64 @@
+# Specification Analysis Report
+
+This report reflects the post-clarify packet-025 scaffold pass across `spec.md`, `plan.md`,
+`contracts/`, and `tasks.md`.
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| -- | -------- | -------- | ----------- | ------- | -------------- |
+| A1 | Ambiguity | LOW | `research.md` | The exact standalone Responses streaming-events URL may move before freeze. | Re-check the official reference URL at implementation freeze. |
+
+No critical or high-severity cross-artifact conflicts were detected. Packet `023` ownership of
+run-trace and proof-boundary schema stays intact across the packet-025 scaffold.
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| deterministic-step-difficulty-assessment | Yes | T006, T008, T009, T010 | Deterministic scoring is covered in both types and runtime assembly. |
+| bounded-action-vocabulary | Yes | T011, T013, T014 | The keep or retry or clarify or downgrade or escalate ladder is explicit. |
+| preserve-packet-020-repair-ownership | Yes | T005, T015 | Packet `020` ownership remains explicit in spec, plan, and runtime projection tasks. |
+| preserve-packet-023-proof-ownership | Yes | T001, T005 | Packet `023` ownership is frozen in the shared contract and scaffold docs. |
+| budget-hints-without-new-trace-schema | Yes | T011, T013, T014 | Budget-aware policy is covered without widening trace ownership. |
+| existing-inspect-surfaces-remain-canonical | Yes | T003, T010, T018, T019 | Current task and autonomy surfaces remain the read path. |
+| explicit-placeholder-vs-grounded-wording | Yes | T007, T016, T020 | Summary tests and smoke-harness wording protect proof honesty. |
+| preserve-current-fallback-behavior | Yes | T006, T009, T014 | Deterministic scoring and policy still preserve existing fallback behavior. |
+| responses-event-taxonomy-as-canonical-input | Yes | T001, T005 | The contract and research note preserve the current OpenAI event-taxonomy posture. |
+| deterministic-first-slice | Yes | T006, T011, T014 | No judge-heavy or training-heavy scoring is needed in the current task map. |
+| no-grounded-proof-from-placeholder-completion | Yes | T012, T016, T020 | Tasks explicitly preserve this honesty rule. |
+| bounded-implementation-scope | Yes | T001-T028 | The full task list keeps implementation inside current seams and excludes broader programs. |
+
+## Contract Alignment
+
+- `contracts/step-policy-contract.md` freezes the packet-owned action vocabulary, score summary,
+  budget summary, and packet-023-owned proof reference posture.
+- `plan.md` and `tasks.md` both keep packet `020` repair ownership and packet `023` proof
+  ownership explicit instead of implying a new runtime truth owner.
+
+## Constitution Alignment Issues
+
+None detected. The scaffold remains spec-first, packet-bounded, model-agnostic in runtime policy,
+and explicit about deterministic versus live proof.
+
+## Unmapped Tasks
+
+None. All tasks map to packet-owned requirements or final validation closure.
+
+## Metrics
+
+- Total Requirements: 12
+- Total Tasks: 28
+- Coverage: 12/12 requirements mapped to one or more tasks (100%)
+- Ambiguity Count: 1
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Packet `025` is ready for later revision and implementation planning once earlier packets settle.
+- Before any implementation freeze, re-check the current OpenAI Responses streaming reference page
+  and reconfirm that packet `021` supervision evidence is still only deterministic-only unless a
+  fresher live proof has been produced.
+- If implementation begins later, keep the shared contract freeze serial before runtime or UI
+  lanes start.

--- a/specs/025-step-level-intelligence-v2/checklists/requirements.md
+++ b/specs/025-step-level-intelligence-v2/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Step-Level Intelligence v2
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-01
+**Feature**: `/Users/macmain/.local/share/symphony-workspaces/025-step-level-intelligence-v2/specs/025-step-level-intelligence-v2/spec.md`
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- First-pass scaffold validation passed for the packet-025 spec.
+- This remains a scaffolding packet that must be revised before implementation after earlier packet
+  work settles.

--- a/specs/025-step-level-intelligence-v2/checklists/step-policy.md
+++ b/specs/025-step-level-intelligence-v2/checklists/step-policy.md
@@ -1,0 +1,73 @@
+# Step Policy Checklist: Step-Level Intelligence v2
+
+**Purpose**: Validate the quality, clarity, and completeness of the packet requirements for
+bounded step-level intelligence policy
+**Created**: 2026-04-01
+**Feature**: `/Users/macmain/.local/share/symphony-workspaces/025-step-level-intelligence-v2/specs/025-step-level-intelligence-v2/spec.md`
+
+**Note**: This checklist tests the packet requirements, not the implementation.
+
+## Requirement Completeness
+
+- [ ] CHK001 Are deterministic step-scoring requirements defined using current step, routing,
+      supervision, and budget context? [Completeness, Spec §FR-001]
+- [ ] CHK002 Are all bounded action outcomes defined for `keep`, `retry`, `clarify`, `downgrade`,
+      and `escalate`? [Completeness, Spec §FR-002]
+- [ ] CHK003 Are budget-aware policy requirements defined without creating a new trace schema?
+      [Completeness, Spec §FR-005]
+- [ ] CHK004 Are operator summary requirements defined for existing task inspect, autonomy, and
+      packet-owned operator-facing summaries? [Completeness, Spec §FR-006]
+
+## Requirement Clarity
+
+- [ ] CHK005 Is "deterministic step scoring" specific enough to prevent later judge-heavy or
+      training-heavy interpretation? [Clarity, Spec §FR-001, Spec §FR-010]
+- [ ] CHK006 Is "placeholder orchestration proof" clearly distinguished from grounded task proof?
+      [Clarity, Spec §FR-007, Spec §FR-011]
+- [ ] CHK007 Is the budget-aware policy wording specific enough to choose between local correction
+      and broader escalation without inventing new packet scope? [Clarity, Spec §User Story 2]
+
+## Requirement Consistency
+
+- [ ] CHK008 Do packet `020` repair-lineage requirements and packet `025` step-policy
+      requirements avoid conflicting source-of-truth claims? [Consistency, Spec §FR-003]
+- [ ] CHK009 Do packet `023` ownership requirements stay consistent across the spec, planned
+      contract, and proof wording? [Consistency, Spec §FR-004]
+- [ ] CHK010 Is packet-021 supervision evidence described consistently as deterministic-only unless
+      fresher live proof is found? [Consistency, Spec §Current Truth & Scope, Spec §Clarifications]
+
+## Acceptance Criteria Quality
+
+- [ ] CHK011 Can each success criterion be verified through deterministic validation without
+      inventing new runtime claims? [Measurability, Spec §Success Criteria]
+- [ ] CHK012 Do the user stories define independently testable slices for scoring, policy action,
+      and operator-visible summaries? [Acceptance Criteria, Spec §User Scenarios & Testing]
+
+## Scenario Coverage
+
+- [ ] CHK013 Are requirements defined for the no-graph-context case where packet `025` still must
+      stay deterministic and bounded? [Coverage, Spec §Edge Cases]
+- [ ] CHK014 Are conflicting budget-pressure and difficulty-signal cases covered by explicit
+      policy wording? [Coverage, Spec §Edge Cases]
+- [ ] CHK015 Are simultaneous packet `020` repair and packet `021` supervision cases addressed
+      without scope drift? [Coverage, Spec §Edge Cases]
+
+## Non-Functional Requirements
+
+- [ ] CHK016 Are proof-honesty requirements explicit enough to prevent overstating
+      `workflow.execute_step` completion? [Coverage, Spec §FR-007, Spec §FR-011]
+- [ ] CHK017 Are scope-boundary requirements explicit enough to exclude benchmarks, training,
+      coordinator runtime, and interoperability work? [Coverage, Spec §FR-012]
+
+## Dependencies And Assumptions
+
+- [ ] CHK018 Does the spec clearly say packet `023` owns proof-boundary schema and packet `025`
+      only consumes it? [Dependency, Spec §FR-004]
+- [ ] CHK019 Does the spec clearly say this scaffold will be revised before implementation after
+      earlier packet work settles? [Assumption, Spec §Current Truth & Scope, Spec §Assumptions]
+
+## Notes
+
+- Check items off as completed: `[x]`
+- Record findings inline when a requirement is incomplete or ambiguous
+- Use this checklist to harden the packet before any later implementation freeze

--- a/specs/025-step-level-intelligence-v2/contracts/step-policy-contract.md
+++ b/specs/025-step-level-intelligence-v2/contracts/step-policy-contract.md
@@ -1,0 +1,133 @@
+# Contract: Step Policy Surface
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Design Goal
+
+Freeze one shared step-policy contract that scores the current step, chooses one bounded action,
+and projects that summary through existing inspect surfaces without competing with packet `023`
+truth ownership or packet `020` repair ownership.
+
+This packet does **not** create a new proof-boundary schema. Packet `023` remains the owner of
+run-trace taxonomy and proof-boundary language.
+
+## Canonical Mapping
+
+The contract for this packet is:
+
+- `StepDifficultyAssessment` scores the current step using deterministic current-state inputs
+- `StepBudgetPressureSummary` carries bounded budget hints that can influence action choice
+- `StepPolicyDecision` chooses one bounded action from `keep`, `retry`, `clarify`, `downgrade`,
+  and `escalate`
+- `StepPolicySummaryView` projects those packet-owned summaries onto existing inspect surfaces
+- `proof_boundary_ref` and any grounding status remain packet-023-owned references that packet
+  `025` consumes but does not redefine
+
+No packet-025 surface may become a competing run-trace or proof-boundary contract.
+
+## Canonical Evidence Shape
+
+Example authoritative payload shape:
+
+```json
+{
+  "step_id": "result_track",
+  "difficulty_assessment": {
+    "difficulty_bucket": "high",
+    "confidence_label": "deterministic",
+    "reason_codes": [
+      "weak_current_evidence",
+      "unstable_recent_step_history"
+    ],
+    "grounding_status_ref": {
+      "owner_packet": "023",
+      "grounding_status": "placeholder_completion"
+    }
+  },
+  "budget_pressure": {
+    "budget_root": "runtime.task_path",
+    "pressure_level": "softcap",
+    "policy_hint": "prefer_downgrade_before_escalate"
+  },
+  "policy_decision": {
+    "chosen_action": "downgrade",
+    "action_reason": "high_difficulty_plus_softcap_budget_pressure",
+    "repair_lineage_ref": "packet-020:last-stable-checkpoint"
+  },
+  "proof_boundary_ref": {
+    "owner_packet": "023",
+    "proof_boundary": "supported task path only"
+  },
+  "display_note": "placeholder orchestration proof only"
+}
+```
+
+Behavior:
+
+- the only bounded action values are `keep`, `retry`, `clarify`, `downgrade`, and `escalate`
+- budget hints may influence action choice but do not create a second proof schema
+- `grounding_status_ref` and `proof_boundary_ref` are packet-023-owned references
+- packet `020` repair lineage may be linked when the chosen action overlaps with the current repair
+  seam, but packet `025` does not replace that lineage
+
+## Event Taxonomy Guidance
+
+Packet `025` treats the OpenAI Responses event taxonomy as the canonical input baseline for
+streamed step-policy terminology.
+
+Expected posture:
+
+- use the current Responses semantic event model as the source for streamed event naming guidance
+- re-confirm the exact official streaming reference page before final implementation freeze
+- do not let event-naming alignment turn packet `025` into the owner of packet-023 trace schema
+
+## Task Surface Contract
+
+`task.result` remains the task-facing authoritative inspection surface for the latest step-policy
+summary.
+
+Expected behavior:
+
+- task inspection exposes the latest bounded score, action, and budget summary
+- task inspection carries packet-023-owned proof references without redefining them
+- the task surface can state explicitly that a result is placeholder orchestration proof
+
+## Autonomy Surface Contract
+
+`AutonomyStatusView` remains the operator-facing status surface for packet-owned summaries.
+
+Expected behavior:
+
+- autonomy status can show the latest bounded step-policy summary
+- autonomy status remains a summary surface, not a competing trace owner
+- autonomy status points back to task inspection for the canonical full view when needed
+
+## Operator Summary Contract
+
+Any packet-owned operator-facing summary must remain a bounded projection of current inspect
+surfaces.
+
+Expected behavior:
+
+- no new endpoint is introduced
+- the operator summary shows score, action, budget hint, and explicit placeholder-vs-grounded
+  wording if UI work is in scope
+- the summary does not widen into a new dashboard or a new run-trace owner
+
+## Relationship To Existing Surfaces
+
+The following existing surfaces remain authoritative baseline inputs:
+
+- `crates/mister-smith-core/src/autonomy.rs`
+- `crates/mister-smith-app/src/execution.rs`
+- `crates/mister-smith-app/src/autonomy.rs`
+- `crates/mister-smith-events/src/autonomy.rs`
+- `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+- `scripts/tests/test_live_runtime_proof_smoke.py`
+
+This packet only extends them with:
+
+- one explicit deterministic step-scoring surface
+- one bounded action-decision vocabulary
+- one bounded budget-aware summary
+- one coherent projection through current inspect surfaces

--- a/specs/025-step-level-intelligence-v2/data-model.md
+++ b/specs/025-step-level-intelligence-v2/data-model.md
@@ -1,0 +1,57 @@
+# Data Model: Step-Level Intelligence v2
+
+## Step policy entities
+
+### `StepDifficultyAssessment`
+
+- `step_id`: stable step identifier from the current runtime seam
+- `difficulty_bucket`: bounded deterministic category such as `low`, `moderate`, `high`, or
+  `critical`
+- `confidence_label`: bounded confidence summary for why the score is stable enough to act on
+- `reason_codes`: ordered short reasons explaining why the current difficulty bucket was chosen
+- `supervision_ref`: optional reference to the latest packet-021 supervision evidence used as an
+  input signal
+- `budget_pressure_ref`: optional reference to the current budget-pressure summary
+- `grounding_status_ref`: packet-023-owned reference used to preserve placeholder-vs-grounded
+  honesty
+
+### `StepBudgetPressureSummary`
+
+- `budget_root`: current budget ownership root if the runtime already exposes it
+- `pressure_level`: bounded summary such as `none`, `watch`, `softcap`, or `hard-stop`
+- `policy_hint`: deterministic hint that can shape action choice without becoming a new proof
+  schema
+- `remaining_headroom_note`: short human-readable note for existing inspect surfaces
+
+### `StepPolicyDecision`
+
+- `step_id`: stable step identifier
+- `chosen_action`: one value from `keep`, `retry`, `clarify`, `downgrade`, or `escalate`
+- `action_reason`: concise explanation for why that action was chosen
+- `difficulty_ref`: reference to the driving `StepDifficultyAssessment`
+- `budget_reason`: optional explanation of how budget pressure affected the chosen action
+- `repair_lineage_ref`: optional link to packet-020-owned repair lineage when the chosen action
+  intersects with existing repair behavior
+
+## Operator evidence projection
+
+### `StepPolicySummaryView`
+
+- `difficulty_assessment`: latest bounded score summary
+- `budget_pressure`: latest budget hint summary
+- `policy_decision`: latest bounded action summary
+- `proof_boundary_ref`: packet-023-owned proof or grounding reference
+- `display_note`: short text that explains whether the current result is placeholder orchestration
+  proof or grounded task proof
+
+## Invariants
+
+- packet `023` owns run-trace taxonomy and proof-boundary schema; packet `025` only stores a
+  reference to those fields
+- packet `020` remains the owner of verifier and repair lineage
+- packet `025` action selection stays inside the bounded vocabulary of keep, retry, clarify,
+  downgrade, and escalate
+- placeholder completion can inform a step-policy summary but cannot become grounded task proof by
+  itself
+- missing or inconclusive policy inputs fall back to current runtime behavior rather than forcing a
+  synthetic policy decision

--- a/specs/025-step-level-intelligence-v2/plan.md
+++ b/specs/025-step-level-intelligence-v2/plan.md
@@ -1,0 +1,164 @@
+# Implementation Plan: Step-Level Intelligence v2
+
+**Branch**: `025-step-level-intelligence-v2` | **Date**: 2026-04-01 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from
+`/specs/025-step-level-intelligence-v2/spec.md`
+
+## Summary
+
+The repo already has packet `020` verifier and repair lineage, packet `021` supervision evidence,
+and packet `023` truth-boundary ownership in the prep dossier. The bounded next slice is to freeze
+one deterministic step-policy contract that scores the current step, chooses a bounded action
+across keep, retry, clarify, downgrade, and escalate, carries budget-aware hints, and projects
+that summary through current inspect surfaces without claiming grounded task proof from placeholder
+execution.
+
+This is a scaffold packet for later revision. It freezes the design surface and future
+implementation map, but it does not change current router truth or claim that packet `025` is
+implementation-ready while earlier packets still move.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88.0 plus existing operator-console TypeScript if the packet-owned
+summary reaches the current run-detail UI
+**Primary Dependencies**: `mister-smith-core`, `mister-smith-app`, `mister-smith-events`,
+existing packet `020` and packet `021` seams, `scripts/tests/test_live_runtime_proof_smoke.py`,
+and current task or autonomy summary surfaces
+**Storage**: existing runtime metadata and summary surfaces only; no new packet-owned persistence
+store is required for the first scaffolded slice
+**Testing**: targeted Rust tests for deterministic scoring and summary projection, smoke-harness
+summary assertions, optional operator-console checks if UI files move, markdown lint, and diff
+hygiene
+**Target Platform**: local macOS development with Linux runtime parity for the shipped app binary
+**Project Type**: Rust workspace packet scaffold with bounded summary-surface follow-on work
+**Performance Goals**: choose a deterministic bounded action without regressing current fallback
+behavior and expose that summary without raw log archaeology
+**Constraints**: packet `023` owns run-trace taxonomy and proof-boundary schema; packet `020`
+owns verifier and repair lineage; the first slice stays heuristic and deterministic; no new
+endpoint; no grounded-proof overclaim from `workflow.execute_step`
+**Scale/Scope**: one bounded step-policy packet on top of current step-evaluation, result-summary,
+and smoke-harness seams
+
+## Constitution Check
+
+| Principle | Status | Evidence |
+| --------- | ------ | -------- |
+| I. Canonical Single Source | PASS | Grounded in `docs/direction.md`, `docs/current-state.md`, packet `025` and packet `023` prep dossiers, and the current runtime code seams. |
+| II. Spec-First Design | PASS | `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md`, and `analyze.md` are authored before any implementation. |
+| III. Phase-And-Packet-Gated Delivery | PASS | Keeps packet `025` as a bounded scaffold layered on landed packet `020` and packet `021` seams without reopening deeper packets. |
+| IV. Model-Agnostic Architecture | PASS | The packet defines provider-neutral step policy and uses OpenAI Responses docs only as event-taxonomy guidance, not as a provider lock-in. |
+| V. Erlang/OTP-Style Fault Tolerance | PASS | The design prefers local corrective actions before broader escalation and preserves packet `020` repair lineage as the existing recovery owner. |
+| VI. Evidence-Based Validation | PASS | The packet keeps current proof deterministic-only unless a later live rerun is actually produced, and it preserves placeholder-versus-grounded honesty. |
+| VII. Explicit Dependency Management | PASS | The packet names the exact repo seams it consumes and keeps packet `023` and packet `020` ownership boundaries explicit. |
+| VIII. Clean Closure And Resumability | PASS | The scaffold lands as a durable packet bundle in a separate worktree with explicit revision-later notes and no mutation of current router truth. |
+
+## Project Structure
+
+```text
+specs/025-step-level-intelligence-v2/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── step-policy-contract.md
+├── checklists/
+│   ├── requirements.md
+│   └── step-policy.md
+├── tasks.md
+└── analyze.md
+
+crates/mister-smith-core/
+└── src/autonomy.rs
+
+crates/mister-smith-app/
+├── src/execution.rs
+├── src/autonomy.rs
+└── tests/autonomy_status_tests.rs
+
+crates/mister-smith-events/
+└── src/autonomy.rs
+
+scripts/tests/
+└── test_live_runtime_proof_smoke.py
+
+apps/operator-console/
+├── src/types.ts
+├── src/views/RunsView.tsx
+└── src/App.test.tsx
+```
+
+## Design Decisions
+
+### D1: Step policy layers on top of current step-evaluation seams
+
+Packet `025` should build on `StepEvaluationRecord`, current routing summaries, supervision
+evidence, and existing inspect surfaces instead of inventing a second runtime truth model.
+
+### D2: Packet `023` remains the owner of proof-boundary language
+
+Packet `025` can consume packet-023-owned proof or grounding references, but it should not create
+its own competing trace taxonomy or proof-boundary schema.
+
+### D3: The first slice is heuristic and deterministic
+
+The first useful packet is not a training stack. It is one bounded deterministic scoring and
+action ladder that operators and future implementers can audit.
+
+### D4: Existing inspect surfaces remain canonical
+
+Task inspect and autonomy status stay the canonical read surfaces. Any packet-owned operator
+summary must remain a bounded projection of those same fields rather than a new endpoint or a new
+trace owner.
+
+## Minimal Implementation Slice
+
+### Milestone 1: Freeze the shared step-policy contract
+
+Validation:
+
+- `spec.md`, `data-model.md`, and `contracts/step-policy-contract.md` agree on the action
+  vocabulary, score summary, budget summary, and packet `023` ownership boundary
+- packet `025` continues to describe itself as scaffold-only and revision-later
+
+### Milestone 2: Add deterministic scoring and action selection
+
+Validation:
+
+- targeted `mister-smith-core` and `mister-smith-app` coverage can prove at least one `keep`
+  decision and one non-`keep` decision from bounded deterministic inputs
+- missing or inconclusive inputs preserve current fallback behavior
+
+### Milestone 3: Project honest summaries onto existing inspect surfaces
+
+Validation:
+
+- task and autonomy summaries can show score, action, and budget-aware summary fields without raw
+  log archaeology
+- proof wording remains explicit that placeholder completion is not grounded task proof
+
+## Parallel Staging Posture
+
+Use only when the packet benefits from bounded parallel work.
+
+- Blocking freeze before any parallel lanes: the shared step-policy contract and packet `023`
+  ownership boundary
+- Allowed disjoint lanes after the freeze:
+  - core value-object lane: `crates/mister-smith-core/src/autonomy.rs`
+  - runtime policy lane: `crates/mister-smith-app/src/execution.rs`
+  - summary projection lane: `crates/mister-smith-app/src/autonomy.rs`,
+    `crates/mister-smith-events/src/autonomy.rs`, and
+    `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+  - optional operator-summary lane: `apps/operator-console/`
+- Single-owner choke points:
+  - `crates/mister-smith-app/src/execution.rs`
+  - `crates/mister-smith-app/src/autonomy.rs`
+  - `crates/mister-smith-core/src/autonomy.rs`
+  - any active proof or packet note under `docs/plans/`
+
+## Explicitly Deferred
+
+- grounded step execution beyond the current placeholder `workflow.execute_step` seam
+- packet `023` run-trace taxonomy or proof-boundary schema changes
+- PRM training, benchmark work, coordinator runtime, subagent runtime, or interoperability work

--- a/specs/025-step-level-intelligence-v2/quickstart.md
+++ b/specs/025-step-level-intelligence-v2/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Step-Level Intelligence v2
+
+## Targeted deterministic validation
+
+Run the narrowest honest checks for the future packet implementation:
+
+```bash
+cargo test -p mister-smith-core
+cargo test -p mister-smith-app
+cargo test -p mister-smith-events --test autonomy_event_tests
+cargo test -p mister-smith-app --test autonomy_status_tests
+python3 -m unittest scripts.tests.test_live_runtime_proof_smoke
+npm --prefix apps/operator-console run build
+git diff --check
+```
+
+## Proof expectation
+
+This packet earns proof by showing one bounded deterministic step-policy surface on top of current
+runtime seams:
+
+- at least one `keep` and one non-`keep` decision can be derived from deterministic inputs
+- task and autonomy summaries can show score, chosen action, and budget-aware summary fields
+- explicit placeholder-versus-grounded wording remains visible on the current inspect path
+
+## Live-proof boundary
+
+Deterministic validation can prove the step-policy contract, summary projection, and proof-honesty
+behavior before any later live rerun exists. A later live rerun must stay explicitly bounded to
+the supported provider path that was actually exercised and must not imply grounded task proof
+from `workflow.execute_step` placeholder completion alone.

--- a/specs/025-step-level-intelligence-v2/research.md
+++ b/specs/025-step-level-intelligence-v2/research.md
@@ -1,0 +1,114 @@
+# Research Notes: Step-Level Intelligence v2
+
+## Current repo truth
+
+- packet `020` already landed verifier-gated step decisions, clarification, and repair lineage on
+  the runtime-backed task path
+- packet `021` already landed supervision evidence on task, autonomy, and operator-visible
+  surfaces, but the newer packet-021 proof remains deterministic-only unless fresher live proof is
+  produced
+- packet `023` is the scoped owner of run-trace taxonomy and proof-boundary language in the
+  packet-prep layer
+- the March 28 session context report still shows the core truth gap: `workflow.execute_step`
+  proves orchestration-substrate completion, not grounded task proof
+
+## Decision 1: Use the OpenAI Responses event taxonomy as the canonical event input
+
+**Decision**: Packet `025` should treat the OpenAI Responses event taxonomy as the canonical event
+input for streamed step-policy terms.
+
+**Rationale**:
+
+- the current official streaming guide says the Responses API uses semantic typed events for
+  streaming
+- the function-calling streaming guide names concrete tool-call events such as
+  `response.output_item.added`, `response.function_call_arguments.delta`, and
+  `response.function_call_arguments.done`
+- packet `025` needs one event-language baseline for step-policy naming, and the packet-prep
+  dossier already points to Responses docs as that baseline
+
+**Alternatives considered**:
+
+- older Chat Completions streaming docs: rejected because packet `025` should not backslide to an
+  older event model
+- repo-only ad hoc event names: rejected because the packet explicitly wants official Responses
+  terminology as the input baseline
+
+## Decision 2: Re-confirm the exact official streaming-events reference page before freeze
+
+**Decision**: The final implementation freeze should re-confirm the exact current official
+  streaming-events reference page before packet `025` treats individual event names as frozen.
+
+**Rationale**:
+
+- the packet-prep dossier names a standalone streaming-events reference path
+- the current OpenAI docs still clearly document the Responses semantic event model, but the exact
+  standalone reference URL may have moved
+- packet `025` should preserve the Responses event taxonomy as canonical without pretending the
+  current reference path is already stable forever
+
+**Alternatives considered**:
+
+- freezing the older packet-prep URL without re-checking: rejected because the docs path may move
+- ignoring official docs entirely and relying only on the packet-prep note: rejected because the
+  final packet must be grounded in current primary-source docs
+
+## Decision 3: Keep the first slice heuristic and deterministic
+
+**Decision**: The first real packet-025 implementation slice should use deterministic heuristics
+and bounded policy rules rather than a judge-heavy or training-heavy control loop.
+
+**Rationale**:
+
+- the packet-prep dossier explicitly says the first slice should stay heuristic and deterministic
+- the repo already has useful step-evaluation, routing, repair, and supervision seams to build on
+- deterministic policy is easier to audit and keeps the proof boundary honest while the underlying
+  step boundary is still placeholder-only
+
+**Alternatives considered**:
+
+- PRM or judge-heavy scoring from day one: rejected because it would widen the scope into training
+  or heavier runtime claims before the packet owns a stable deterministic policy surface
+- benchmark-first work: rejected because packet `025` is a policy packet, not a benchmark packet
+
+## Decision 4: Packet `025` consumes packet `023` proof ownership instead of competing with it
+
+**Decision**: Packet `025` should use packet-023-owned proof or grounding references and never
+create a competing proof-boundary schema.
+
+**Rationale**:
+
+- packet `023` is the packet-prep owner of run-trace taxonomy and proof-boundary language
+- packet `025` is about step scoring and action policy, not about redefining run truth
+- keeping ownership boundaries clean prevents the same proof claim from drifting across packets
+
+**Alternatives considered**:
+
+- embedding a packet-025-specific proof schema in step policy: rejected because it would silently
+  duplicate packet-023 scope
+- treating step-policy summaries as self-sufficient proof: rejected because the March 28 session
+  report shows why placeholder completion must stay explicit
+
+## Decision 5: Existing inspect surfaces stay canonical
+
+**Decision**: Packet `025` should project step-policy summaries through existing task inspect and
+autonomy surfaces, with only a bounded operator-facing summary layered on top if needed.
+
+**Rationale**:
+
+- those are already the current runtime truth surfaces
+- the packet goal is better step policy, not a new observability product
+- keeping the first slice on current surfaces reduces scope and preserves current-state honesty
+
+**Alternatives considered**:
+
+- a new endpoint or a new trace dashboard: rejected because it widens scope and collides with
+  packet `023`
+
+## Bounded conclusion
+
+The legitimate packet-025 scaffold is a deterministic step-policy packet layered on current packet
+`020` and packet `021` seams. It should freeze one bounded score and action contract, carry
+budget-aware hints, and project honest placeholder-vs-grounded wording through current inspect
+surfaces without widening into trace ownership, grounded execution, training, benchmarks,
+coordinator runtime, or interoperability.

--- a/specs/025-step-level-intelligence-v2/spec.md
+++ b/specs/025-step-level-intelligence-v2/spec.md
@@ -1,0 +1,209 @@
+# Feature Specification: Step-Level Intelligence v2
+
+**Feature Branch**: `025-step-level-intelligence-v2`
+**Created**: 2026-04-01
+**Status**: Draft scaffold
+**Input**: `docs/direction.md`, `docs/current-state.md`, `docs/packet-prep/README.md`,
+`docs/packet-prep/025-step-level-intelligence-v2.md`,
+`docs/packet-prep/023-runtime-truth-and-run-trace.md`,
+`docs/plans/2026-03-26-verifier-gated-adaptive-orchestration.md`,
+`docs/plans/2026-03-29-packet-021-supervision-evidence-proof-boundary.md`,
+`docs/plans/2026-03-29-packet-021-live-evaluation.md`,
+`docs/2026-03-28-session-context-report.md`, and the current step-policy seams in
+`crates/mister-smith-core/src/autonomy.rs`, `crates/mister-smith-app/src/execution.rs`,
+`crates/mister-smith-app/src/autonomy.rs`, `crates/mister-smith-events/src/autonomy.rs`,
+`crates/mister-smith-app/tests/autonomy_status_tests.rs`, and
+`scripts/tests/test_live_runtime_proof_smoke.py`
+
+## Current Truth & Scope
+
+Scaffold note:
+
+- this packet is scaffolding only
+- it is based on current repo truth as of 2026-04-01
+- it will be revised before implementation after earlier packet work settles
+- it must not be treated as the new forward authority in `docs/current-state.md`
+
+Current repo truth already includes:
+
+- packet `020` verifier-gated step decisions, explicit clarification, and repair lineage on the
+  runtime-backed task path
+- packet `021` supervision evidence on task inspect, autonomy status, and operator surfaces, but
+  the newer packet-021 proof remains deterministic-only unless fresher live proof is produced
+- typed step evaluation, clarification, routing, and orchestration-quality value objects on the
+  current runtime path
+- supported task and autonomy result surfaces that already project proof-related summaries
+
+The remaining gap is narrower than a broad new program:
+
+- there is no single deterministic step-policy contract for scoring step difficulty and choosing a
+  bounded action across keep, retry, clarify, downgrade, and escalate
+- budget pressure, routing posture, and supervision hints are present in the runtime, but they are
+  not yet frozen into one bounded step-policy summary
+- the current `workflow.execute_step` boundary can still make placeholder orchestration completion
+  look semantically stronger than the repo can honestly prove
+
+This packet therefore freezes one bounded scaffold slice:
+
+1. define deterministic step scoring on top of the current step-evaluation seam
+2. define one deterministic step-policy action ladder across keep, retry, clarify, downgrade, and
+   escalate, including budget-aware policy hints
+3. define operator-visible step-policy summaries that consume packet `023` proof language without
+   taking over packet `023` run-trace or proof-boundary ownership
+
+This is not:
+
+- a packet-023 follow-on that redefines run-trace taxonomy or proof-boundary schema
+- a claim that `workflow.execute_step` now proves grounded task execution
+- PRM training, benchmark work, coordinator runtime, subagent runtime, or interoperability scope
+
+## Clarifications
+
+### Session 2026-04-01
+
+- Q: Does packet `025` own run-trace taxonomy or proof-boundary schema? → A: No. Packet `023`
+  remains the owner, and packet `025` only consumes those fields.
+- Q: Where does budget data live for the first slice? → A: In packet-owned step-policy metadata
+  and summaries, not in a new packet-023 trace schema.
+- Q: What proof wording applies when `workflow.execute_step` reports completion? → A: Packet `025`
+  inherits packet-023 proof wording and must treat that outcome as placeholder orchestration proof
+  unless grounded task evidence exists.
+- Q: Are new read endpoints in scope for this packet? → A: No. Existing task inspect and
+  autonomy surfaces remain the canonical read surfaces.
+- Q: What proof posture applies to packet-021 supervision evidence while writing this scaffold?
+  → A: Deterministic-only unless a fresher live proof is actually found later.
+
+## User Scenarios & Testing
+
+Use independently testable stories. For Mister Smith packets, prefer a small number of bounded
+stories over a long backlog of loosely related asks.
+
+### User Story 1 - Score a step deterministically (Priority: P1)
+
+An operator or future packet implementer can rely on one deterministic step score that classifies
+the current step using the existing step-evaluation, routing, supervision, and budget context.
+
+**Independent Test**: targeted deterministic fixtures or tests can prove that the same step
+context always produces the same score and grounding summary, while steps with missing policy
+signals preserve the current fallback behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step with accepted verifier output, stable routing, and no budget pressure,
+   **When** the runtime builds a step-policy summary, **Then** it produces a deterministic
+   low-risk score and a `keep` action.
+2. **Given** a step with weak evidence, degraded supervision signals, or repeated instability,
+   **When** the runtime builds a step-policy summary, **Then** it produces a deterministic
+   non-keep score that can drive a bounded corrective action.
+
+### User Story 2 - Choose a bounded step action under budget pressure (Priority: P1)
+
+An operator or future runtime implementation can apply one deterministic policy ladder so budget
+pressure and step difficulty influence whether the runtime keeps, retries, clarifies, downgrades,
+or escalates a step.
+
+**Independent Test**: targeted deterministic inputs can prove at least one retry or clarify path
+and at least one downgrade or escalate path without inventing a new packet-023 trace schema or
+regressing current happy-path fallback.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recoverable step with high uncertainty but bounded budget pressure, **When** the
+   step policy is evaluated, **Then** the chosen action stays inside the bounded ladder and prefers
+   local correction before broader escalation.
+2. **Given** a step with severe difficulty or budget pressure that exceeds the bounded local
+   correction policy, **When** the step policy is evaluated, **Then** the chosen action is a
+   deterministic downgrade or escalate decision with explicit budget-aware reasoning.
+
+### User Story 3 - Inspect step policy without overstating proof (Priority: P2)
+
+An operator can inspect current task, autonomy, or operator-facing summaries and see the latest
+step score, chosen action, budget hint, and honest proof wording without mistaking placeholder
+completion for grounded task proof.
+
+**Independent Test**: task and autonomy summaries plus any operator-facing packet-owned summary can
+show the same step-policy fields and explicit proof wording without requiring raw log archaeology.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step-policy decision was produced, **When** an operator inspects the existing
+   result surfaces, **Then** they can see the current score, chosen action, and budget-aware
+   summary.
+2. **Given** a step completed only through the current placeholder execution boundary, **When**
+   that step policy is displayed, **Then** the surface states that the outcome is orchestration
+   proof or placeholder completion rather than grounded task proof.
+
+## Edge Cases
+
+- step policy runs before graph or branch context exists and must still produce a deterministic
+  outcome without claiming packet-023 ownership
+- budget pressure suggests downgrade while step difficulty suggests clarify or retry
+- packet `020` repair lineage and packet `021` supervision evidence both apply to the same step
+- the OpenAI Responses streaming-events reference path changes again before implementation freeze,
+  requiring a re-check of the current official reference page
+- a step returns `completed` through `workflow.execute_step` but provides no grounded task
+  evidence
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST define one deterministic `StepDifficultyAssessment` on top of the
+  current step-evaluation, routing, supervision, and budget context.
+- **FR-002**: System MUST define one bounded step-policy action vocabulary across `keep`,
+  `retry`, `clarify`, `downgrade`, and `escalate`.
+- **FR-003**: System MUST preserve packet `020` ownership of verifier and repair lineage, with
+  packet `025` only layering step policy on top of that existing seam.
+- **FR-004**: System MUST preserve packet `023` ownership of run-trace taxonomy and proof-boundary
+  schema, with packet `025` only consuming those fields and not redefining them.
+- **FR-005**: System MUST carry budget pressure or budget hint information in step-policy metadata
+  and summaries without inventing a new packet-023 trace schema.
+- **FR-006**: System MUST surface packet-owned step-policy summaries through the existing task
+  inspect, autonomy, and packet-owned operator-facing summary surfaces rather than a new endpoint.
+- **FR-007**: System MUST state explicitly when a step result is placeholder orchestration proof
+  rather than grounded task proof.
+- **FR-008**: System MUST preserve current fallback behavior when policy inputs are absent,
+  inconclusive, or outside the bounded first slice.
+- **FR-009**: System MUST treat the OpenAI Responses event taxonomy as the canonical streaming
+  event input for packet-025 terms, while re-confirming the current official reference page before
+  final implementation freeze.
+- **FR-010**: System MUST keep the first slice heuristic and deterministic; it MUST NOT require a
+  judge-heavy or training-heavy policy to be useful.
+- **FR-011**: System MUST NOT infer grounded task proof from placeholder step completion alone.
+- **FR-012**: System MUST keep the future implementation scope bounded to current step-evaluation,
+  result-summary, and smoke-harness seams rather than widening into coordinator runtime,
+  subagent runtime, benchmark work, or interoperability work.
+
+### Key Entities
+
+- **StepDifficultyAssessment**: deterministic packet-owned summary of current step difficulty,
+  confidence, and why the current step belongs in a bounded policy bucket
+- **StepPolicyDecision**: packet-owned action summary that chooses one bounded action from keep,
+  retry, clarify, downgrade, or escalate
+- **StepBudgetPressureSummary**: packet-owned summary of budget pressure or budget hint that can
+  influence the chosen action without taking over packet-023 trace ownership
+- **StepGroundingStatusRef**: packet-023-owned proof-boundary reference that packet `025` consumes
+  so the step-policy surface can distinguish placeholder completion from grounded proof
+
+## Success Criteria
+
+- **SC-001**: targeted deterministic validation can show at least one `keep` decision and at least
+  one non-`keep` decision from the bounded step-policy ladder without regressing current fallback
+  behavior
+- **SC-002**: existing inspect surfaces can show step score, action, and budget-aware summary
+  without requiring raw log archaeology
+- **SC-003**: every packet-025 artifact repeats the same honest proof boundary and does not claim
+  that `workflow.execute_step` is grounded task proof
+- **SC-004**: packet `023` ownership of run-trace and proof-boundary schema remains unchanged
+  across the spec, plan, contract, tasks, and analysis artifacts
+
+## Assumptions
+
+- packets `022` through `024` are still moving, so this scaffold will be revised before any
+  implementation freeze
+- packet `021` supervision evidence remains deterministic-only unless a fresher live proof is
+  found during a later revision pass
+- the current task inspect and autonomy surfaces remain the canonical read surfaces for any
+  packet-owned summary in the first slice
+- the current official OpenAI Responses streaming reference may move, so the final implementation
+  freeze will re-confirm the exact current page before event names are treated as final

--- a/specs/025-step-level-intelligence-v2/tasks.md
+++ b/specs/025-step-level-intelligence-v2/tasks.md
@@ -1,0 +1,168 @@
+# Tasks: Step-Level Intelligence v2
+
+**Input**: Design documents from `/specs/025-step-level-intelligence-v2/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/`
+
+**Tests**: Included. This packet requires targeted deterministic coverage for scoring and summary
+projection plus smoke-harness summary assertions and bounded UI validation if the operator-facing
+summary lane is used.
+
+**Organization**: Tasks are grouped by bounded implementation checkpoints so the shared step-policy
+contract lands first, then deterministic scoring and summary lanes can proceed without conflicting
+with packet `023` truth ownership.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel only when every blocking checkpoint in the current section is
+  already landed and the write set is disjoint from every other active lane
+- **[Story]**: Which user story the task advances (`US1` through `US3`)
+- Include exact file paths in every task description
+
+---
+
+## Subphase 25.0 — Shared Step-Policy Contract Freeze
+
+**Goal**: freeze the shared step-policy contract before any implementation lane starts.
+
+**CRITICAL**: No `[P]` lane may begin until this checkpoint is complete.
+
+- [ ] T001 Freeze the shared step-policy contract in
+      `specs/025-step-level-intelligence-v2/contracts/step-policy-contract.md`
+- [ ] T002 Freeze packet-owned score, budget, and summary entities in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T003 Extend current summary projections to consume the frozen packet contract in
+      `crates/mister-smith-app/src/autonomy.rs` and
+      `crates/mister-smith-events/src/autonomy.rs`
+- [ ] T004 Add shared contract coverage in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+- [ ] T005 Reconfirm packet `023` proof-boundary ownership and packet `020` repair-lineage
+      ownership in `specs/025-step-level-intelligence-v2/spec.md` and
+      `specs/025-step-level-intelligence-v2/plan.md`
+
+**Checkpoint**: step-policy fields, packet `023` ownership boundaries, and packet `020`
+intersections are frozen once before later lanes begin.
+
+---
+
+## User Story 1 — Deterministic Step Scoring (Priority: P1)
+
+**Goal**: derive one deterministic step score from the current step-evaluation seam.
+
+**Independent Test**: deterministic inputs can produce the same score repeatedly, including one
+low-risk `keep` case and one higher-risk case, without regressing current fallback behavior.
+
+### Tests For User Story 1
+
+- [ ] T006 [P] [US1] Add deterministic step-scoring coverage in
+      `crates/mister-smith-app/src/execution.rs`
+- [ ] T007 [P] [US1] Extend task and autonomy summary coverage for step scores in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+
+### Implementation For User Story 1
+
+- [ ] T008 [P] [US1] Add `StepDifficultyAssessment` fields and exports in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T009 [US1] Build deterministic score assembly from current runtime inputs in
+      `crates/mister-smith-app/src/execution.rs`
+- [ ] T010 [US1] Project packet-owned step scores through existing summary surfaces in
+      `crates/mister-smith-app/src/autonomy.rs` and
+      `crates/mister-smith-events/src/autonomy.rs`
+
+**Checkpoint**: the runtime can derive a bounded deterministic step score without widening packet
+scope or redefining proof ownership.
+
+---
+
+## User Story 2 — Budget-Aware Step Action Policy (Priority: P1)
+
+**Goal**: choose one bounded action across keep, retry, clarify, downgrade, and escalate using
+deterministic policy rules and budget-aware hints.
+
+**Independent Test**: deterministic inputs can prove at least one retry or clarify path and at
+least one downgrade or escalate path without inventing a new trace schema.
+
+### Tests For User Story 2
+
+- [ ] T011 [P] [US2] Add bounded action-ladder tests in
+      `crates/mister-smith-app/src/execution.rs`
+- [ ] T012 [P] [US2] Add smoke-harness summary assertions for score and action wording in
+      `scripts/tests/test_live_runtime_proof_smoke.py`
+
+### Implementation For User Story 2
+
+- [ ] T013 [P] [US2] Add `StepBudgetPressureSummary` and `StepPolicyDecision` fields in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T014 [US2] Implement the deterministic action ladder in
+      `crates/mister-smith-app/src/execution.rs`
+- [ ] T015 [US2] Reconcile packet-020 repair-lineage references with packet-owned step policy in
+      `crates/mister-smith-app/src/autonomy.rs`
+
+**Checkpoint**: the runtime can choose a bounded step action from deterministic inputs while
+preserving packet `020` ownership and packet `023` proof boundaries.
+
+---
+
+## User Story 3 — Honest Operator-Facing Step Summaries (Priority: P2)
+
+**Goal**: expose step score, chosen action, and proof-honesty wording through current summary
+surfaces without making placeholder completion look like grounded task proof.
+
+**Independent Test**: existing inspect surfaces can show the packet-owned summary and explicit
+placeholder-versus-grounded wording without raw log archaeology.
+
+### Tests For User Story 3
+
+- [ ] T016 [P] [US3] Extend summary rendering coverage in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+- [ ] T017 [P] [US3] Add bounded operator-summary coverage in
+      `apps/operator-console/src/App.test.tsx`
+
+### Implementation For User Story 3
+
+- [ ] T018 [P] [US3] Extend task and autonomy summary assembly in
+      `crates/mister-smith-app/src/autonomy.rs` and
+      `crates/mister-smith-events/src/autonomy.rs`
+- [ ] T019 [P] [US3] Render the packet-owned step-policy summary in
+      `apps/operator-console/src/views/RunsView.tsx` and
+      `apps/operator-console/src/types.ts`
+- [ ] T020 [US3] Add explicit placeholder-versus-grounded wording to current proof summary
+      assertions in `scripts/tests/test_live_runtime_proof_smoke.py`
+
+**Checkpoint**: operators can inspect step-policy summaries without mistaking placeholder
+completion for grounded task proof.
+
+---
+
+## Final Validation And Packet Note Sync
+
+- [ ] T021 Run `cargo test -p mister-smith-core`
+- [ ] T022 Run `cargo test -p mister-smith-app`
+- [ ] T023 Run `cargo test -p mister-smith-events --test autonomy_event_tests`
+- [ ] T024 Run `cargo test -p mister-smith-app --test autonomy_status_tests`
+- [ ] T025 Run `python3 -m unittest scripts.tests.test_live_runtime_proof_smoke`
+- [ ] T026 Run `npm --prefix apps/operator-console run build`
+- [ ] T027 Run `git diff --check`
+- [ ] T028 Capture one bounded packet note under `docs/plans/` that keeps deterministic-only
+      versus live-proof wording honest
+
+## Parallel Staging Directive
+
+`[P]` means the task may run in parallel only when its write set is disjoint from every other
+active lane and all blocking checkpoint tasks in the current section are already landed.
+
+Shared-write choke points for this packet:
+
+- `crates/mister-smith-app/src/execution.rs`
+- `crates/mister-smith-app/src/autonomy.rs`
+- `crates/mister-smith-core/src/autonomy.rs`
+- the active `docs/plans/...` packet note
+
+Only one active lane may own a choke-point file at a time.
+
+## Explicitly Out Of Scope For This Packet
+
+- grounded step execution beyond the current placeholder `workflow.execute_step` seam
+- packet `023` trace taxonomy or proof-boundary schema work
+- coordinator runtime, subagent runtime, or interoperability work
+- benchmark work, PRM training, or judge-heavy scoring programs


### PR DESCRIPTION
## Summary
- add the full packet 025 SpecKit scaffold under 
- keep packet 023 proof-boundary ownership explicit and preserve packet 021 as deterministic-only unless later live proof exists
- frame packet 025 as revision-later scaffolding instead of an implementation-ready freeze

## Validation
- git diff --check
- npx markdownlint-cli2 "specs/025-step-level-intelligence-v2/**/*.md" --config .markdownlint.json