### PR TITLE
docs: scaffold packet 026 runtime spec

### DIFF
--- a/specs/026-first-real-coordinator-subagent-runtime/analyze.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/analyze.md
@@ -1,0 +1,70 @@
+# Specification Analysis Report
+
+This report reflects the scaffold pass across `spec.md`, `plan.md`, `contracts/`, and `tasks.md`
+for packet `026`.
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| -- | -------- | -------- | ----------- | ------- | -------------- |
+| A1 | Dependency | MEDIUM | `spec.md`, `plan.md`, `tasks.md` | Packet `026` depends on still-in-progress packets `022` through `025`. | Keep the revision gate mandatory. |
+
+No critical or high-severity cross-artifact conflicts were detected. The scaffold is internally
+consistent, but it is intentionally not implementation-ready until the revision gate is complete.
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --------------- | --------- | -------- | ----- |
+| scaffold-requires-revision-before-implementation | Yes | T001, T002, T003, T004, T005 | Revision gate is the first blocking phase. |
+| separate-current-truth-from-missing-runtime-truth | Yes | T001, T002, T004 | Reconciliation and artifact refresh keep this separation explicit. |
+| coordinator-owned-delegation-records | Yes | T009, T011, T013, T014 | User Story 1 covers delegation visibility. |
+| visible-subagent-state | Yes | T009, T010, T011, T012, T013, T014 | User Story 1 covers state visibility. |
+| grounded-delegated-work-required | Yes | T015, T017, T018, T019 | User Story 2 covers grounded work evidence. |
+| placeholder-only-is-non-grounded | Yes | T015, T018, T021, T025 | Proof boundary stays explicit when work is still placeholder-only. |
+| preserve-smallest-workflow-rule | Yes | T009, T010, T013, T014 | User Story 1 keeps honest sequential collapse in scope. |
+| visible-coordinator-decisions | Yes | T016, T017, T019, T024, T025 | User Story 2 and User Story 3 cover decision visibility. |
+| proof-boundary-on-task-autonomy-run-detail | Yes | T021, T022, T023, T024, T025, T026 | User Story 3 covers all required operator surfaces. |
+| consume-022-through-025-ownership-without-redefining | Yes | T001, T002, T003, T004 | Revision gate and artifact refresh preserve upstream ownership. |
+| keep-federation-and-discovery-out-of-scope | Yes | T002, T003, T004 | Scope language is maintained across artifacts. |
+| explicit-pre-implementation-revision-gate | Yes | T001, T002, T003, T004, T005 | This is the main scaffold gate. |
+| session-follow-up-uses-identifiers-and-evidence-refs | Yes | T020, T021, T024, T025 | Session-aware follow-up stays bounded. |
+| scaffold-stays-decision-useful | Yes | T002, T003, T004, T008 | Artifact set is designed for later refinement rather than re-authoring. |
+| no-implementation-or-live-proof-claims-yet | Yes | T001, T004, T005, T035 | Revision gate and final proof note keep claims honest. |
+
+## Contract Alignment
+
+- `contracts/coordinator-subagent-runtime-contract.md` freezes the packet `026` contract shape
+  now, but it also repeats the revision-gate requirement so it cannot be mistaken for a final
+  landed runtime contract.
+- `plan.md` and `tasks.md` both place upstream packet reconciliation ahead of any code work.
+
+## Constitution Alignment Issues
+
+None detected. The scaffold is spec-first, bounded, explicit about proof boundaries, and clear
+about dependency ownership.
+
+## Unmapped Tasks
+
+None. Every task supports either the revision gate, the shared contract freeze, one user story, or
+final validation.
+
+## Metrics
+
+- Total Requirements: 15
+- Total Tasks: 35
+- Coverage: 15/15 requirements mapped to one or more tasks (100%)
+- Ambiguity Count: 1
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Packet `026` is ready as a scaffold and can speed up later work.
+- Do not implement from this scaffold without completing the revision gate first.
+- When packet `022` through `025` land, refresh this packet and then rerun `/speckit.analyze`.
+
+## Remediation Offer
+
+If you want, the next refinement pass can tighten the exact field names and state labels after the
+upstream packets finish landing.

--- a/specs/026-first-real-coordinator-subagent-runtime/checklists/requirements.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: First Real Coordinator-Subagent Runtime
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This packet is intentionally a scaffold draft, not an implementation-ready freeze.
+- The required revision gate before implementation is part of feature readiness for this packet.

--- a/specs/026-first-real-coordinator-subagent-runtime/checklists/scaffold.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/checklists/scaffold.md
@@ -1,0 +1,62 @@
+# Scaffold Checklist: First Real Coordinator-Subagent Runtime
+
+**Purpose**: Validate the quality, clarity, and completeness of the packet `026` scaffold before
+later implementation work
+**Created**: 2026-04-01
+**Feature**: `/Users/macmain/.local/share/symphony-workspaces/026-first-real-coordinator-subagent-runtime/specs/026-first-real-coordinator-subagent-runtime/spec.md`
+
+**Note**: This checklist tests the packet requirements and scaffold boundaries, not the
+implementation.
+
+## Truth Separation
+
+- [ ] CHK001 Does the scaffold clearly separate current live graph/runtime truth from the still
+      missing grounded coordinator-subagent runtime? [Clarity, Spec §Current Truth & Scope]
+- [ ] CHK002 Does the scaffold explicitly state that packets `022` through `025` are still in
+      progress and must be reconciled later? [Completeness, Spec §Current Truth & Scope]
+
+## Proof Standard
+
+- [ ] CHK003 Does the scaffold define packet `026` success using delegation, state, grounded
+      evidence, and coordinator decisions rather than graph completion alone? [Completeness,
+      Spec §FR-003, Spec §FR-005, Spec §FR-008]
+- [ ] CHK004 Is placeholder-only delegated completion clearly marked as insufficient for packet
+      success? [Clarity, Spec §FR-006]
+
+## Scope Boundaries
+
+- [ ] CHK005 Are federation, capability discovery, and generic interoperability explicitly kept
+      out of scope across `spec.md`, `plan.md`, and `tasks.md`? [Consistency]
+- [ ] CHK006 Does the scaffold preserve the smallest-workflow rule and honest sequential collapse
+      instead of forcing fan-out? [Coverage, Spec §FR-007]
+
+## Upstream Ownership
+
+- [ ] CHK007 Does packet `026` avoid redefining packet `022` through `025` ownership? [Consistency,
+      Spec §FR-010]
+- [ ] CHK008 Are the upstream dependency assumptions repeated consistently in `spec.md`,
+      `plan.md`, `contracts/`, and `analyze.md`? [Consistency]
+
+## Operator Surfaces
+
+- [ ] CHK009 Are task result, autonomy status, and operator-console run detail the only required
+      operator surfaces named for this packet? [Coverage, Spec §FR-009]
+- [ ] CHK010 Does the scaffold avoid implying a broader UI or observability redesign?
+      [Clarity, Plan §D5]
+
+## Revision Gate
+
+- [ ] CHK011 Is the pre-implementation revision gate present and visible in `spec.md`, `plan.md`,
+      `quickstart.md`, and `tasks.md`? [Completeness]
+- [ ] CHK012 Does the scaffold make it clear that no implementation or live-proof claim is valid
+      before that gate is complete? [Coverage, Spec §FR-015]
+
+## Session Follow-Up
+
+- [ ] CHK013 Are session carry-forward limits defined in terms of identifiers and evidence
+      references rather than transcript reuse? [Clarity, Spec §FR-013]
+
+## Notes
+
+- Keep this checklist open until the pre-implementation refresh pass is complete.
+- If upstream packet wording changes materially, update this checklist before coding starts.

--- a/specs/026-first-real-coordinator-subagent-runtime/contracts/coordinator-subagent-runtime-contract.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/contracts/coordinator-subagent-runtime-contract.md
@@ -1,0 +1,142 @@
+# Contract: Coordinator-Subagent Runtime Surface
+
+**Spec**: [../spec.md](../spec.md) | **Plan**: [../plan.md](../plan.md)
+
+## Scaffold note
+
+This is a scaffold contract written before packets `022` through `025` are complete. It defines
+the packet `026` contract shape now, but it must be revised before implementation starts.
+
+## Design goal
+
+Freeze one bounded contract for the first honest local coordinator-subagent runtime so later
+implementation does not have to rediscover what "real coordinator-subagent runtime" means.
+
+This packet does **not**:
+
+- redefine packet `022` durability ownership
+- redefine packet `023` trace or proof-boundary ownership
+- redefine packet `024` boundary-hardening ownership
+- redefine packet `025` step-policy ownership
+- widen into federation or capability discovery
+
+## Canonical mapping
+
+The contract for packet `026` is:
+
+- `CoordinatorDelegationRecord` is the required visible record that the coordinator delegated one
+  bounded job to one subagent
+- `SubagentStateRecord` is the required visible state surface for that delegated job
+- `DelegatedWorkEvidenceRef` is the required proof reference for what the delegated job actually
+  produced
+- `CoordinatorMergeDecision` is the required visible record of merge, clarify, reassign, stop, or
+  collapse decisions owned by the coordinator
+- `CoordinatorRuntimeProofView` is the required joined view on task result, autonomy status, and
+  run detail
+
+No other packet `026` surface may claim real coordinator-subagent runtime success without these
+records.
+
+## Packet success rule
+
+Packet `026` success requires:
+
+- at least one visible coordinator-owned delegation record
+- visible delegated subagent state
+- grounded delegated work evidence for at least one delegated job
+- visible coordinator merge or recovery decisions when the run requires them
+- explicit proof text when delegated work remains placeholder-only
+
+Packet `026` does **not** require fan-out on every task. Honest sequential collapse remains valid
+when the smallest-workflow rule says branching is unnecessary.
+
+## Canonical evidence shape
+
+Example authoritative payload shape:
+
+```json
+{
+  "workflow_id": "11111111-1111-1111-1111-111111111111",
+  "session_id": "22222222-2222-2222-2222-222222222222",
+  "coordinator_agent_id": "agent-coordinator-1",
+  "delegations": [
+    {
+      "delegation_id": "delegation-1",
+      "subagent_id": "agent-worker-1",
+      "delegated_job_label": "audit backend boundaries",
+      "status": "running"
+    }
+  ],
+  "subagent_states": [
+    {
+      "delegation_id": "delegation-1",
+      "current_state": "running",
+      "state_reason": "grounded repo inspection in progress"
+    }
+  ],
+  "delegated_work_evidence": [
+    {
+      "delegation_id": "delegation-1",
+      "evidence_kind": "grounded",
+      "evidence_summary": "bounded evidence captured for delegated backend audit"
+    }
+  ],
+  "coordinator_decisions": [
+    {
+      "decision_id": "decision-1",
+      "decision_kind": "merge",
+      "decision_outcome": "accepted"
+    }
+  ],
+  "proof_boundary": "real coordinator-subagent runtime satisfied"
+}
+```
+
+Behavior:
+
+- placeholder-only delegated completion must remain explicitly non-grounded
+- mixed runs may include both grounded and non-grounded delegated outcomes
+- coordinator decisions remain separate from subagent state, but must be linkable to it
+- sequential collapse must not fabricate delegation records
+
+## Task surface contract
+
+`task.result` remains one authoritative operator-facing inspection surface.
+
+Expected behavior:
+
+- task result exposes the latest joined `CoordinatorRuntimeProofView`
+- task result can explain why a run did or did not satisfy the packet `026` proof standard
+- task result can distinguish graph success from real coordinator-subagent success
+
+## Autonomy surface contract
+
+`AutonomyStatusView` remains the main runtime status surface.
+
+Expected behavior:
+
+- autonomy status exposes delegation, subagent state, and proof-boundary summary data
+- autonomy status shows collapse honestly when the run stayed sequential
+- autonomy status stays consistent with task result and does not invent extra coordination claims
+
+## Operator run-detail contract
+
+The operator-console run detail remains a bounded summary surface.
+
+Expected behavior:
+
+- run detail renders delegation, state, evidence, and decision summaries as first-class content
+- run detail does not require raw payload digging to understand the proof boundary
+- run detail stays bounded and does not widen into a new dashboard or observability redesign
+
+## Relationship to upstream packets
+
+Packet `026` depends on upstream ownership from packets `022` through `025`:
+
+- packet `022`: durable lifecycle and effect-boundary semantics
+- packet `023`: run-trace and proof-boundary semantics
+- packet `024`: security-boundary and delegated-authority semantics
+- packet `025`: step-policy and escalation semantics
+
+Before implementation starts, this contract must be revised to match what those packets actually
+landed.

--- a/specs/026-first-real-coordinator-subagent-runtime/data-model.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/data-model.md
@@ -1,0 +1,75 @@
+# Data Model: First Real Coordinator-Subagent Runtime
+
+## Scaffold note
+
+These entities are frozen now as scaffold names and intent. Final field wording must be revised
+before implementation after packet `022` through `025` land.
+
+## Coordinator-runtime entities
+
+### `CoordinatorDelegationRecord`
+
+- `delegation_id`: stable identifier for one coordinator-owned delegation event
+- `workflow_id`: stable workflow identifier for the run
+- `session_id`: optional stable session identifier for session-aware follow-up
+- `coordinator_agent_id`: stable coordinator identity for the run
+- `subagent_id`: delegated subagent identity
+- `delegated_job_label`: short plain-English label for the bounded delegated job
+- `delegated_scope_ref`: link to the branch, node, or bounded work unit the subagent owns
+- `delegation_reason`: plain-English rationale for why the job was delegated
+- `created_at`: delegation creation time
+- `status`: current high-level delegation state
+
+### `SubagentStateRecord`
+
+- `delegation_id`: stable reference back to the owning delegation record
+- `subagent_id`: delegated subagent identity
+- `current_state`: one of `queued`, `delegated`, `running`, `blocked`, `clarified`,
+  `reassigned`, `merged`, `completed`, `failed`, or `collapsed`
+- `previous_state`: last visible state, if any
+- `state_reason`: short explanation for the current state
+- `state_updated_at`: last state-change time
+- `coordinator_action_ref`: optional reference to the latest coordinator decision tied to this
+  state
+
+### `DelegatedWorkEvidenceRef`
+
+- `delegation_id`: stable reference to the delegated job
+- `evidence_kind`: grounded, placeholder-only, or mixed
+- `evidence_summary`: short summary of what the delegated job actually produced
+- `artifact_refs`: references to result artifacts, task output, or other bounded evidence
+- `proof_boundary_note`: explicit note explaining what this evidence does and does not prove
+- `recorded_at`: time the evidence reference was written
+
+### `CoordinatorMergeDecision`
+
+- `decision_id`: stable identifier for one coordinator-owned merge or recovery decision
+- `workflow_id`: stable workflow identifier
+- `decision_kind`: merge, clarify, reassign, stop, or collapse
+- `input_refs`: delegated job or state references the coordinator used
+- `decision_reason`: short explanation for the decision
+- `decision_outcome`: accepted, deferred, blocked, or terminal
+- `decided_at`: time the decision was made
+
+### `CoordinatorRuntimeProofView`
+
+- `workflow_id`: stable workflow identifier
+- `coordinator_agent_id`: stable coordinator identity
+- `delegation_refs`: ordered set of delegation records included in the proof view
+- `subagent_state_refs`: ordered set of visible subagent states
+- `evidence_refs`: ordered set of delegated work evidence references
+- `decision_refs`: ordered set of coordinator merge or recovery decisions
+- `proof_boundary`: explicit statement of whether the run satisfied the packet `026` proof
+  standard
+- `session_follow_up_note`: note describing what session context can legitimately carry forward
+
+## Invariants
+
+- no run may satisfy packet `026` proof without at least one `CoordinatorDelegationRecord`
+- no run may satisfy packet `026` proof without visible `SubagentStateRecord` data
+- `DelegatedWorkEvidenceRef.evidence_kind = placeholder-only` cannot satisfy packet success
+- `CoordinatorMergeDecision` remains coordinator-owned even when the final outcome is collapse
+- sequential collapse is a valid honest outcome when fan-out is not justified
+- session-aware follow-up may preserve identifiers and evidence references, but must not imply
+  unlimited transcript reuse
+- all final wording and field names must pass through the pre-implementation revision gate

--- a/specs/026-first-real-coordinator-subagent-runtime/plan.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/plan.md
@@ -1,0 +1,174 @@
+# Implementation Plan: First Real Coordinator-Subagent Runtime
+
+**Branch**: `026-first-real-coordinator-subagent-runtime` | **Date**: 2026-04-01 |
+**Spec**: [spec.md](spec.md)
+**Input**: Feature specification from
+`/specs/026-first-real-coordinator-subagent-runtime/spec.md`
+
+## Summary
+
+This is a scaffold plan written before packets `022` through `025` are complete. Its job is to
+lock the packet `026` shape now, not to pretend the packet is ready to implement today.
+
+Packet `026` is the first bounded packet that should make the local runtime feel like a real
+coordinator-subagent system. That means visible coordinator-owned delegation, visible subagent
+state, grounded delegated work, visible feedback and merge or recovery loops, and explicit proof
+text that says when those things were not actually present.
+
+Before implementation starts, this plan must go through one explicit revision gate so the packet
+matches the real landed outputs of packets `022` through `025`.
+
+## Technical Context
+
+**Language/Version**: Rust 1.88.0 plus repo-owned TypeScript for the operator console
+**Primary Dependencies**: `mister-smith-core`, `mister-smith-agents`, `mister-smith-app`,
+`mister-smith-events`, `apps/operator-console/`, and the still-in-progress packet `022` through
+`025` outputs once they land
+**Storage**: existing task, autonomy, and session state plus the durable workflow and trace seams
+owned by packets `022` and `023`; exact final storage wording is deferred to the revision gate
+**Testing**: targeted Rust tests, task and autonomy projection tests, operator-console view tests,
+markdown lint, and `git diff --check`
+**Target Platform**: local macOS development with Linux runtime parity for the shipped app binary
+**Project Type**: Rust workspace packet with one bounded operator-console surface
+**Performance Goals**: preserve the smallest-workflow rule, avoid fake delegation overhead on
+sequential work, and keep proof surfaces readable without log archaeology
+**Constraints**: no implementation before the revision gate; no federation or discovery scope; do
+not redefine packet `022` through `025` ownership; do not claim live proof from scaffold-only work
+**Scale/Scope**: one bounded scaffold packet and one later implementation packet after upstream
+reconciliation
+
+## Constitution Check
+
+| Principle | Status | Evidence |
+| --------- | ------ | -------- |
+| I. Canonical Single Source | PASS | Grounded in `docs/direction.md`, `docs/current-state.md`, the packet-prep dossiers, and the session-context report. |
+| II. Spec-First Design | PASS | `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/`, `tasks.md`, and `analyze.md` are authored before any implementation. |
+| III. Phase-And-Packet-Gated Delivery | PASS | Packet `026` is explicitly scaffolded behind a revision gate so it cannot silently bypass packets `022` through `025`. |
+| IV. Model-Agnostic Architecture | PASS | The packet focuses on coordinator-runtime semantics, not provider-specific behavior. |
+| V. Erlang/OTP-Style Fault Tolerance | PASS | The packet keeps coordinator-owned recovery and collapse decisions explicit instead of hiding them inside opaque graph success. |
+| VI. Evidence-Based Validation | PASS | The scaffold states clear proof boundaries and requires a later refresh before any implementation or live-proof claim. |
+| VII. Explicit Dependency Management | PASS | Upstream ownership from packets `022` through `025` is consumed by reference and called out directly. |
+| VIII. Clean Closure And Resumability | PASS | The scaffold is written to be revised later without reauthoring packet scope from scratch. |
+
+## Project Structure
+
+```text
+specs/026-first-real-coordinator-subagent-runtime/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── coordinator-subagent-runtime-contract.md
+├── checklists/
+│   ├── requirements.md
+│   └── scaffold.md
+├── tasks.md
+└── analyze.md
+
+crates/mister-smith-core/
+├── src/autonomy.rs
+└── src/lib.rs
+
+crates/mister-smith-agents/
+├── src/execution_graph.rs
+├── src/orchestrator.rs
+├── src/roles/coordinator.rs
+└── src/roles/executor.rs
+
+crates/mister-smith-app/
+├── src/execution.rs
+├── src/autonomy.rs
+└── src/conversation.rs
+
+crates/mister-smith-events/
+└── src/bus.rs
+
+apps/operator-console/
+├── src/views/RunsView.tsx
+└── src/types.ts
+```
+
+## Design Decisions
+
+### D1: Scaffold now, revise before implementation
+
+Freeze the packet goal, non-goals, proof standard, and artifact shape now, but require a revision
+gate before any implementation begins.
+
+### D2: Real coordinator-subagent runtime needs more than graph success
+
+Packet `026` only counts as successful when a run shows coordinator-owned delegation records, real
+subagent state, grounded delegated work, and visible coordinator merge or recovery decisions.
+
+### D3: The smallest-workflow rule stays in force
+
+Real coordinator-runtime behavior must still allow honest sequential collapse when the task does
+not justify fan-out.
+
+### D4: Packet `022` through `025` keep their ownership
+
+Packet `026` consumes upstream packet ownership for durability, trace truth, security boundaries,
+and step policy. It does not redefine those seams.
+
+### D5: Operator evidence stays on existing surfaces
+
+The packet stays bounded to task result, autonomy status, and operator-console run detail.
+
+## Minimal Implementation Slice
+
+### Milestone 0: Revision gate and upstream reconciliation
+
+Validation:
+
+- `spec.md`, `plan.md`, `tasks.md`, and `analyze.md` all reflect the reconciled upstream truth
+- no packet `026` artifact still assumes upstream completion that did not actually land
+
+### Milestone 1: Shared contract freeze
+
+Validation:
+
+- `contracts/coordinator-subagent-runtime-contract.md` is final for the implementation pass
+- shared value objects and proof-boundary wording stop moving
+
+### Milestone 2: Visible delegation and subagent state
+
+Validation:
+
+- bounded runtime tests show delegation records and state transitions
+- sequential collapse stays honest and visible
+
+### Milestone 3: Grounded delegated work and feedback loops
+
+Validation:
+
+- bounded runtime tests prove grounded delegated work
+- placeholder-only delegated completion remains clearly non-grounded
+
+### Milestone 4: Operator proof surfaces and final evidence
+
+Validation:
+
+- all three operator surfaces tell the same proof story
+- final packet note keeps deterministic checks separate from live proof
+
+## Parallel Staging Posture
+
+- No implementation lane may start until Milestone 0 is complete.
+- Milestone 1 is a single-owner freeze.
+- After Milestone 1, bounded lanes may split if write sets are disjoint.
+- Shared-write choke points:
+  - `crates/mister-smith-app/src/execution.rs`
+  - `crates/mister-smith-agents/src/orchestrator.rs`
+  - `crates/mister-smith-agents/src/execution_graph.rs`
+  - `crates/mister-smith-core/src/autonomy.rs`
+  - `apps/operator-console/src/views/RunsView.tsx`
+
+## Explicitly Deferred
+
+- federation, capability discovery, and generic interoperability work
+- any new protocol baseline or capability-mapping contract
+- default fan-out or fixed multi-worker shapes
+- any attempt to replace packet `022` through `025` ownership
+- live proof claims before implementation and the revision gate are complete

--- a/specs/026-first-real-coordinator-subagent-runtime/quickstart.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: First Real Coordinator-Subagent Runtime
+
+## Current scaffold validation
+
+Use these checks to validate the scaffold artifact set now:
+
+```bash
+./.specify/scripts/bash/check-prerequisites.sh --json
+npx markdownlint-cli2 "specs/026-first-real-coordinator-subagent-runtime/**/*.md" --config .markdownlint.json
+git diff --check
+```
+
+## Required pre-implementation refresh pass
+
+Before implementation starts, rerun this refresh sequence:
+
+```bash
+sed -n '1,260p' docs/current-state.md
+sed -n '1,220p' docs/direction.md
+sed -n '1,260p' docs/packet-prep/022-durable-workflow-core.md
+sed -n '1,260p' docs/packet-prep/023-runtime-truth-and-run-trace.md
+sed -n '1,260p' docs/packet-prep/024-agent-boundary-security-hardening.md
+sed -n '1,260p' docs/packet-prep/025-step-level-intelligence-v2.md
+./.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
+```
+
+Then revise:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `analyze.md`
+- `contracts/coordinator-subagent-runtime-contract.md`
+
+## Future implementation validation target
+
+Once the revision gate is complete and implementation actually begins, the packet should be
+validated with the narrowest honest checks for the touched runtime and operator surfaces:
+
+```bash
+cargo test -p mister-smith-core
+cargo test -p mister-smith-agents
+cargo test -p mister-smith-events
+cargo test -p mister-smith-app
+npm --prefix apps/operator-console test
+npm --prefix apps/operator-console run build
+git diff --check
+```
+
+## Proof expectation
+
+Packet `026` only earns implementation proof when one bounded run shows:
+
+- visible coordinator-owned delegation
+- visible subagent state
+- grounded delegated work evidence
+- visible coordinator merge or recovery decisions
+- explicit proof text on task result, autonomy status, and run detail
+
+## Live-proof boundary
+
+This scaffold does not claim implementation proof or live runtime proof. Those claims stay blocked
+until the pre-implementation refresh pass is complete and the later implementation work is
+actually validated.

--- a/specs/026-first-real-coordinator-subagent-runtime/research.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/research.md
@@ -1,0 +1,75 @@
+# Research Notes: First Real Coordinator-Subagent Runtime
+
+## Current repo truth
+
+- the supported runtime path already proves workflow graph formation, topology selection, routing
+  metadata, supervision summaries, and same-agent session continuity
+- the March 27 runtime-planning simplification pass restored the smallest-workflow rule and made
+  sequential collapse the honest default when fan-out is not justified
+- the March 28 session-context report made the remaining gap explicit: current graph success is
+  still not the same thing as visible coordinator-subagent runtime behavior
+- the current placeholder step boundary still allows delegated-looking work to complete without
+  grounded delegated evidence
+
+## Upstream packet assumptions
+
+This packet is scaffolded before packets `022` through `025` are finished.
+
+Current working assumptions are:
+
+- packet `022` will own durable workflow semantics, lifecycle verbs, and effect boundaries
+- packet `023` will own run-trace taxonomy and proof-boundary wording
+- packet `024` will own boundary hardening, quarantine, and delegated authority rules
+- packet `025` will own step scoring, escalation, retry, clarify, and downgrade policy
+
+These assumptions must be rechecked before implementation starts.
+
+## Why current graph/runtime proof is not enough
+
+The current runtime can already show graph shape, branch counts, topology rationale, selected
+workers, routing history, and result envelopes. That is useful, but it is still insufficient for
+packet `026`.
+
+Packet `026` exists because a real coordinator-subagent runtime must also show:
+
+- which bounded job the coordinator delegated
+- which subagent owned that job
+- what state that delegated job moved through
+- what grounded evidence the delegated job produced
+- what merge or recovery decision the coordinator made in response
+
+Without those things, the runtime can still look successful while failing the user's expected
+meaning of coordination.
+
+## Proof standard for "real coordinator-subagent runtime"
+
+The scaffold uses this proof standard:
+
+1. a run must show at least one coordinator-owned delegation record
+2. a run must show visible state for delegated subagent work
+3. a run must show grounded delegated work evidence for at least one delegated job
+4. a run must show at least one visible coordinator merge, clarify, reassign, stop, or collapse
+   decision when the run requires it
+5. a run that only reaches placeholder delegated completion must remain explicitly non-grounded
+6. a task that does not justify branching may still satisfy the packet honestly by collapsing back
+   to sequential work instead of inventing fake subagent activity
+
+## Why comparator frameworks are only reference points
+
+OpenAI Agents SDK, Google ADK, and LangGraph are useful comparators for how delegation can be
+surfaced, how state can be shown to operators, and how bounded coordination loops can be
+described. They are not the Mister Smith contract.
+
+Packet `026` must stay grounded in:
+
+- `docs/current-state.md`
+- the packet-prep dossiers
+- the session-context report
+- the smallest-workflow rule already landed in this repo
+
+## Bounded conclusion
+
+The right scaffold for packet `026` is not generic multi-agent expansion. It is one bounded future
+packet that makes local coordinator-subagent runtime behavior honest and visible while preserving
+the current runtime's smallest-workflow discipline and while reusing the ownership boundaries
+already assigned to packets `022` through `025`.

--- a/specs/026-first-real-coordinator-subagent-runtime/spec.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/spec.md
@@ -1,0 +1,249 @@
+# Feature Specification: First Real Coordinator-Subagent Runtime
+
+**Feature Branch**: `026-first-real-coordinator-subagent-runtime`
+**Created**: 2026-04-01
+**Status**: Scaffold Draft
+**Input**: `docs/direction.md`, `docs/current-state.md`, `docs/packet-prep/README.md`,
+`docs/packet-prep/026-first-real-coordinator-subagent-runtime.md`,
+`docs/packet-prep/022-durable-workflow-core.md`,
+`docs/packet-prep/023-runtime-truth-and-run-trace.md`,
+`docs/packet-prep/024-agent-boundary-security-hardening.md`,
+`docs/packet-prep/025-step-level-intelligence-v2.md`,
+`docs/2026-03-28-session-context-report.md`,
+`docs/plans/2026-03-27-runtime-planning-simplification.md`, and
+`docs/plans/2026-03-15-first-live-multi-agent-runtime-proof.md`
+
+## Current Truth & Scope
+
+This packet is a provisional scaffold written before packets `022` through `025` are complete.
+It uses their packet-prep contract ownership as the current source of truth for scope boundaries,
+not their final landed implementations.
+
+This scaffold exists to save time later. It is meant to lock the packet goal, non-goals, proof
+standard, and main artifact shape now so future work is mostly revision instead of starting from
+zero.
+
+Current repo truth already includes:
+
+- live graph and topology formation on the supported runtime path
+- routing, provenance, repair, and supervision summaries on operator-facing surfaces
+- same-agent session continuity with stable `session_id` and `coordinator_agent_id`
+- smallest-workflow behavior that stays sequential unless branching is clearly justified
+
+Current repo truth does not yet include:
+
+- real coordinator-owned delegation records during a run
+- real subagent state that operators can inspect during a run
+- grounded delegated work below the current placeholder step boundary
+- an honest local coordinator-subagent runtime proof standard
+
+This packet therefore freezes one bounded future packet shape:
+
+- visible coordinator-owned delegation
+- visible subagent state
+- grounded delegated work
+- visible feedback, merge, and recovery loops
+- explicit proof language that separates graph success from real coordinator-subagent success
+
+### Pre-Implementation Revision Gate
+
+Before any implementation starts for packet `026`, the owner of the packet must:
+
+1. reread `docs/current-state.md`
+2. reread `docs/direction.md`
+3. confirm what packet `022` through `025` actually landed
+4. revise `spec.md`, `plan.md`, `tasks.md`, and `analyze.md` to match that landed truth
+
+This scaffold is not implementation-ready until that revision gate is completed.
+
+### Out Of Scope
+
+- federation, capability discovery, or generic interoperability work
+- mandatory fan-out or a fixed multi-worker shape
+- redefining packet `022` durability ownership
+- redefining packet `023` run-trace or proof-boundary ownership
+- redefining packet `024` boundary-hardening ownership
+- redefining packet `025` step-policy ownership
+
+## Clarifications
+
+### Session 2026-04-01
+
+- Q: Who owns merge, reassign, clarify, stop, and collapse decisions in this packet? → A: The
+  coordinator owns those decisions and the packet must keep them visible.
+- Q: What subagent state model does this scaffold assume? → A: `queued`, `delegated`, `running`,
+  `blocked`, `clarified`, `reassigned`, `merged`, `completed`, `failed`, and `collapsed`.
+- Q: What session continuity carries across coordinator-led follow-up runs? → A: Preserve
+  `session_id`, `coordinator_agent_id`, and evidence references, but do not assume transcript
+  duplication or unlimited carry-forward.
+- Q: What counts as placeholder-only execution for this packet? → A: If delegated work stops at a
+  `workflow.execute_step`-style envelope without grounded evidence, it does not satisfy packet
+  `026` success.
+
+## User Scenarios & Testing
+
+### User Story 1 - See Real Delegation And Subagent State (Priority: P1)
+
+An operator inspects a runtime-backed run and can see that a coordinator delegated real bounded
+work to named subagents, along with each subagent's current state and any coordinator response to
+that state.
+
+**Why this priority**: This is the first honest difference between graph metadata and a real
+coordinator-subagent runtime. Without it, the packet does not deliver its core value.
+
+**Independent Test**: A bounded run that justifies delegation shows at least one coordinator-owned
+delegation record and at least two visible subagent state transitions without requiring log
+archaeology.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task that clearly benefits from bounded fan-out, **When** the runtime delegates
+   work, **Then** the operator can see a coordinator-owned delegation record for each delegated
+   subagent job.
+2. **Given** a delegated subagent job moves from waiting to active or blocked work, **When** the
+   operator inspects the run, **Then** the current subagent state is visible and attributable to
+   that delegated job.
+3. **Given** a task does not justify branching, **When** the runtime keeps the work sequential,
+   **Then** the run still succeeds honestly and shows collapse or non-delegation instead of fake
+   subagent activity.
+
+---
+
+### User Story 2 - Prove Grounded Delegated Work And Feedback Loops (Priority: P1)
+
+An operator or reviewer can tell whether delegated work was actually grounded, how the
+coordinator reacted when a subagent stalled or failed, and whether a merge or recovery decision
+was taken on real evidence instead of placeholder completion.
+
+**Why this priority**: Packet `026` must prove more than delegation theater. It must show
+grounded delegated work and visible feedback loops.
+
+**Independent Test**: A bounded delegated run records grounded evidence for at least one
+subagent-owned job and records a visible coordinator decision for one merge, clarify, reassign,
+stop, or collapse case.
+
+**Acceptance Scenarios**:
+
+1. **Given** a delegated subagent completes real bounded work, **When** the coordinator inspects
+   the result, **Then** the run records grounded delegated work rather than only placeholder step
+   completion.
+2. **Given** a delegated subagent becomes blocked, fails, or needs clarification, **When** the
+   coordinator responds, **Then** the follow-up decision is visible as clarify, reassign, stop, or
+   collapse.
+3. **Given** delegated work only returns placeholder completion, **When** the run reaches a
+   terminal state, **Then** the proof boundary explicitly says the run did not satisfy real
+   coordinator-subagent success.
+
+---
+
+### User Story 3 - Inspect Proof Boundaries And Session-Aware Follow-Up (Priority: P2)
+
+An operator can inspect task, autonomy, and run-detail views and understand both the packet's
+proof boundary and what session-aware follow-up will preserve if a later coordinator-led run
+continues the work.
+
+**Why this priority**: The packet must stay honest. Operators need to know what was proven and
+what still depends on later work or on the revision gate.
+
+**Independent Test**: Task result, autonomy status, and run detail all show the same proof
+boundary story and the same session carry-forward assumptions for coordinator-led follow-up.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run used real coordinator-owned delegation, **When** an operator inspects task,
+   autonomy, or run detail, **Then** all three views present the same proof-boundary story.
+2. **Given** a run ended with sequential collapse or partial delegation only, **When** the
+   operator inspects the proof view, **Then** the packet clearly states what was and was not
+   proven.
+3. **Given** a later coordinator-led follow-up run resumes related work, **When** session context
+   is reused, **Then** the packet preserves stable identifiers and evidence references without
+   implying unlimited transcript carry-forward.
+
+### Edge Cases
+
+- a task starts as a candidate for delegation but collapses back to sequential execution because
+  the smallest-workflow rule says fan-out is unnecessary
+- a subagent becomes blocked after a delegation record exists but before grounded evidence exists
+- a merge decision combines one grounded branch and one failed or placeholder-only branch
+- upstream packet `022` through `025` implementations change field names or proof-boundary wording
+  before packet `026` implementation begins
+- a coordinator-led follow-up run tries to reuse session context after the upstream revision gate
+  changes the contract
+- operator surfaces show graph completion for a run that still fails the packet `026` proof
+  standard
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST define packet `026` as a provisional scaffold packet and MUST state
+  that it requires revision before implementation begins.
+- **FR-002**: System MUST keep current live graph, topology, routing, provenance, and session
+  continuity truth separate from the still-missing grounded coordinator-subagent runtime.
+- **FR-003**: System MUST require coordinator-owned delegation records as first-class runtime
+  evidence for any run that claims coordinator-subagent behavior.
+- **FR-004**: System MUST require visible subagent state transitions for delegated work.
+- **FR-005**: System MUST require grounded delegated work evidence before a run can satisfy the
+  packet `026` proof standard.
+- **FR-006**: System MUST treat placeholder-only delegated completion as non-grounded and
+  insufficient for packet success.
+- **FR-007**: System MUST preserve the smallest-workflow rule and MUST allow honest sequential
+  collapse when fan-out is not justified.
+- **FR-008**: System MUST make coordinator merge, clarify, reassign, stop, and collapse decisions
+  visible to the operator when they occur.
+- **FR-009**: System MUST expose packet `026` proof-boundary language on task result, autonomy
+  status, and operator-console run detail.
+- **FR-010**: System MUST consume packet `022` through `025` ownership by reference and MUST NOT
+  redefine lifecycle, run-trace, security-boundary, or step-policy ownership inside packet `026`.
+- **FR-011**: System MUST keep federation, capability discovery, and generic interoperability work
+  out of this packet.
+- **FR-012**: System MUST include an explicit pre-implementation revision gate that reconciles
+  packet `022` through `025` landed truth before any coding starts.
+- **FR-013**: System MUST define the session-aware follow-up contract in terms of stable
+  identifiers and evidence references, not unlimited transcript reuse.
+- **FR-014**: System MUST keep the scaffold decision-useful enough that future work mainly revises
+  it instead of reauthoring the packet from scratch.
+- **FR-015**: System MUST defer any implementation-ready validation or live runtime proof claims
+  until the revision gate is completed.
+
+### Key Entities
+
+- **CoordinatorDelegationRecord**: a visible record that the coordinator assigned one bounded job
+  to a specific subagent, including job intent, scope, and downstream evidence references
+- **SubagentStateRecord**: the current and previous visible state for one delegated subagent job,
+  including blocked, clarified, reassigned, merged, failed, or collapsed outcomes
+- **DelegatedWorkEvidenceRef**: a reference that ties one delegated job to the grounded evidence,
+  proof boundary, or placeholder-only result that job produced
+- **CoordinatorMergeDecision**: a visible coordinator-owned decision that explains how delegated
+  outputs were merged, clarified, reassigned, stopped, or collapsed
+- **CoordinatorRuntimeProofView**: the operator-facing proof summary that joins delegation,
+  subagent state, delegated work evidence, merge or recovery decisions, and the current proof
+  boundary
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `spec.md`, `plan.md`, `tasks.md`, and `analyze.md` all repeat the same packet goal,
+  non-goals, proof standard, and pre-implementation revision gate with no conflicting language.
+- **SC-002**: The scaffold clearly distinguishes current live graph/runtime truth from the
+  missing grounded coordinator-subagent runtime truth in every core artifact.
+- **SC-003**: The scaffold names all required evidence types and all required operator surfaces so
+  a later implementer can map them to concrete work without re-scoping the packet.
+- **SC-004**: The scaffold contains no language that implies packet `022` through `025` are
+  already complete, frozen, or safe to ignore before packet `026` implementation.
+- **SC-005**: The scaffold contains no language that widens packet `026` into federation,
+  capability discovery, generic interoperability, or mandatory fan-out behavior.
+
+## Assumptions
+
+- Packets `022` through `025` are still in progress, so packet `026` uses dossier truth and
+  current repo truth rather than final upstream packet outputs.
+- The supported runtime path still proves graph and workflow mechanics more strongly than grounded
+  delegated work.
+- Task result, autonomy status, and operator-console run detail remain the main operator-facing
+  surfaces for this packet.
+- Session-aware follow-up will preserve `session_id`, `coordinator_agent_id`, and evidence
+  references unless upstream packet revisions explicitly change that contract.
+- Packet `026` will be revised before implementation, so exact field names and operator wording
+  may change once packet `022` through `025` land.

--- a/specs/026-first-real-coordinator-subagent-runtime/tasks.md
+++ b/specs/026-first-real-coordinator-subagent-runtime/tasks.md
@@ -1,0 +1,199 @@
+# Tasks: First Real Coordinator-Subagent Runtime
+
+**Input**: Design documents from `/specs/026-first-real-coordinator-subagent-runtime/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`,
+`contracts/`
+
+**Tests**: Included. This scaffold names the future validation tasks now, but no implementation
+should begin until the revision gate is complete.
+
+**Organization**: Tasks are grouped by the packet revision gate, one shared contract phase, and
+the three packet user stories so later implementation can start from a ready scaffold instead of a
+blank page.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel only when every blocking checkpoint in the current section is
+  complete and the write set is disjoint
+- **[Story]**: Which user story this task belongs to (`US1` through `US3`)
+- Include exact file paths in descriptions
+
+## Status Reconciliation (2026-04-01)
+
+- this is a scaffold task list, not an implementation-complete packet
+- packet `022` through `025` are still in progress
+- packet `026` must not start code work until the revision gate below is complete
+
+---
+
+## Phase 0: Revision And Reconcile (Blocking)
+
+**Goal**: refresh the scaffold against the real landed truth of packets `022` through `025`
+before any implementation begins.
+
+**CRITICAL**: No implementation task may begin until this phase is complete.
+
+- [ ] T001 Review `docs/current-state.md`, `docs/direction.md`, and
+      `docs/packet-prep/README.md` against the landed truth for packets `022` through `025`
+- [ ] T002 Update
+      `/Users/macmain/.local/share/symphony-workspaces/026-first-real-coordinator-subagent-runtime/specs/026-first-real-coordinator-subagent-runtime/spec.md`
+      to match the reconciled upstream packet outputs
+- [ ] T003 Update
+      `/Users/macmain/.local/share/symphony-workspaces/026-first-real-coordinator-subagent-runtime/specs/026-first-real-coordinator-subagent-runtime/plan.md`,
+      `research.md`, `data-model.md`, `quickstart.md`, and
+      `contracts/coordinator-subagent-runtime-contract.md` to match the reconciled upstream packet
+      outputs
+- [ ] T004 Update
+      `/Users/macmain/.local/share/symphony-workspaces/026-first-real-coordinator-subagent-runtime/specs/026-first-real-coordinator-subagent-runtime/tasks.md`,
+      `analyze.md`, and `checklists/scaffold.md` to match the reconciled upstream packet outputs
+- [ ] T005 Re-run `./.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`
+      and confirm packet `026` is still bounded before any coding starts
+
+**Checkpoint**: packet `026` is revised against real upstream truth and is ready for actual
+implementation planning.
+
+---
+
+## Phase 1: Shared Contract Freeze (Blocking Prerequisites)
+
+**Goal**: freeze the shared coordinator-runtime contract and proof standard once the revision gate
+is done.
+
+- [ ] T006 [P] Create or update shared value objects in
+      `crates/mister-smith-core/src/autonomy.rs` and `crates/mister-smith-core/src/lib.rs`
+- [ ] T007 [P] Freeze graph-facing delegation and subagent-state contract seams in
+      `crates/mister-smith-agents/src/execution_graph.rs`
+- [ ] T008 Freeze the runtime contract in
+      `/Users/macmain/.local/share/symphony-workspaces/026-first-real-coordinator-subagent-runtime/specs/026-first-real-coordinator-subagent-runtime/contracts/coordinator-subagent-runtime-contract.md`
+
+**Checkpoint**: shared packet `026` contract and core value objects are stable.
+
+---
+
+## Phase 2: User Story 1 - See Real Delegation And Subagent State (Priority: P1)
+
+**Goal**: make coordinator-owned delegation and subagent state visible on the runtime path.
+
+**Independent Test**: one bounded delegated run exposes at least one delegation record and at
+least two visible subagent state transitions without fake fan-out on sequential tasks.
+
+### Tests For User Story 1
+
+- [ ] T009 [P] [US1] Add delegation and subagent-state runtime tests in
+      `crates/mister-smith-agents/tests/coordinator_runtime_tests.rs`
+- [ ] T010 [P] [US1] Add task-path delegation projection tests in
+      `crates/mister-smith-app/tests/coordinator_runtime_tests.rs`
+
+### Implementation For User Story 1
+
+- [ ] T011 [P] [US1] Add `CoordinatorDelegationRecord` and `SubagentStateRecord` support in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T012 [P] [US1] Extend delegation-aware graph structures in
+      `crates/mister-smith-agents/src/execution_graph.rs`
+- [ ] T013 [US1] Wire coordinator-owned delegation and subagent state updates in
+      `crates/mister-smith-agents/src/orchestrator.rs` and
+      `crates/mister-smith-agents/src/roles/coordinator.rs`
+- [ ] T014 [US1] Project delegation and subagent state into runtime task output in
+      `crates/mister-smith-app/src/execution.rs`
+
+**Checkpoint**: operators can inspect real delegation and subagent state on the runtime path.
+
+---
+
+## Phase 3: User Story 2 - Prove Grounded Delegated Work And Feedback Loops (Priority: P1)
+
+**Goal**: distinguish grounded delegated work from placeholder completion and surface visible
+coordinator feedback decisions.
+
+**Independent Test**: one bounded delegated run records grounded evidence for at least one
+delegated job and records one visible coordinator merge or recovery decision.
+
+### Tests For User Story 2
+
+- [ ] T015 [P] [US2] Add grounded delegated work proof tests in
+      `crates/mister-smith-app/tests/coordinator_runtime_tests.rs`
+- [ ] T016 [P] [US2] Add feedback-loop and partial-failure tests in
+      `crates/mister-smith-agents/tests/coordinator_runtime_tests.rs`
+
+### Implementation For User Story 2
+
+- [ ] T017 [P] [US2] Add `DelegatedWorkEvidenceRef` and `CoordinatorMergeDecision` support in
+      `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T018 [P] [US2] Replace placeholder-only delegated completion handling in
+      `crates/mister-smith-app/src/execution.rs`
+- [ ] T019 [US2] Wire clarify, reassign, stop, collapse, and merge decision capture in
+      `crates/mister-smith-agents/src/orchestrator.rs`,
+      `crates/mister-smith-agents/src/roles/coordinator.rs`, and
+      `crates/mister-smith-agents/src/roles/executor.rs`
+- [ ] T020 [US2] Extend session-aware follow-up references in
+      `crates/mister-smith-app/src/conversation.rs`
+
+**Checkpoint**: packet `026` can distinguish grounded delegated work from placeholder delegated
+completion and can surface visible feedback loops.
+
+---
+
+## Phase 4: User Story 3 - Inspect Proof Boundaries And Session-Aware Follow-Up (Priority: P2)
+
+**Goal**: make proof-boundary and session-follow-up semantics visible on the operator path.
+
+**Independent Test**: task result, autonomy status, and run detail show the same proof story and
+the same session carry-forward assumptions.
+
+### Tests For User Story 3
+
+- [ ] T021 [P] [US3] Add packet `026` proof-view tests in
+      `crates/mister-smith-app/tests/autonomy_status_tests.rs`
+- [ ] T022 [P] [US3] Add event aggregation tests in
+      `crates/mister-smith-events/tests/autonomy_event_tests.rs`
+- [ ] T023 [P] [US3] Add operator-console run-detail tests in
+      `apps/operator-console/src/views/RunsView.test.tsx`
+
+### Implementation For User Story 3
+
+- [ ] T024 [P] [US3] Add `CoordinatorRuntimeProofView` support in
+      `crates/mister-smith-core/src/autonomy.rs` and `crates/mister-smith-events/src/bus.rs`
+- [ ] T025 [P] [US3] Project packet `026` proof-boundary data in
+      `crates/mister-smith-app/src/autonomy.rs` and `crates/mister-smith-app/src/execution.rs`
+- [ ] T026 [US3] Render delegation, state, and proof summaries in
+      `apps/operator-console/src/views/RunsView.tsx` and `apps/operator-console/src/types.ts`
+
+**Checkpoint**: the operator path exposes one coherent packet `026` proof story.
+
+---
+
+## Final Validation And Evidence
+
+- [ ] T027 Run `cargo test -p mister-smith-core`
+- [ ] T028 Run `cargo test -p mister-smith-agents`
+- [ ] T029 Run `cargo test -p mister-smith-events`
+- [ ] T030 Run `cargo test -p mister-smith-app`
+- [ ] T031 Run `npm --prefix apps/operator-console test`
+- [ ] T032 Run `npm --prefix apps/operator-console run build`
+- [ ] T033 Run `npx markdownlint-cli2 "specs/026-first-real-coordinator-subagent-runtime/**/*.md" --config .markdownlint.json`
+- [ ] T034 Run `git diff --check`
+- [ ] T035 Capture the final proof-boundary note under `docs/plans/` and sync
+      `docs/current-state.md` only if packet `026` actually lands
+
+## Parallel Staging Directive
+
+`[P]` means a task may run in parallel only when:
+
+- the revision gate is complete
+- every blocking checkpoint in the current section is complete
+- its write set is disjoint from every other active lane
+
+Shared-write choke points for packet `026`:
+
+- `crates/mister-smith-app/src/execution.rs`
+- `crates/mister-smith-agents/src/orchestrator.rs`
+- `crates/mister-smith-agents/src/execution_graph.rs`
+- `crates/mister-smith-core/src/autonomy.rs`
+- `apps/operator-console/src/views/RunsView.tsx`
+
+## Explicitly Out Of Scope For This Packet
+
+- federation, capability discovery, or generic interoperability work
+- default fan-out or fixed multi-worker topology
+- redefining packet `022` through `025` ownership
+- live runtime-proof claims before the revision gate and later implementation work are complete


### PR DESCRIPTION
## Summary
- add the full SpecKit scaffold packet for `026-first-real-coordinator-subagent-runtime`
- define the spec, plan, tasks, analysis, research, data model, quickstart, checklists, and coordinator-subagent runtime contract
- keep the packet explicitly scaffold-only with a revision gate before any later implementation

## Why
- packets `022` through `025` are still landing, but packet `026` can be scaffolded now to speed up later work
- the scaffold locks the packet goal, proof standard, non-goals, and artifact shape without pretending the runtime work is already implemented

## Validation
- `./.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`
- `npx markdownlint-cli2 "specs/026-first-real-coordinator-subagent-runtime/**/*.md" --config .markdownlint.json`
- `git diff --check`
- `scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync`
