### PR TITLE
docs(specs): scaffold packet 027 interoperability

### DIFF
--- a/specs/027-capability-discovery-and-interoperability/checklists/interop.md
+++ b/specs/027-capability-discovery-and-interoperability/checklists/interop.md
@@ -1,0 +1,86 @@
+# Interop Requirements Checklist: Capability Discovery And Interoperability
+
+**Purpose**: Validate that the packet requirements stay bounded, version-pinned, and clear before
+planning or implementation work starts.  
+**Created**: 2026-04-01  
+**Feature**: [spec.md](../spec.md)
+
+**Note**: This checklist is generated from the current packet `027` scaffold and is meant for
+packet-author and reviewer use before implementation.
+
+## Requirement Completeness
+
+- [ ] CHK001 Are the provisional upstream dependencies on packets `022`, `023`, and `024`
+  explicitly documented wherever packet `027` reuses their contract language? [Completeness,
+  Spec §Current Truth & Scope]
+- [ ] CHK002 Does the spec clearly state that packet `027` must be revised before any
+  implementation work begins? [Completeness, Spec §Current Truth & Scope]
+- [ ] CHK003 Are both required packet outputs defined: one normalized capability contract and one
+  A2A lifecycle-mapping contract? [Completeness, Spec §FR-002, Spec §FR-009]
+
+## Requirement Clarity
+
+- [ ] CHK004 Is the phrase "first interoperability slice" defined concretely as A2A `v0.3.0`
+  discovery plus lifecycle mapping instead of broad federation work? [Clarity, Spec §Current
+  Truth & Scope]
+- [ ] CHK005 Is the separation between discovery metadata and execution permission stated in a way
+  that cannot be mistaken for implicit trust? [Clarity, Spec §FR-005]
+- [ ] CHK006 Is MCP's role described clearly as a pinned baseline input and policy boundary rather
+  than the first new interop slice? [Clarity, Spec §FR-007]
+
+## Requirement Consistency
+
+- [ ] CHK007 Are protocol version requirements consistent across all packet sections, with MCP
+  always pinned to `2025-11-25` and A2A always pinned to `v0.3.0`? [Consistency, Spec §FR-006,
+  Spec §FR-007, Spec §SC-002]
+- [ ] CHK008 Do the non-goals, assumptions, and functional requirements all align on excluding
+  generic federation, extra protocols, and live multi-remote proof? [Consistency, Spec §Current
+  Truth & Scope, Spec §FR-015, Spec §Assumptions]
+- [ ] CHK009 Does every reference to packet `016` stay limited to continuity and provenance
+  instead of drifting into broad lifecycle-proof language? [Consistency, Spec §User Story 3, Spec
+  §FR-013]
+
+## Acceptance Criteria Quality
+
+- [ ] CHK010 Can each success criterion be checked from packet artifacts without needing
+  implementation-specific interpretation? [Measurability, Spec §SC-001 through Spec §SC-006]
+- [ ] CHK011 Do the independent tests for all user stories describe how the packet can be
+  validated as a document set rather than as running code? [Clarity, Spec §User Story 1 through
+  Spec §User Story 3]
+
+## Scenario Coverage
+
+- [ ] CHK012 Are requirements defined for both discovery normalization and remote lifecycle
+  mapping, rather than covering only one of the two? [Coverage, Spec §FR-003, Spec §FR-009]
+- [ ] CHK013 Are unsupported or partial lifecycle mappings addressed so the packet does not imply
+  that every A2A task state already fits Mister Smith directly? [Coverage, Spec §User Story 2,
+  Spec §Edge Cases]
+
+## Edge Case Coverage
+
+- [ ] CHK014 Does the spec define what happens if upstream packet `022`, `023`, or `024`
+  contracts change before implementation begins? [Edge Case, Spec §Edge Cases]
+- [ ] CHK015 Does the spec address the case where discovery remains allowed but execution stays
+  blocked by local policy? [Edge Case, Spec §Edge Cases]
+- [ ] CHK016 Does the spec address version-drift risk by banning mixed pinned and unpinned
+  protocol pages? [Edge Case, Spec §Current Truth & Scope, Spec §FR-008]
+
+## Dependencies & Assumptions
+
+- [ ] CHK017 Are the assumptions about provisional upstream contracts and later refresh clearly
+  stated as assumptions, not as landed truth? [Assumption, Spec §Assumptions]
+- [ ] CHK018 Is the refresh gate before implementation defined as a blocking dependency rather
+  than a nice-to-have follow-up? [Dependency, Spec §FR-016]
+
+## Ambiguities & Conflicts
+
+- [ ] CHK019 Is any wording left that could imply packet `027` is ready for immediate
+  implementation? [Ambiguity, Spec §Current Truth & Scope, Spec §FR-001]
+- [ ] CHK020 Is any wording left that could imply a generic multi-protocol interoperability packet
+  instead of one bounded A2A-first slice? [Conflict, Spec §Current Truth & Scope, Spec §FR-015]
+
+## Notes
+
+- This checklist is intentionally requirement-focused. It does not verify implementation behavior.
+- Use it during packet review to catch scope drift before `/speckit.plan` or implementation work
+  moves forward.

--- a/specs/027-capability-discovery-and-interoperability/checklists/requirements.md
+++ b/specs/027-capability-discovery-and-interoperability/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Capability Discovery And Interoperability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-01  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Packet `027` is intentionally scaffold-only and includes an explicit revision gate before
+  implementation.
+- Upstream packet dependencies (`022`, `023`, `024`) are called out as provisional inputs rather
+  than frozen implementation-ready contracts.

--- a/specs/027-capability-discovery-and-interoperability/contracts/a2a-lifecycle-mapping-contract.md
+++ b/specs/027-capability-discovery-and-interoperability/contracts/a2a-lifecycle-mapping-contract.md
@@ -1,0 +1,71 @@
+# Contract: A2A Lifecycle Mapping
+
+## Purpose
+
+Define the first remote lifecycle bridge frozen by packet `027`.
+
+## Version And Scope
+
+- packet scope: `027-capability-discovery-and-interoperability`
+- remote protocol baseline: A2A `v0.3.0`
+- inherited upstream inputs:
+  - packet `022` lifecycle and durable identifier language
+  - packet `023` proof-boundary language
+  - packet `024` security and discover-vs-execute boundary language
+- this contract is scaffold-only until packet `027` is refreshed against the completed packet
+  `022`, `023`, and `024` outputs
+
+## Source-Native A2A Task States
+
+Packet `027` freezes the following A2A `v0.3.0` source-native task states as the input set:
+
+- `submitted`
+- `working`
+- `input-required`
+- `completed`
+- `canceled`
+- `failed`
+- `rejected`
+- `auth-required`
+- `unknown`
+
+## Mapping Intent
+
+The bridge maps one source-native A2A task state into:
+
+- Mister Smith workflow status
+- result or autonomy projection language
+- operator-visible proof-boundary text
+
+The bridge is explicit and loss-aware. It does not assume every A2A state has a perfect local
+equivalent.
+
+## Minimum Mapping Rules
+
+| A2A state | Local posture | Notes |
+| --------- | ------------- | ----- |
+| `submitted` | non-terminal accepted workflow state | remote task exists but has not started active work yet |
+| `working` | active workflow state | remote agent is actively progressing the task |
+| `input-required` | blocked-on-input workflow state | requires explicit local display of waiting-for-input posture |
+| `completed` | completed workflow state | terminal successful state |
+| `canceled` | canceled workflow state | terminal user- or caller-canceled state |
+| `failed` | failed workflow state | terminal failed state |
+| `rejected` | rejected-before-start boundary state | preserve that the remote agent did not start task execution |
+| `auth-required` | blocked-on-auth boundary state | preserve that more credentials are needed before remote work can continue |
+| `unknown` | explicit unknown mapping | must not be silently coerced into a terminal or successful local state |
+
+## Boundary Rules
+
+- the lifecycle binding MUST preserve proof-boundary text so local views do not overclaim what the
+  remote state proves
+- the lifecycle binding MUST preserve discovery-versus-execute separation
+- `taskId` and `contextId` are source-native A2A continuity identifiers and MUST be recorded as
+  remote provenance, not silently renamed into granted local authority
+- packet `016` continuity references MAY inform provenance wording, but packet `027` MUST NOT use
+  them to claim broad remote lifecycle proof
+
+## Unsupported Or Deferred Areas
+
+- mapping for remote protocols other than A2A `v0.3.0`
+- live proof that the A2A bridge is already part of the default runtime path
+- broad multi-protocol cancellation or restart choreography

--- a/specs/027-capability-discovery-and-interoperability/contracts/capability-normalization-contract.md
+++ b/specs/027-capability-discovery-and-interoperability/contracts/capability-normalization-contract.md
@@ -1,0 +1,61 @@
+# Contract: Capability Normalization
+
+## Purpose
+
+Define the minimum normalized discovery contract for packet `027`.
+
+## Version And Scope
+
+- packet scope: `027-capability-discovery-and-interoperability`
+- MCP baseline: `2025-11-25`
+- A2A baseline: `v0.3.0`
+- this contract is scaffold-only until packet `027` is refreshed against the completed packet
+  `022`, `023`, and `024` outputs
+
+## Source Inputs
+
+| Source | Source-native discovery object | Required normalized inputs |
+| ------ | ------------------------------ | -------------------------- |
+| Local ToolBus | `CapabilityDescriptor` and related delegated actions | descriptor id, title, description, actions, local owner when present |
+| MCP `2025-11-25` | MCP catalog entry and tool metadata | external name, capability descriptor, boundary action, scope, revocation details |
+| A2A `v0.3.0` | Agent Card and `AgentSkill` entries | protocol version, service URL, capabilities, authentication requirements, skill id, name, description, input modes, output modes |
+
+## Required Normalized Fields
+
+Every normalized descriptor MUST include:
+
+- `descriptor_id`
+- `source`
+- `source_reference`
+- `title`
+- `description`
+- `input_modes`
+- `output_modes`
+- `provenance_note`
+
+The following are conditional:
+
+- `service_endpoint`
+- `lifecycle_hint`
+- `permission_reference`
+
+## Separation Rules
+
+- discovery data MUST NOT be treated as execution permission
+- `permission_reference` MUST remain a pointer to a later policy or delegation check
+- source-native authentication or security metadata MAY inform policy but MUST NOT be collapsed
+  into "trusted to execute"
+
+## Drift Rules
+
+- protocol references inside packet `027` MUST stay pinned to MCP `2025-11-25` and A2A `v0.3.0`
+- if a later revision changes either pin, packet `027` MUST record that change explicitly instead
+  of mixing sources silently
+- list-change or card-change notifications MAY update discovery state, but they MUST NOT update
+  execution authority automatically
+
+## Deferred Items
+
+- generic multi-protocol registry APIs
+- dynamic trust scoring
+- live remote execution authorization

--- a/specs/027-capability-discovery-and-interoperability/data-model.md
+++ b/specs/027-capability-discovery-and-interoperability/data-model.md
@@ -1,0 +1,103 @@
+# Data Model: Capability Discovery And Interoperability
+
+## 1. NormalizedCapabilityDescriptor
+
+Represents one discovered capability after source-specific discovery data has been normalized.
+
+### Permission Fields
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `descriptor_id` | string | Stable capability identifier used inside Mister Smith. |
+| `source` | enum | Origin of the discovery data: `local_toolbus`, `mcp_2025_11_25`, or `a2a_v0_3_0`. |
+| `source_reference` | string | Source-native identifier such as a local tool descriptor id, MCP capability id, or A2A skill id. |
+| `title` | string | Human-readable name for the capability. |
+| `description` | string | Human-readable summary of the capability. |
+| `service_endpoint` | optional string | Addressable remote endpoint when present. |
+| `input_modes` | string list | Accepted input content or schema modes. |
+| `output_modes` | string list | Produced output content or schema modes. |
+| `lifecycle_hint` | optional string | Source-native hint that the capability may create or update a long-running task. |
+| `permission_reference` | optional object | Separate pointer to the policy or delegation surface required for execution. |
+| `provenance_note` | string | Operator-visible explanation of where the descriptor came from. |
+
+### Validation Rules
+
+- `source` is mandatory and immutable after normalization.
+- `permission_reference` is descriptive only and must not be interpreted as granted authority.
+- remote descriptors may omit `service_endpoint` only when the source is not directly callable.
+
+## 2. CapabilitySource
+
+Typed source classification for discovery inputs.
+
+### Allowed Values
+
+| Value | Meaning |
+| ----- | ------- |
+| `local_toolbus` | Capability discovered from Mister Smith's local ToolBus registry. |
+| `mcp_2025_11_25` | Capability discovered from a pinned MCP `2025-11-25` surface. |
+| `a2a_v0_3_0` | Capability discovered from an A2A `v0.3.0` Agent Card. |
+
+## 3. PermissionReference
+
+Describes where execution permission must be checked.
+
+### Lifecycle Fields
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `action_id` | optional string | Source-specific action identifier when available. |
+| `required_scope` | optional string | Delegation or auth scope needed for execution. |
+| `revocation_key` | optional string | Revocation or policy key when the source provides one. |
+| `authority_surface` | string | Boundary where execution permission is enforced. |
+
+### Rules
+
+- `PermissionReference` may exist even when execution is not currently allowed.
+- absence of `PermissionReference` does not imply ambient permission.
+
+## 4. RemoteTaskLifecycleBinding
+
+Maps one remote lifecycle model into Mister Smith workflow, result, and autonomy views.
+
+### Provenance Fields
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `protocol` | enum | Protocol version for the remote lifecycle: `a2a_v0_3_0`. |
+| `remote_state` | string | Source-native remote task state. |
+| `local_workflow_state` | string | Closest Mister Smith workflow state projection. |
+| `proof_boundary_label` | string | Text that explains what is and is not proven by this mapping. |
+| `input_required` | boolean | Whether the local view should represent a blocked-on-input posture. |
+| `terminal` | boolean | Whether the remote state is terminal. |
+| `operator_rationale` | string | Operator-visible explanation for the mapping. |
+
+### Transition Notes
+
+- packet `027` treats the A2A states `submitted`, `working`, `input-required`, `completed`,
+  `canceled`, `failed`, `rejected`, `auth-required`, and `unknown` as source-native values
+- mapping remains explicit and loss-aware; unsupported mappings must be called out directly
+
+## 5. RemoteCapabilityUseProvenance
+
+Operator-facing projection that records discovery and lifecycle context together.
+
+### Fields
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `descriptor_id` | string | Normalized capability identifier. |
+| `source` | enum | Discovery source that produced the descriptor. |
+| `lifecycle_binding_id` | optional string | Reference to the lifecycle binding used for the remote task. |
+| `authority_surface` | string | Where execution permission still had to be enforced. |
+| `continuity_reference` | optional string | Reference to packet `016`-style continuity or provenance context, when applicable. |
+| `display_summary` | string | Short operator-facing explanation. |
+
+## Relationships
+
+- one `CapabilitySource` can feed many `NormalizedCapabilityDescriptor` records
+- one `NormalizedCapabilityDescriptor` may reference zero or one `PermissionReference`
+- one `NormalizedCapabilityDescriptor` may participate in zero or many `RemoteTaskLifecycleBinding`
+  records over time
+- one `RemoteCapabilityUseProvenance` record joins one normalized descriptor with zero or one
+  lifecycle binding

--- a/specs/027-capability-discovery-and-interoperability/plan.md
+++ b/specs/027-capability-discovery-and-interoperability/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: Capability Discovery And Interoperability
+
+**Branch**: `027-capability-discovery-and-interoperability` | **Date**: 2026-04-01 | **Spec**:
+[spec.md](spec.md)
+**Input**: Feature specification from
+`specs/027-capability-discovery-and-interoperability/spec.md`
+
+## Summary
+
+Packet `027` freezes one bounded interop scaffold only. It does not authorize immediate
+implementation. The packet uses the current finished packet outputs for packets `022`, `023`, and
+`024` as upstream inputs, then defines one shared capability normalization seam and one first
+remote lifecycle seam for A2A `v0.3.0`. MCP remains pinned to `2025-11-25` as an input and policy
+boundary, not as the first new interop slice.
+
+## Technical Context
+
+**Language/Version**: Markdown packet artifacts for a Rust 1.88.0 workspace  
+**Primary Dependencies**: `docs/direction.md`, `docs/current-state.md`,
+`specs/022-durable-workflow-core/spec.md`,
+`specs/023-runtime-truth-and-run-trace/spec.md`,
+`specs/024-agent-boundary-security-hardening/spec.md`, packet `016` and `MS-77` proof notes,
+`crates/mister-smith-agents`,
+`crates/mister-smith-mcp`, `crates/mister-smith-core`, and the pinned MCP/A2A primary sources  
+**Storage**: packet-local markdown only for this scaffold; future target surfaces remain the
+existing workflow, autonomy, and result metadata seams  
+**Testing**: `git diff --check`, targeted `npx markdownlint-cli2` on the packet directory, and
+read-only cross-artifact consistency analysis after `tasks.md` exists  
+**Target Platform**: repo-local SpecKit packet authoring on macOS with future implementation
+targeting the existing Rust runtime and operator-facing status surfaces  
+**Project Type**: docs-first SpecKit packet scaffold for future runtime and interoperability work  
+**Performance Goals**: keep one bounded slice, preserve proof-boundary clarity, and avoid protocol
+drift or scope creep before implementation starts  
+**Constraints**: packet `027` must be revised before implementation, must not redefine packet
+`022`, `023`, or `024`, must keep discovery separate from execution permission, must keep MCP pinned
+to `2025-11-25`, must keep A2A pinned to `v0.3.0`, and must not widen into generic federation  
+**Scale/Scope**: one normalized capability contract, one A2A lifecycle mapping contract, one
+operator-visible provenance shape, and one blocking refresh gate before any future implementation
+
+## Constitution Check
+
+| Principle | Status | Evidence |
+| --------- | ------ | -------- |
+| I. Canonical Single Source | PASS | Grounds packet truth in `docs/direction.md`, `docs/current-state.md`, packet outputs `022` to `024`, pinned protocol docs, and current repo seams. |
+| II. Spec-First Design | PASS | `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, `tasks.md`, and checklist artifacts are authored before any implementation work. |
+| III. Phase-And-Packet-Gated Delivery | PASS | The packet is scaffold-only and includes a blocking refresh gate before implementation so it does not silently outrun packets `022`, `023`, and `024`. |
+| IV. Model-Agnostic Architecture | PASS | The packet defines protocol and lifecycle mapping surfaces without binding Mister Smith to a provider-specific model API. |
+| V. Erlang/OTP-Style Fault Tolerance | PASS | The packet reuses current workflow and autonomy surfaces, keeps failure isolation intact, and treats remote lifecycle mapping as additive and bounded. |
+| VI. Evidence-Based Validation | PASS | Validation is explicit, deterministic, and separated from future live runtime proof claims. |
+| VII. Explicit Dependency Management | PASS | Upstream packet dependencies, protocol pins, repo anchors, and deferred follow-on work are all called out directly. |
+| VIII. Clean Closure And Resumability | PASS | The packet leaves a resumable scaffold with a mandatory refresh gate and durable contract artifacts for a later implementation pass. |
+
+## Project Structure
+
+```text
+specs/027-capability-discovery-and-interoperability/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+├── checklists/
+│   ├── requirements.md
+│   └── interop.md
+└── contracts/
+    ├── capability-normalization-contract.md
+    └── a2a-lifecycle-mapping-contract.md
+
+Future repo write set after the refresh gate:
+crates/mister-smith-agents/src/tool_bus.rs
+crates/mister-smith-mcp/src/client.rs
+crates/mister-smith-mcp/src/server.rs
+crates/mister-smith-mcp/src/compatibility.rs
+crates/mister-smith-core/src/autonomy.rs
+crates/mister-smith-events/src/bus.rs
+crates/mister-smith-app/src/autonomy.rs
+```
+
+## Design Decisions
+
+### D1: A2A is the first new interop slice, MCP is the pinned baseline input
+
+**Decision**: freeze A2A `v0.3.0` agent discovery and A2A task lifecycle mapping as the first new
+interop slice, while keeping MCP `2025-11-25` as the pinned normalization and policy-boundary
+baseline.
+
+**Rationale**: the repo already has bounded MCP discovery and delegated boundary enforcement from
+`MS-77`. The missing new seam is one remote discovery and lifecycle mapping path, not another MCP
+discovery packet.
+
+### D2: Normalized discovery must preserve source and permission separation
+
+**Decision**: the shared capability descriptor will carry source identity, schema hints, lifecycle
+signals, and a separate permission reference, but the descriptor itself will never stand in for
+execution authority.
+
+**Rationale**: packet `024` and `MS-77` already anchor discover-vs-execute separation, and packet
+`027` must preserve that rule across local ToolBus, MCP, and A2A discovery inputs.
+
+### D3: Remote lifecycle mapping reuses earlier packet language provisionally
+
+**Decision**: packet `027` will reuse packet `022` lifecycle and identifier language, packet `023`
+proof-boundary language, and packet `024` security language as provisional inherited inputs.
+
+**Rationale**: this packet owns capability normalization and one remote lifecycle bridge. It does
+not own durable workflow semantics, truth taxonomy, or security policy definitions.
+
+### D4: Implementation is blocked until upstream packets are refreshed
+
+**Decision**: the first future implementation milestone is a refresh gate that revises packet `027`
+against the completed packet `022`, `023`, and `024` outputs before any code work begins.
+
+**Rationale**: this packet is being written now for speed, but the repo would drift if a later
+implementation treated provisional dossier language as final contract truth.
+
+## Minimal Implementation Slice
+
+### Milestone 1: Upstream Refresh Gate (Blocking)
+
+**Scope**: reconcile packet `027` with the finished packet `022`, `023`, and `024` outputs, then
+refresh packet artifacts before implementation.
+
+**Validation**:
+
+- `spec.md`, `plan.md`, `research.md`, and `tasks.md` are updated against the final upstream
+  packet outputs
+- protocol pins remain MCP `2025-11-25` and A2A `v0.3.0`
+- the refresh gate remains the first executable step in `tasks.md`
+
+### Milestone 2: Shared Descriptor Freeze
+
+**Scope**: implement the normalized capability descriptor and source mapping across local ToolBus,
+MCP, and one A2A discovery adapter.
+
+**Validation**:
+
+- targeted Rust tests prove normalized descriptor parity across local ToolBus, MCP, and A2A inputs
+- discovery metadata remains distinct from execution permission in the shared descriptor
+
+### Milestone 3: A2A Lifecycle Projection And Provenance
+
+**Scope**: implement the A2A task lifecycle bridge into Mister Smith workflow, result, and
+autonomy surfaces, plus operator-visible provenance.
+
+**Validation**:
+
+- targeted Rust tests prove the A2A lifecycle binding into workflow and status surfaces
+- operator-facing result or autonomy views preserve discovery-versus-execute boundaries and packet
+  `016` continuity language
+
+## Parallel Staging Posture
+
+- Blocking freeze before any parallel lanes: upstream refresh gate plus final packet contract
+  refresh
+- Allowed disjoint lanes after the freeze:
+  - descriptor normalization lane: `crates/mister-smith-agents/src/tool_bus.rs`,
+    `crates/mister-smith-mcp/src/client.rs`, `crates/mister-smith-mcp/src/server.rs`
+  - lifecycle projection lane: `crates/mister-smith-core/src/autonomy.rs`,
+    `crates/mister-smith-events/src/bus.rs`, `crates/mister-smith-app/src/autonomy.rs`
+  - compatibility adapter lane: `crates/mister-smith-mcp/src/compatibility.rs` plus packet `027`
+    proof note updates
+- Single-owner choke points:
+  - `specs/027-capability-discovery-and-interoperability/spec.md`
+  - `specs/027-capability-discovery-and-interoperability/contracts/a2a-lifecycle-mapping-contract.md`
+  - `crates/mister-smith-core/src/autonomy.rs`
+  - `crates/mister-smith-mcp/src/compatibility.rs`
+
+## Explicitly Deferred
+
+- generic federation or mesh design
+- remote execution permission expansion
+- other remote protocols beyond MCP baseline input and one A2A slice
+- live multi-remote runtime proof claims
+- packet `028` strong-coordination policy or state-taxonomy work
+- any change that turns packet `016` into a broader remote lifecycle proof claim

--- a/specs/027-capability-discovery-and-interoperability/quickstart.md
+++ b/specs/027-capability-discovery-and-interoperability/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Packet 027 Scaffold Refresh And Use
+
+## Purpose
+
+Use this packet as a scaffold for future implementation planning. Do not treat it as immediate
+implementation authorization.
+
+## Steps
+
+1. Re-read `docs/direction.md` and `docs/current-state.md`.
+2. Re-read the completed packet outputs for `022`, `023`, and `024` once they exist.
+3. Refresh packet `027` artifacts against those final upstream outputs before writing code.
+4. Confirm protocol pins still match:
+   - MCP `2025-11-25`
+   - A2A `v0.3.0`
+5. Confirm the packet still freezes only:
+   - normalized capability discovery
+   - one A2A lifecycle bridge
+   - operator-visible provenance for remote capability use
+6. Confirm the packet still defers:
+   - generic federation
+   - remote execution authorization expansion
+   - extra protocols
+   - live multi-remote runtime proof
+7. Use `tasks.md` only after the refresh gate has been completed.
+
+## Packet Validation Commands
+
+```bash
+git diff --check
+npx markdownlint-cli2 "specs/027-capability-discovery-and-interoperability/**/*.md" --config .markdownlint.json
+```
+
+## Implementation Reopen Checklist
+
+- upstream packets `022`, `023`, and `024` are complete
+- packet `027` artifacts were refreshed after those packet completions
+- version pins remain unchanged or are explicitly updated everywhere
+- the packet still separates discovery metadata from execution permission
+- packet `016` is still referenced only for continuity and provenance boundaries

--- a/specs/027-capability-discovery-and-interoperability/research.md
+++ b/specs/027-capability-discovery-and-interoperability/research.md
@@ -1,0 +1,117 @@
+# Research: Capability Discovery And Interoperability
+
+## Scope
+
+This research file supports packet `027` as a scaffold. It uses:
+
+- current repo truth from `docs/direction.md` and `docs/current-state.md`
+- the current finished packet outputs for packets `022`, `023`, and `024`, plus the packet `027`
+  scaffold itself
+- `docs/plans/2026-03-19-ms-77-bounded-external-agent-surface.md`
+- `docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md`
+- `docs/research-output/analysis/2026-03-28-coordination-state-protocol-transfer-brief.md`
+- pinned MCP `2025-11-25` and A2A `v0.3.0` primary sources
+
+## Decision 1: Use the current packet outputs for packets 022 to 024 as upstream input
+
+**Decision**: packet `027` reuses the current packet output language from packets `022`, `023`,
+and `024` as upstream contract input and adds a mandatory refresh gate before implementation.
+
+**Rationale**: the user wants packet `027` authored now for scaffolding. A refresh gate preserves
+speed without pretending those upstream packet outputs will never change again.
+
+**Alternatives considered**:
+
+- wait for packets `022`, `023`, and `024` before writing packet `027`
+- restate all of their contracts inside packet `027`
+
+## Decision 2: Freeze A2A `v0.3.0` as the first new interop slice
+
+**Decision**: packet `027` freezes A2A `v0.3.0` discovery and lifecycle mapping as the first new
+interop slice.
+
+**Rationale**: the A2A discovery guidance identifies the Agent Card as the standard discovery
+surface and lists the core fields needed for remote suitability checks: identity, service URL,
+capabilities, authentication, and skills. The A2A specification also publishes a stable `TaskState`
+set for remote task lifecycles. That makes A2A the cleanest first remote slice once MCP has
+already been used for bounded discovery on the repo side.
+
+**Alternatives considered**:
+
+- freeze only discovery and defer lifecycle mapping
+- make MCP tasks the first new slice instead of A2A
+
+## Decision 3: Keep MCP `2025-11-25` pinned as an input and policy boundary
+
+**Decision**: packet `027` keeps MCP pinned to `2025-11-25` and uses it as a normalization and
+boundary input, not as the first new interoperability slice.
+
+**Rationale**: the MCP tools spec declares `tools.listChanged` for tool-list drift, the lifecycle
+spec fixes the `initialize` plus `initialized` handshake boundary, the authorization spec grounds
+OAuth metadata discovery, and the tasks utility fixes one explicit task lifecycle for task-augmented
+requests. These are important comparators and boundary inputs, but the repo already has bounded MCP
+discovery from `MS-77`.
+
+**Alternatives considered**:
+
+- move to unpinned or mixed-version MCP pages
+- make MCP lifecycle mapping the first new slice and postpone A2A
+
+## Decision 4: The shared descriptor must carry source plus permission reference, not permission itself
+
+**Decision**: the normalized descriptor carries source identity, lifecycle hints, schema or mode
+information, and a separate permission reference.
+
+**Rationale**: the A2A Agent Card includes capability and skill metadata plus authentication
+requirements, but those fields describe what the remote agent says it can do. The repo research and
+packet `024` boundary guidance both require discovery to stay separate from execution authority.
+
+**Alternatives considered**:
+
+- use one lowest-common-denominator discovery record with no source-specific detail
+- treat remote skill discovery as implicit permission to execute
+
+## Decision 5: The first lifecycle bridge should stay explicit and loss-aware
+
+**Decision**: packet `027` defines an explicit A2A-to-Mister-Smith lifecycle binding instead of
+pretending the remote states match local workflow states one-to-one.
+
+**Rationale**: A2A `v0.3.0` defines task states including `submitted`, `working`, `input-required`,
+`completed`, `canceled`, `failed`, `rejected`, `auth-required`, and `unknown`. The MCP tasks
+utility uses a narrower status model centered on `working`, `input_required`, `completed`,
+`failed`, and `cancelled`. Mister Smith already has its own workflow and proof-boundary language.
+The bridge therefore needs explicit mapping rules and explicit unsupported-state handling.
+
+**Alternatives considered**:
+
+- force all remote states into one lossy local status with no provenance
+- delay lifecycle mapping entirely and freeze discovery only
+
+## Pinned Primary Sources
+
+- MCP lifecycle: [modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+- MCP tools: [modelcontextprotocol.io/specification/2025-11-25/server/tools](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- MCP authorization: [modelcontextprotocol.io/specification/2025-11-25/basic/authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization)
+- MCP tasks utility: [modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
+- A2A agent discovery: [a2a-protocol.org/v0.3.0/topics/agent-discovery](https://a2a-protocol.org/v0.3.0/topics/agent-discovery/)
+- A2A task lifecycle: [a2a-protocol.org/v0.3.0/topics/life-of-a-task](https://a2a-protocol.org/v0.3.0/topics/life-of-a-task/)
+- A2A specification: [a2a-protocol.org/v0.3.0/specification](https://a2a-protocol.org/v0.3.0/specification/)
+
+## Repo Anchors
+
+- `crates/mister-smith-agents/src/tool_bus.rs`
+- `crates/mister-smith-mcp/src/server.rs`
+- `crates/mister-smith-mcp/src/client.rs`
+- `crates/mister-smith-mcp/src/compatibility.rs`
+- `crates/mister-smith-core/src/autonomy.rs`
+- `docs/plans/2026-03-19-ms-77-bounded-external-agent-surface.md`
+- `docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md`
+
+## Open Follow-On For The Refresh Gate
+
+- confirm the final packet `022` lifecycle and identifier vocabulary still matches the packet `027`
+  lifecycle contract
+- confirm the final packet `023` proof-boundary language still matches the packet `027`
+  provenance contract
+- confirm the final packet `024` security posture still matches the packet `027`
+  discover-versus-execute boundary

--- a/specs/027-capability-discovery-and-interoperability/spec.md
+++ b/specs/027-capability-discovery-and-interoperability/spec.md
@@ -1,0 +1,238 @@
+# Feature Specification: Capability Discovery And Interoperability
+
+**Feature Branch**: `027-capability-discovery-and-interoperability`  
+**Created**: 2026-04-01  
+**Status**: Draft  
+**Input**: `docs/direction.md`, `docs/current-state.md`,
+`specs/022-durable-workflow-core/spec.md`,
+`specs/023-runtime-truth-and-run-trace/spec.md`,
+`specs/024-agent-boundary-security-hardening/spec.md`,
+`docs/research-output/analysis/2026-03-28-coordination-state-protocol-transfer-brief.md`, and
+the current capability and status seams in `crates/mister-smith-agents/src/tool_bus.rs`,
+`crates/mister-smith-mcp/src/server.rs`, `crates/mister-smith-mcp/src/client.rs`,
+`crates/mister-smith-mcp/src/compatibility.rs`, and `crates/mister-smith-core/src/autonomy.rs`
+
+## Current Truth & Scope
+
+This packet is being written now as scaffolding so later implementation can move faster. It is not
+immediate implementation approval.
+
+Current repo truth already includes:
+
+- bounded local capability descriptors in `ToolBus`
+- bounded MCP catalog exposure and delegated discovery enforcement from `MS-77`
+- packet `016` accepted delegated-ingress continuity and operator-visible provenance
+- workflow, task, session, and autonomy identifiers that can support later cross-boundary mapping
+
+What the repo does not yet have as one frozen contract is narrower than generic federation:
+
+- one shared capability normalization model across local tools, MCP, and one remote protocol input
+- one explicit lifecycle mapping from a remote task model into Mister Smith workflow, result, and
+  autonomy surfaces
+- one pinned interoperability baseline that does not drift across mixed protocol pages
+
+This packet therefore freezes one bounded next step only:
+
+1. normalize capability discovery metadata across local ToolBus entries, MCP catalog entries, and
+   one A2A `v0.3.0` agent-card input path
+2. map the A2A `v0.3.0` task lifecycle into Mister Smith workflow, result, and autonomy surfaces
+   using existing lifecycle, proof-boundary, and security contracts as inherited inputs
+3. keep discovery metadata, execution permission, and operator trust as separate concepts
+
+This packet is scaffolded from the current finished packet outputs for packets `022`, `023`, and
+`024`.
+Packet `027` still MUST be revised before implementation so its contracts line up with any later
+changes to those upstream packet outputs.
+
+This is not:
+
+- a generic federation or mesh packet
+- a broad remote-agent lifecycle proof claim
+- a packet that redefines packet `022`, `023`, or `024`
+- a packet that treats packet `016` as broad remote-agent lifecycle proof
+- a packet that widens discovery into implicit execution permission
+- a packet that mixes `latest`, `dev`, and pinned protocol pages
+
+## Clarifications
+
+### Session 2026-04-01
+
+- Q: Is packet `027` being written as immediate implementation approval or as scaffolding? → A:
+  It is scaffolding only and must be revised before implementation.
+- Q: What should packet `027` use as its upstream contract baseline? → A: Use the current finished
+  packet outputs for `022`, `023`, and `024`, then refresh this packet again before
+  implementation if those upstream packets change.
+- Q: Which first interoperability slice is in scope? → A: A2A `v0.3.0` discovery plus A2A task
+  lifecycle mapping.
+- Q: What role does MCP play in this packet? → A: MCP `2025-11-25` remains a pinned baseline
+  input and policy boundary, not the first new interop slice.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Normalize Capability Discovery (Priority: P1)
+
+An operator or future implementer can use one frozen descriptor model to compare local ToolBus
+tools, MCP-discovered capabilities, and one A2A agent-card input without assuming that discovery
+metadata grants permission to execute anything.
+
+**Why this priority**: capability normalization is the first contract needed before any remote
+lifecycle mapping can stay bounded and comparable across surfaces.
+
+**Independent Test**: inspect the packet contracts and confirm they define one normalized
+descriptor model, one explicit source marker, and one explicit separation between discovery and
+execution authority.
+
+**Acceptance Scenarios**:
+
+1. **Given** a local ToolBus capability, an MCP capability catalog entry, and an A2A agent card,
+   **When** packet `027` is read, **Then** all three can be described through one normalized
+   capability model with explicit source attribution.
+2. **Given** any discovered capability, **When** an operator or implementer reads the packet,
+   **Then** it is clear that discovery metadata alone does not authorize execution.
+3. **Given** upstream packet `024` boundary rules, **When** this packet defines the normalized
+   descriptor, **Then** it reuses discover-vs-execute separation instead of redefining it.
+
+---
+
+### User Story 2 - Map One Remote Lifecycle Model (Priority: P1)
+
+An operator or future implementer can map one A2A `v0.3.0` remote task lifecycle into Mister Smith
+workflow, result, and autonomy surfaces without broadening the packet into multi-protocol runtime
+proof.
+
+**Why this priority**: the first interoperability slice needs one honest lifecycle mapping, not
+just discovery metadata.
+
+**Independent Test**: inspect the packet contracts and confirm they define one lifecycle bridge
+from A2A task states into Mister Smith workflow, result, and autonomy views using inherited
+lifecycle and proof-boundary language.
+
+**Acceptance Scenarios**:
+
+1. **Given** an A2A task that progresses through non-terminal and terminal states, **When** the
+   packet is read, **Then** the mapping into Mister Smith workflow and status surfaces is explicit.
+2. **Given** an A2A task state that has no exact local match, **When** the lifecycle contract is
+   read, **Then** the packet defines an explicit mapping rule or an explicit unsupported-state
+   boundary.
+3. **Given** upstream packet `022` and `023` contracts are still provisional, **When** this packet
+   defines lifecycle mapping, **Then** it states that those inherited terms must be refreshed
+   before implementation.
+
+---
+
+### User Story 3 - Preserve Provenance And Scope Boundaries (Priority: P2)
+
+An operator or future implementer can see exactly what packet `027` does and does not claim,
+including protocol pins, packet `016` continuity boundaries, and the required refresh gate before
+implementation.
+
+**Why this priority**: the main risk in this packet is scope drift and overclaim, not missing
+syntax.
+
+**Independent Test**: inspect `spec.md`, `plan.md`, and `tasks.md` and confirm they all carry the
+same revision-before-implementation note, the same protocol pins, and the same non-goals.
+
+**Acceptance Scenarios**:
+
+1. **Given** packet `027` is read without the earlier dossier context, **When** the reader inspects
+   the packet, **Then** they can see that it is a scaffold based on provisional upstream inputs and
+   must be revised before implementation.
+2. **Given** packet `016` continuity evidence exists, **When** packet `027` references it,
+   **Then** the packet limits that reference to continuity and provenance rather than broad remote
+   lifecycle proof.
+3. **Given** pinned MCP and A2A sources are part of the packet, **When** protocol references are
+   inspected, **Then** no mixed-version or unpinned protocol pages appear.
+
+### Edge Cases
+
+- an A2A agent card advertises a capability that lacks enough metadata to normalize safely
+- discovery is allowed on a remote surface, but execution remains blocked by local policy
+- an A2A task enters a lifecycle state that does not map cleanly onto current Mister Smith status
+  language
+- the final packet `022`, `023`, or `024` contracts change enough that the packet `027` scaffold
+  needs a revision before implementation
+- an MCP descriptor and an A2A descriptor appear similar at discovery time but imply different
+  execution permission rules
+- a later reader treats packet `016` as broad interop proof unless packet `027` calls out the
+  narrower continuity boundary explicitly
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Packet `027` MUST state that it is a scaffold built from current repo truth and the
+  finished packet outputs for `022`, `023`, and `024`, and MUST be revised before implementation
+  if those upstream packet contracts change.
+- **FR-002**: Packet `027` MUST freeze one bounded interoperability scope only: capability
+  normalization plus one remote lifecycle mapping slice.
+- **FR-003**: Packet `027` MUST define one normalized capability descriptor that can represent
+  local ToolBus entries, MCP catalog entries, and one A2A `v0.3.0` agent-card input path.
+- **FR-004**: Packet `027` MUST make capability source explicit so local, MCP, and A2A discovery
+  inputs remain distinguishable after normalization.
+- **FR-005**: Packet `027` MUST keep discovery metadata separate from execution permission and
+  operator trust.
+- **FR-006**: Packet `027` MUST freeze A2A `v0.3.0` as the first new interoperability slice for
+  agent discovery and remote task lifecycle mapping.
+- **FR-007**: Packet `027` MUST keep MCP pinned to `2025-11-25` and MUST use MCP as an existing
+  normalization and policy-boundary input rather than the first new interop slice.
+- **FR-008**: Packet `027` MUST NOT mix `latest`, `dev`, and pinned protocol pages inside the
+  packet artifact set.
+- **FR-009**: Packet `027` MUST define one lifecycle binding from A2A `v0.3.0` task states into
+  Mister Smith workflow, result, and autonomy surfaces.
+- **FR-010**: Packet `027` MUST reuse packet `022` lifecycle and durable-identifier language as
+  provisional upstream input instead of redefining it.
+- **FR-011**: Packet `027` MUST reuse packet `023` proof-boundary and run-truth language as
+  provisional upstream input instead of redefining it.
+- **FR-012**: Packet `027` MUST reuse packet `024` security and discover-vs-execute boundary
+  language as provisional upstream input instead of redefining it.
+- **FR-013**: Packet `027` MUST preserve packet `016` as continuity and provenance evidence only
+  and MUST NOT describe it as broad remote-agent lifecycle proof.
+- **FR-014**: Packet `027` MUST define one operator-visible provenance projection for remote
+  capability use and remote lifecycle state mapping.
+- **FR-015**: Packet `027` MUST explicitly defer generic federation, multi-protocol execution
+  permission, extra remote protocols, strong-coordination policy, and live multi-remote runtime
+  proof.
+- **FR-016**: Packet `027` MUST include a blocking refresh gate in its plan and task artifacts so
+  no implementation begins until the final packet `022`, `023`, and `024` outputs are reconciled.
+
+### Key Entities *(include if feature involves data)*
+
+- **NormalizedCapabilityDescriptor**: a shared discovery record that captures stable identifier,
+  title, description, source, lifecycle hints, schema references, and permission references
+  without granting execution authority by itself.
+- **CapabilitySource**: a typed source marker that distinguishes local ToolBus, MCP
+  `2025-11-25`, and A2A `v0.3.0` discovery inputs.
+- **RemoteTaskLifecycleBinding**: a mapping record that translates A2A task states and lifecycle
+  events into Mister Smith workflow, result, and autonomy projections.
+- **RemoteCapabilityUseProvenance**: an operator-visible summary that records where a remote
+  capability came from, which lifecycle binding applied, and which boundary rules still controlled
+  execution permission.
+- **InteropRevisionGate**: a packet-level rule that blocks implementation until packet `027` is
+  refreshed against the finished packet `022`, `023`, and `024` outputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `spec.md`, `plan.md`, and `tasks.md` all state that packet `027` is scaffold-only and
+  must be revised before implementation.
+- **SC-002**: every protocol reference in the packet artifact set resolves only to MCP
+  `2025-11-25` or A2A `v0.3.0`, with no mixed-version protocol references.
+- **SC-003**: the packet artifact set freezes one normalized capability contract and one A2A
+  lifecycle-mapping contract without widening into generic federation work.
+- **SC-004**: the packet artifact set preserves explicit discovery-vs-execute separation in the
+  normalized descriptor and lifecycle-mapping language.
+- **SC-005**: the packet artifact set uses packet `016` only for continuity and provenance
+  boundary language.
+- **SC-006**: the packet tasks include one blocking refresh gate ahead of any future
+  implementation work and cover every functional requirement in this packet.
+
+## Assumptions
+
+- packets `022`, `023`, and `024` are the current upstream contract baseline for this scaffold
+- packet `027` will be revised before implementation so it still matches the then-current packet
+  `022`, `023`, and `024` outputs
+- the first interoperable remote input path is A2A `v0.3.0` agent discovery plus A2A task
+  lifecycle mapping, not broad multi-protocol federation
+- MCP `2025-11-25` remains a pinned discovery and policy-boundary input for this packet
+- discovery metadata is never sufficient on its own to authorize execution

--- a/specs/027-capability-discovery-and-interoperability/tasks.md
+++ b/specs/027-capability-discovery-and-interoperability/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: Capability Discovery And Interoperability
+
+**Input**: Design documents from `specs/027-capability-discovery-and-interoperability/`  
+**Prerequisites**: `plan.md`, `spec.md`, plus packet-local `research.md`, `data-model.md`,
+`quickstart.md`, and both contracts under `contracts/`
+
+**Tests**: Future implementation must keep deterministic packet validation separate from runtime
+proof. Run targeted crate tests for discovery and lifecycle mapping, then `cargo build --workspace`,
+`git diff --check`, packet-local markdown linting, and final closure checks only after the
+blocking refresh gate is complete.
+
+**Organization**: Group tasks by blocking refresh work first, then bounded user stories, then final
+validation and evidence.
+
+This tasks file is a future implementation scaffold only. Do not begin code work until `T001`
+through `T003` refresh packet `027` against the completed packet `022`, `023`, and `024` outputs.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Use only when every blocking checkpoint in the current section is already complete and
+  the write set is disjoint from every other active lane
+- **[Story]**: Use `US1`, `US2`, and `US3` for story-bound work
+- Include exact file paths in every implementation or documentation task
+
+## Status Reconciliation
+
+Capture the current repo truth this packet must preserve.
+
+- Local capability discovery already exists in
+  `crates/mister-smith-agents/src/tool_bus.rs`.
+- Bounded MCP discovery and delegated boundary enforcement already exist in
+  `crates/mister-smith-mcp/src/client.rs`, `crates/mister-smith-mcp/src/server.rs`, and
+  `crates/mister-smith-mcp/src/compatibility.rs`.
+- Packet `016` continuity and provenance baselines already exist in
+  `specs/016-external-agent-boundary-continuity-and-runtime-proof/spec.md` and
+  `docs/plans/2026-03-20-packet-016-external-agent-boundary-continuity-evaluation.md`.
+- Packets `022`, `023`, and `024` are the current upstream packet baseline and must be rechecked
+  again before any later implementation work starts.
+
+---
+
+## T1. Scope And Design Freeze (Blocking Prerequisites)
+
+**Goal**: refresh packet `027` against finished upstream packet contracts before any implementation
+lane begins.
+
+**CRITICAL**: no `[P]` lane may begin until this checkpoint is complete.
+
+- [ ] T001 Refresh `specs/027-capability-discovery-and-interoperability/spec.md` and
+  `specs/027-capability-discovery-and-interoperability/plan.md` against the completed packet
+  `022`, `023`, and `024` outputs before implementation starts
+- [ ] T002 Refresh `specs/027-capability-discovery-and-interoperability/research.md`,
+  `specs/027-capability-discovery-and-interoperability/data-model.md`,
+  `specs/027-capability-discovery-and-interoperability/contracts/capability-normalization-contract.md`,
+  and
+  `specs/027-capability-discovery-and-interoperability/contracts/a2a-lifecycle-mapping-contract.md`
+  against the final upstream packet contracts
+- [ ] T003 Re-run the scope and boundary checks in
+  `specs/027-capability-discovery-and-interoperability/checklists/interop.md` and
+  `specs/027-capability-discovery-and-interoperability/quickstart.md` so MCP `2025-11-25`, A2A
+  `v0.3.0`, packet `016` continuity wording, and explicit deferrals stay frozen
+
+**Checkpoint**: packet `027` is refreshed against the final upstream contracts and still freezes
+one bounded interoperability scaffold only.
+
+---
+
+## User Story 1 - Normalize Capability Discovery (Priority: P1)
+
+**Goal**: implement one shared descriptor model across local ToolBus, MCP, and one A2A discovery
+input without turning discovery into execution permission.
+
+**Independent Test**: targeted tests prove local ToolBus, MCP, and A2A inputs normalize into the
+same descriptor shape while permission and trust remain separate fields.
+
+### Tests For User Story 1
+
+- [ ] T004 [P] [US1] Add descriptor normalization coverage in
+  `crates/mister-smith-agents/tests/tool_bus_tests.rs`
+- [ ] T005 [P] [US1] Add MCP and A2A normalization coverage in
+  `crates/mister-smith-mcp/tests/capability_normalization_tests.rs`
+
+### Implementation For User Story 1
+
+- [ ] T006 [P] [US1] Add or extend normalized local capability projection in
+  `crates/mister-smith-agents/src/tool_bus.rs`
+- [ ] T007 [P] [US1] Add normalized remote capability parsing for MCP and A2A discovery inputs in
+  `crates/mister-smith-mcp/src/client.rs`
+- [ ] T008 [US1] Preserve discovery-versus-execution separation and explicit permission references
+  in `crates/mister-smith-mcp/src/server.rs` and
+  `crates/mister-smith-mcp/src/compatibility.rs`
+
+**Checkpoint**: local ToolBus, MCP, and A2A discovery inputs share one normalized descriptor model
+without granting execution authority by discovery alone.
+
+---
+
+## User Story 2 - Map One Remote Lifecycle Model (Priority: P1)
+
+**Goal**: map one A2A `v0.3.0` task lifecycle into Mister Smith workflow, result, and autonomy
+surfaces without widening into generic federation or live remote proof claims.
+
+**Independent Test**: targeted tests prove the A2A discovery adapter and lifecycle bridge map
+known states into Mister Smith workflow, result, and autonomy projections, with explicit handling
+for unsupported or boundary-only states.
+
+### Tests For User Story 2
+
+- [ ] T009 [P] [US2] Add A2A discovery adapter coverage in
+  `crates/mister-smith-mcp/tests/a2a_discovery_tests.rs`
+- [ ] T010 [P] [US2] Add lifecycle projection coverage in
+  `crates/mister-smith-app/tests/a2a_lifecycle_projection_tests.rs`
+
+### A2A Discovery Mapping
+
+- [ ] T011 [P] [US2] Implement the first A2A discovery adapter in
+  `crates/mister-smith-mcp/src/a2a.rs`
+- [ ] T012 [US2] Thread A2A discovery normalization through
+  `crates/mister-smith-mcp/src/compatibility.rs`
+
+### A2A Lifecycle Mapping
+
+- [ ] T013 [P] [US2] Implement the A2A-to-workflow lifecycle binding in
+  `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T014 [P] [US2] Project lifecycle events onto the event bus in
+  `crates/mister-smith-events/src/bus.rs`
+- [ ] T015 [US2] Surface mapped lifecycle state in operator-facing autonomy and result views in
+  `crates/mister-smith-app/src/autonomy.rs`
+
+**Checkpoint**: one A2A `v0.3.0` task lifecycle is mapped into Mister Smith workflow, result, and
+autonomy surfaces with explicit unsupported-state handling and no generic federation claims.
+
+---
+
+## User Story 3 - Preserve Provenance And Scope Boundaries (Priority: P2)
+
+**Goal**: keep operator-visible provenance, packet `016` continuity wording, and discovery-versus-
+execute boundaries explicit while recording the first interop slice honestly.
+
+**Independent Test**: packet-local docs and proof notes show where remote capability information
+came from, which lifecycle binding applied, what remains deferred, and what packet `027` still
+does not claim.
+
+### Tests For User Story 3
+
+- [ ] T016 [P] [US3] Add provenance and boundary regression coverage in
+  `crates/mister-smith-core/tests/remote_capability_provenance_tests.rs`
+- [ ] T017 [P] [US3] Add operator-surface provenance coverage in
+  `crates/mister-smith-app/tests/remote_capability_status_tests.rs`
+
+### Operator And Proof-Boundary Projection
+
+- [ ] T018 [P] [US3] Add operator-visible remote capability provenance projection in
+  `crates/mister-smith-core/src/autonomy.rs`
+- [ ] T019 [US3] Capture the bounded interop proof note in
+  `docs/plans/2026-04-01-packet-027-capability-discovery-and-interoperability.md`
+- [ ] T020 [US3] Refresh packet-local boundary language in
+  `specs/027-capability-discovery-and-interoperability/quickstart.md` and
+  `specs/027-capability-discovery-and-interoperability/spec.md` so packet `016` remains
+  continuity and provenance only
+
+**Checkpoint**: operator-facing provenance is explicit, packet `016` stays narrow, and packet
+`027` still reads as one bounded interoperability scaffold.
+
+---
+
+## Final Validation And Evidence
+
+- [ ] T021 Run targeted Rust validation for the touched lifecycle and discovery crates with
+  `cargo test -p mister-smith-agents`, `cargo test -p mister-smith-mcp`,
+  `cargo test -p mister-smith-core`, `cargo test -p mister-smith-events`, and
+  `cargo test -p mister-smith-app`
+- [ ] T022 Run broader compatibility checks with `cargo build --workspace` and
+  `npx markdownlint-cli2 "specs/027-capability-discovery-and-interoperability/**/*.md" --config .markdownlint.json`
+- [ ] T023 Refresh the durable proof note and any packet-local validation evidence in
+  `docs/plans/2026-04-01-packet-027-capability-discovery-and-interoperability.md`
+- [ ] T024 Run `git diff --check`
+- [ ] T025 Run `scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync`
+
+## Dependencies And Execution Order
+
+- Complete `T001` through `T003` before starting any user-story implementation work.
+- Complete User Story 1 before User Story 2 so the shared descriptor shape is frozen before A2A
+  lifecycle projection depends on it.
+- Complete User Story 2 before User Story 3 so provenance and operator-facing projection reflect
+  the final lifecycle mapping.
+- Run `T021` through `T025` only after the story checkpoints are complete.
+
+## Parallel Directive
+
+`[P]` means a task may run in parallel only when:
+
+- every blocking checkpoint task in the current section is already complete
+- its write set is disjoint from every other active lane
+
+Shared-write choke points for this packet:
+
+- `crates/mister-smith-core/src/autonomy.rs`
+- `crates/mister-smith-mcp/src/compatibility.rs`
+- `specs/027-capability-discovery-and-interoperability/spec.md`
+- `docs/plans/2026-04-01-packet-027-capability-discovery-and-interoperability.md`
+
+Allowed concurrent lanes after the blocking freeze:
+
+- descriptor normalization lane: `T004`, `T006`, and `T007` across
+  `crates/mister-smith-agents/src/tool_bus.rs`,
+  `crates/mister-smith-agents/tests/tool_bus_tests.rs`,
+  `crates/mister-smith-mcp/src/client.rs`, and
+  `crates/mister-smith-mcp/tests/capability_normalization_tests.rs`
+- A2A lifecycle lane: `T009`, `T010`, `T011`, `T013`, and `T014` across
+  `crates/mister-smith-mcp/src/a2a.rs`,
+  `crates/mister-smith-mcp/tests/a2a_discovery_tests.rs`,
+  `crates/mister-smith-app/tests/a2a_lifecycle_projection_tests.rs`,
+  `crates/mister-smith-core/src/autonomy.rs`, and
+  `crates/mister-smith-events/src/bus.rs`
+
+Serial merge points:
+
+- `T008` and `T012` in `crates/mister-smith-mcp/src/compatibility.rs`
+- `T015` and `T018` in `crates/mister-smith-core/src/autonomy.rs` and
+  `crates/mister-smith-app/src/autonomy.rs`
+- `T019`, `T020`, and `T023` in the packet-local docs and proof note


### PR DESCRIPTION
## Summary
- add scaffold packet 027 for capability discovery and interoperability
- keep packet scope on capability normalization, one A2A lifecycle bridge, and provenance boundaries
- point scaffold references at repo files that actually exist on main

## Validation
- npx markdownlint-cli2 "specs/027-capability-discovery-and-interoperability/**/*.md" --config .markdownlint.json
- git diff --check
- rg -n "docs/packet-prep|/specs/027-capability-discovery-and-interoperability|/Users/macmain|TODO|TBD|FIXME" specs/027-capability-discovery-and-interoperability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification package for capability discovery and interoperability features, including data model definitions, contract specifications, implementation roadmap, and validation checklists to guide future development.

* **Chores**
  * Established foundational architecture and requirements for discovering and integrating remote capabilities across multiple protocol standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->