### PR TITLE
docs(specs): finish packet 025 cleanup

### DIFF
--- a/specs/025-step-level-intelligence-v2/analyze.md
+++ b/specs/025-step-level-intelligence-v2/analyze.md
@@ -16,19 +16,19 @@ current repo truth and is implementation-ready.
 
 | Requirement Key | Has Task? | Task IDs | Notes |
 | --------------- | --------- | -------- | ----- |
-| step-difficulty-assessment | Yes | T006, T008, T009, T010 | Deterministic assessment is covered in types, runtime assembly, and projection. |
-| bounded-action-ladder | Yes | T011, T013, T014 | The keep or retry or clarify or downgrade or escalate ladder is frozen. |
+| step-difficulty-assessment | Yes | T007, T010, T011, T013, T014, T015 | Deterministic assessment is covered in the contract freeze, runtime assembly, and projection work. |
+| bounded-action-ladder | Yes | T010, T016, T018, T019, T020 | The keep or retry or clarify or downgrade or escalate ladder is frozen in both contract and code tasks. |
 | preserve-packet-022-ownership | Yes | T001, T010, T020 | Packet `022` lifecycle and event-history ownership stays explicit in docs and projections. |
-| preserve-packet-020-ownership | Yes | T005, T015 | Packet `020` ownership stays explicit in docs and runtime projection. |
-| preserve-packet-023-ownership | Yes | T001, T005, T020 | Packet `023` proof ownership stays explicit in contract, docs, and smoke assertions. |
+| preserve-packet-020-ownership | Yes | T001, T010, T015, T020 | Packet `020` ownership stays explicit in docs, projections, and repair-lineage references. |
+| preserve-packet-023-ownership | Yes | T001, T010, T017, T020, T025 | Packet `023` proof ownership stays explicit in the contract, docs, and proof-honesty checks. |
 | preserve-packet-024-ownership | Yes | T001, T002, T010 | Packet `024` boundary ownership stays explicit and unchanged. |
-| budget-pressure-summary | Yes | T011, T013, T014 | Budget-aware summary and action choice are explicitly covered. |
-| existing-read-surfaces-only | Yes | T003, T010, T018, T019 | Task inspect, autonomy, and selected-run detail remain the read path. |
-| proof-boundary-wording | Yes | T007, T016, T020 | Summary rendering and smoke assertions keep packet-023 wording honest. |
-| preserve-fallback-behavior | Yes | T006, T009, T014 | Runtime assembly tasks require bounded fallback behavior. |
-| deterministic-first-slice | Yes | T006, T011, T014 | No training-heavy or judge-heavy policy is required. |
-| no-placeholder-proof-upgrade | Yes | T017, T020, T025 | Packet `025` does not turn placeholder completion into grounded proof. |
-| bounded-current-seam-scope | Yes | T001-T028 | The task map stays inside current repo seams. |
+| budget-pressure-summary | Yes | T007, T010, T016, T018, T019 | Budget-aware summary and action choice are explicitly covered. |
+| existing-read-surfaces-only | Yes | T001, T010, T021, T023, T024 | Task inspect, autonomy, and selected-run detail remain the read path. |
+| proof-boundary-wording | Yes | T010, T017, T025 | Summary rendering and smoke assertions keep packet-023 wording honest. |
+| preserve-fallback-behavior | Yes | T011, T014, T019 | Runtime assembly tasks require bounded fallback behavior. |
+| deterministic-first-slice | Yes | T001, T002, T007, T018 | No training-heavy or judge-heavy policy is required. |
+| no-placeholder-proof-upgrade | Yes | T010, T017, T025 | Packet `025` does not turn placeholder completion into grounded proof. |
+| bounded-current-seam-scope | Yes | T001-T032 | The task map stays inside current repo seams and final validation. |
 | repo-anchor-traceability | Yes | T001, T002, T006 | Packet claims stay tied to named repo anchors and current router docs. |
 
 ## Contract Alignment
@@ -51,7 +51,7 @@ None. All tasks map to packet-owned requirements or final validation closure.
 ## Metrics
 
 - Total Requirements: 14
-- Total Tasks: 28
+- Total Tasks: 32
 - Coverage: 14/14 requirements mapped to one or more tasks (100%)
 - Ambiguity Count: 0
 - Duplication Count: 0

--- a/specs/025-step-level-intelligence-v2/checklists/step-policy.md
+++ b/specs/025-step-level-intelligence-v2/checklists/step-policy.md
@@ -10,20 +10,20 @@ bounded step-level intelligence policy
 ## Requirement Completeness
 
 - [X] CHK001 Are deterministic step-scoring requirements defined using current step, routing,
-      supervision, runtime-truth, and budget context? [Completeness, Spec §FR-001 through §FR-004]
+      supervision, runtime-truth, and budget context? [Completeness, Spec §FR-001]
 - [X] CHK002 Are all bounded action outcomes defined for `keep`, `retry`, `clarify`,
-      `downgrade`, and `escalate`? [Completeness, Spec §FR-003]
+      `downgrade`, and `escalate`? [Completeness, Spec §FR-002]
 - [X] CHK003 Are budget-aware policy requirements defined without creating a new trace or proof
-      schema? [Completeness, Spec §FR-002, Spec §FR-006]
+      schema? [Completeness, Spec §FR-005, Spec §FR-007]
 - [X] CHK004 Are operator summary requirements defined for existing task inspect, autonomy status,
       and selected-run operator detail surfaces? [Completeness, Spec §FR-008, Spec §FR-009]
 
 ## Requirement Clarity
 
 - [X] CHK005 Is "deterministic step policy" specific enough to prevent later judge-heavy or
-      training-heavy interpretation? [Clarity, Spec §FR-012]
+      training-heavy interpretation? [Clarity, Spec §FR-011]
 - [X] CHK006 Is "placeholder orchestration proof" clearly distinguished from grounded task proof?
-      [Clarity, Spec §FR-010]
+      [Clarity, Spec §FR-009, Spec §FR-012]
 - [X] CHK007 Is the budget-aware policy wording specific enough to choose between local correction
       and broader `downgrade` or `escalate` action without inventing new packet scope? [Clarity,
       Spec §User Story 2]
@@ -31,9 +31,9 @@ bounded step-level intelligence policy
 ## Requirement Consistency
 
 - [X] CHK008 Do packet `020` repair-lineage requirements and packet `025` step-policy
-      requirements avoid conflicting source-of-truth claims? [Consistency, Spec §FR-005]
+      requirements avoid conflicting source-of-truth claims? [Consistency, Spec §FR-003]
 - [X] CHK009 Do packet `023` ownership requirements stay consistent across the spec, plan,
-      contract, and proof wording? [Consistency, Spec §FR-006]
+      contract, and proof wording? [Consistency, Spec §FR-005]
 - [X] CHK010 Is packet-021 supervision evidence described consistently as deterministic-only
       unless fresher live proof is found? [Consistency, Spec §Current Truth And Scope]
 
@@ -56,15 +56,15 @@ bounded step-level intelligence policy
 ## Non-Functional Requirements
 
 - [X] CHK016 Are proof-honesty requirements explicit enough to prevent overstating
-      `workflow.execute_step` completion? [Coverage, Spec §FR-010]
+      `workflow.execute_step` completion? [Coverage, Spec §FR-009, Spec §FR-012]
 - [X] CHK017 Are scope-boundary requirements explicit enough to exclude benchmarks, training,
-      coordinator runtime, subagent runtime, and interoperability work? [Coverage, Spec §FR-012,
+      coordinator runtime, subagent runtime, and interoperability work? [Coverage, Spec §FR-011,
       Spec §FR-013]
 
 ## Dependencies And Assumptions
 
 - [X] CHK018 Does the spec clearly say packet `023` owns proof-boundary schema and packet `025`
-      only consumes it? [Dependency, Spec §FR-006]
+      only consumes it? [Dependency, Spec §FR-005]
 - [X] CHK019 Does the spec clearly say packet `025` is now the active implementation packet on top
       of landed packet `019` through `024` seams? [Dependency, Spec §Current Truth And Scope]
 

--- a/specs/025-step-level-intelligence-v2/contracts/step-policy-contract.md
+++ b/specs/025-step-level-intelligence-v2/contracts/step-policy-contract.md
@@ -18,7 +18,7 @@ The contract for this packet is:
 - `StepDifficultyAssessment` scores the current step using deterministic current-state inputs
 - `StepBudgetPressureSummary` carries bounded pressure hints that can shape action choice
 - `StepPolicyDecision` chooses one bounded action from `keep`, `retry`, `clarify`, `downgrade`,
-  and `escalate`
+  and `escalate`, and that summary does not rename existing step-routing action values
 - `StepPolicySummaryView` projects those packet-owned summaries onto existing inspect surfaces
 - `proof_boundary_ref` and grounding posture remain packet-023-owned references that packet `025`
   consumes but does not redefine
@@ -81,7 +81,8 @@ Example authoritative payload shape:
       "latest_step_evaluation": "packet-020:planner.step.2",
       "latest_step_routing": "step-routing:planner.step.2",
       "supervision_evidence": "packet-021:planner.step.2",
-      "runtime_truth": "packet-023:placeholder_or_simulated_step_completion"
+      "runtime_truth": "packet-023:placeholder_or_simulated_step_completion",
+      "boundary_evidence": "packet-024:clean_quarantine_boundary"
     },
     "proof_boundary_ref": {
       "owner_packet": "023",
@@ -95,6 +96,8 @@ Example authoritative payload shape:
 Behavior:
 
 - the only bounded action values are `keep`, `retry`, `clarify`, `downgrade`, and `escalate`
+- `policy_decision.chosen_action` is a new packet-owned summary field and does not replace
+  `step_routing_history.action`
 - packet `020` repair lineage may be referenced, but packet `025` does not replace that contract
 - packet `021` supervision evidence may be referenced, but packet `025` does not replace that
   contract

--- a/specs/025-step-level-intelligence-v2/data-model.md
+++ b/specs/025-step-level-intelligence-v2/data-model.md
@@ -32,6 +32,7 @@
 - `workflow_id`: stable workflow identifier
 - `step_id`: stable step identifier
 - `chosen_action`: one bounded value from `keep`, `retry`, `clarify`, `downgrade`, or `escalate`
+  and a new packet-owned summary field rather than a rename of `step_routing_history.action`
 - `action_reason`: concise explanation for why that action was chosen
 - `difficulty_ref`: reference to the driving `StepDifficultyAssessment`
 - `budget_ref`: optional reference to the driving `StepBudgetPressureSummary`
@@ -45,6 +46,7 @@
 - `latest_step_routing`: latest step-routing reference used as input
 - `supervision_evidence`: latest packet-021 supervision-evidence reference when used
 - `runtime_truth`: latest packet-023 runtime-truth reference when used
+- `boundary_evidence`: latest packet-024 boundary evidence reference when relevant
 
 ### `StepPolicySummaryView`
 

--- a/specs/025-step-level-intelligence-v2/spec.md
+++ b/specs/025-step-level-intelligence-v2/spec.md
@@ -175,7 +175,8 @@ endpoint.
   `StepEvaluationRecord`, routing history, step-routing history, supervision evidence,
   runtime-truth, and budget-hint inputs already present on current `main`.
 - **FR-002**: System MUST define one bounded step-policy action vocabulary across `keep`, `retry`,
-  `clarify`, `downgrade`, and `escalate`.
+  `clarify`, `downgrade`, and `escalate`, and that packet-owned summary MUST remain separate from
+  existing step-routing action fields.
 - **FR-003**: System MUST preserve packet `020` ownership of verifier verdicts, repair
   directives, clarification requests, failure-context checkpoints, and `orchestration_quality`,
   with packet `025` only layering step policy on top of those existing seams.


### PR DESCRIPTION
## Summary
- fix the remaining packet 025 doc consistency mismatches after the implementation-ready prep landed
- align analyze.md task counts and task-id references with the current packet task map
- keep packet 024 boundary evidence and chosen_action wording consistent across the packet bundle

## Validation
- npx markdownlint-cli2 "specs/025-step-level-intelligence-v2/**/*.md" --config .markdownlint.json
- git diff --check
- scripts/verify_worktree_closure.sh --fetch --require-upstream --require-sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated step-policy specification with clarified action vocabulary (`clarify`, `downgrade`, `escalate`, `keep`, `retry`).
  * Added new `boundary_evidence` and `chosen_action` fields to support step-policy decision documentation.
  * Updated requirement mappings and checklist references across step-level intelligence specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->